### PR TITLE
chore: do not use `platform: "node"` defaults

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,4 +1,5 @@
 import fs from "fs/promises";
+import { builtinModules } from "module";
 import path from "path";
 import esbuild from "esbuild";
 import { getPackage, pkgsDir, pkgsList, projectRoot } from "./common.mjs";
@@ -30,6 +31,8 @@ async function walk(rootPath) {
  */
 function getPackageDependencies(pkg, includeDev) {
   return [
+    "node:",
+    ...builtinModules,
     ...(pkg.dependencies ? Object.keys(pkg.dependencies) : []),
     ...(includeDev && pkg.devDependencies
       ? Object.keys(pkg.devDependencies)
@@ -46,11 +49,13 @@ function getPackageDependencies(pkg, includeDev) {
 const buildOptions = {
   format: "esm",
   // outExtension: { ".js": ".mjs" },
-  platform: "node",
+  platform: "neutral",
   target: "esnext",
   bundle: true,
   sourcemap: true,
   sourcesContent: false,
+  mainFields: ["module", "main"],
+  conditions: ["import", "node", "production", "default"],
   // minify: true,
   // minifySyntax: true,
   // minifyWhitespace: true,

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -31,8 +31,6 @@ async function walk(rootPath) {
  */
 function getPackageDependencies(pkg, includeDev) {
   return [
-    "node:",
-    ...builtinModules,
     ...(pkg.dependencies ? Object.keys(pkg.dependencies) : []),
     ...(includeDev && pkg.devDependencies
       ? Object.keys(pkg.devDependencies)
@@ -61,7 +59,11 @@ const buildOptions = {
   // minifyWhitespace: true,
   // Mark root package's dependencies as external, include root devDependencies
   // (e.g. test runner) as we don't want these bundled
-  external: [...getPackageDependencies(await getPackage(projectRoot), true)],
+  external: [
+    "node:",
+    ...builtinModules,
+    ...getPackageDependencies(await getPackage(projectRoot), true),
+  ],
   logLevel: watch ? "info" : "warning",
   watch,
 };


### PR DESCRIPTION
The [`platform`](https://esbuild.github.io/api/#platform) config assumes a CommonJS world when set to the `"node"` value. Any of the implied defaults can be overridden (as already done with `format: esm`), but I changed the `platform` value to `"neutral"` to indicate that (along with these changes) we're no longer relying on any default value from the `"node"` setting.

Ran the tests locally after new build outputs & everything seems to be fine. Also checked most build output contents manually – most of them appear to be unchanged, but there are some improvements. Using `cli-parser` as an example here:

***Before***

```js
var __create = Object.create;
var __defProp = Object.defineProperty;
var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
var __getOwnPropNames = Object.getOwnPropertyNames;
var __getProtoOf = Object.getPrototypeOf;
var __hasOwnProp = Object.prototype.hasOwnProperty;
var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
var __commonJS = (cb, mod) => function __require() {
  return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
};
var __reExport = (target, module, desc) => {
  if (module && typeof module === "object" || typeof module === "function") {
    for (let key of __getOwnPropNames(module))
      if (!__hasOwnProp.call(target, key) && key !== "default")
        __defProp(target, key, { get: () => module[key], enumerable: !(desc = __getOwnPropDesc(module, key)) || desc.enumerable });
  }
  return target;
};
var __toModule = (module) => {
  return __reExport(__markAsModule(__defProp(module != null ? __create(__getProtoOf(module)) : {}, "default", module && module.__esModule && "default" in module ? { get: () => module.default, enumerable: true } : { value: module, enumerable: true })), module);
};

// node_modules/mri/lib/index.js
var require_lib = __commonJS({
  "node_modules/mri/lib/index.js"(exports, module) {
    function toArr(any) {
```

This is all boilerplate stuff that esbuild injects to import & expose CommonJS dependencies as if they were written in ESM format. It's ~30 lines of helper logic that's entirely unneeded because `mri` has a 'module' entry that can be used.

In the new build, the `mri` dependency is inlined directly w/o any boilerplate helpers.

This happens in a couple other modules too