### PR TITLE
fix(http-server): append livereload to end of document;

### DIFF
--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@miniflare/core": "2.0.0-next.2",
-    "@miniflare/html-rewriter": "2.0.0-next.2",
     "@miniflare/shared": "2.0.0-next.2",
     "@miniflare/web-sockets": "2.0.0-next.2",
     "kleur": "^4.1.4",

--- a/packages/http-server/src/index.ts
+++ b/packages/http-server/src/index.ts
@@ -40,7 +40,7 @@ const liveReloadScript = `<script defer type="application/javascript">
   function connect(reconnected) {
     var ws = new WebSocket(url);
     if (reconnected) ws.onopen = reload;
-    ws.onclose = function(e) { 
+    ws.onclose = function(e) {
       e.code === 1012 ? reload() : e.code === 1000 || e.code === 1001 || setTimeout(connect, 1000, true);
     }
   }
@@ -227,10 +227,10 @@ export function createRequestListener<Plugins extends HTTPPluginSignatures>(
             // Technically this might get assigned twice because of this await,
             // but that doesn't matter at all
             const { HTMLRewriter } = await import("@miniflare/html-rewriter");
-            liveReloadRewriter = new HTMLRewriter().on("body", {
-              element(end) {
-                end.append(liveReloadScript, { html: true });
-              },
+            liveReloadRewriter = new HTMLRewriter().onDocument({
+              end(tag) {
+                tag.append(liveReloadScript, { html: true });
+              }
             });
           }
           response = liveReloadRewriter.transform(response);


### PR DESCRIPTION
Scripts are still valid & will still execute, even if outside of the `<html>` tags. The browsers' HTML parsers are incredibly loose/forgiving haha

Here's a valid HTML document, which still logs to the console:

```html
<html>
  <title>hello</title>
  <p>content</p>
</html>
<script defer>
  console.log('loaded')
</script>
```

Closes #70