### PR TITLE
chore: add `engines.node` constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "vitepress": "^0.20.0",
     "which": "^2.0.2"
   },
+  "engines": {
+    "node": ">=16.7"
+  },
   "volta": {
     "node": "16.9.0"
   }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli-parser/package.json
+++ b/packages/cli-parser/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/durable-objects/package.json
+++ b/packages/durable-objects/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/html-rewriter/package.json
+++ b/packages/html-rewriter/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -18,6 +18,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -18,6 +18,9 @@
     "dist/src",
     "bootstrap.js"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/runner-vm/package.json
+++ b/packages/runner-vm/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shared-test/package.json
+++ b/packages/shared-test/package.json
@@ -18,6 +18,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cloudflare/miniflare.git",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage-file/package.json
+++ b/packages/storage-file/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage-memory/package.json
+++ b/packages/storage-memory/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage-redis/package.json
+++ b/packages/storage-redis/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web-sockets/package.json
+++ b/packages/web-sockets/package.json
@@ -17,6 +17,9 @@
   "files": [
     "dist/src"
   ],
+  "engines": {
+    "node": ">=16.7"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/scripts/scaffold.mjs
+++ b/scripts/scaffold.mjs
@@ -41,6 +41,9 @@ async function scaffoldPackage(unscopedPkgName) {
     exports: "./dist/src/index.js",
     types: "./dist/src/index.d.ts",
     files: ["dist/src"],
+    engines: {
+      node: ">=16.7",
+    },
     publishConfig: { access: "public" },
     repository: {
       type: "git",


### PR DESCRIPTION
Provides install-time Node version checks, preventing users with outdated/unsupported `node` versions from installing miniflare.

This `16.7` is the value reflected as of [v2.0.0-next.1](https://github.com/cloudflare/miniflare/releases/tag/v2.0.0-next.1) & was confirmed by @mrbbot  in conversation 