### PR TITLE
chore: bump `undici` version;

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,9 @@
         "typescript": "^4.4.4",
         "vitepress": "^0.20.0",
         "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
@@ -8948,9 +8951,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.8.1.tgz",
-      "integrity": "sha512-0HYfUmepa5euTv3ewj9OqJDiBrZrBEr4o8HPdNHeWOsPCLLXZSBVovW+D3D1LoFeGXhe5Bm2V/e7YJatUjeWfQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.9.3.tgz",
+      "integrity": "sha512-9WbSy4Y2At64gXTOclOjkEgkVrQj09DoH3sgyUYP6e8XCMU/VN8UbjIl+Syd084JgLnlYslgJ0jFM+3hx1ClvQ==",
       "engines": {
         "node": ">=12.18"
       }
@@ -9525,12 +9528,15 @@
         "@miniflare/core": "2.0.0-next.2",
         "@miniflare/shared": "2.0.0-next.2",
         "http-cache-semantics": "^4.1.0",
-        "undici": "^4.8.1"
+        "undici": "^4.9.3"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2",
         "@miniflare/web-sockets": "2.0.0-next.2",
         "@types/http-cache-semantics": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/cli-parser": {
@@ -9546,6 +9552,9 @@
         "@miniflare/shared-test": "2.0.0-next.2",
         "@types/mri": "^1.1.1",
         "mri": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/core": {
@@ -9559,7 +9568,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "^4.8.1"
+        "undici": "^4.9.3"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2",
@@ -9568,6 +9577,9 @@
         "@types/busboy": "^0.3.1",
         "@types/set-cookie-parser": "^2.4.1",
         "dequal": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       },
       "peerDependencies": {
         "@miniflare/watcher": "2.0.0-next.2"
@@ -9588,6 +9600,9 @@
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2",
         "@miniflare/storage-memory": "2.0.0-next.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/html-rewriter": {
@@ -9598,10 +9613,13 @@
         "@miniflare/core": "2.0.0-next.2",
         "@miniflare/shared": "2.0.0-next.2",
         "html-rewriter-wasm": "^0.3.2",
-        "undici": "^4.8.1"
+        "undici": "^4.9.3"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/http-server": {
@@ -9610,18 +9628,20 @@
       "license": "MIT",
       "dependencies": {
         "@miniflare/core": "2.0.0-next.2",
-        "@miniflare/html-rewriter": "2.0.0-next.2",
         "@miniflare/shared": "2.0.0-next.2",
         "@miniflare/web-sockets": "2.0.0-next.2",
         "kleur": "^4.1.4",
         "selfsigned": "^1.10.11",
-        "undici": "^4.8.1",
+        "undici": "^4.9.3",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2",
         "@types/node-forge": "^0.10.4"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/jest": {
@@ -9637,6 +9657,9 @@
         "@miniflare/shared-test": "2.0.0-next.2",
         "jest": "^27.2.1"
       },
+      "engines": {
+        "node": ">=16.7"
+      },
       "peerDependencies": {
         "jest": ">=27"
       }
@@ -9650,6 +9673,9 @@
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/miniflare": {
@@ -9674,7 +9700,7 @@
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "^4.8.1"
+        "undici": "^4.9.3"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -9682,6 +9708,9 @@
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2",
         "@types/source-map-support": "^0.5.4"
+      },
+      "engines": {
+        "node": ">=16.7"
       },
       "peerDependencies": {
         "@miniflare/storage-redis": "2.0.0-next.2",
@@ -9706,6 +9735,9 @@
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/scheduler": {
@@ -9720,6 +9752,9 @@
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2",
         "@types/node-cron": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/shared": {
@@ -9732,6 +9767,9 @@
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/shared-test": {
@@ -9745,6 +9783,9 @@
         "@miniflare/shared": "2.0.0-next.2",
         "@miniflare/storage-memory": "2.0.0-next.2",
         "ws": "^8.2.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/sites": {
@@ -9760,6 +9801,9 @@
         "@cloudflare/kv-asset-handler": "^0.1.3",
         "@miniflare/core": "2.0.0-next.2",
         "@miniflare/shared-test": "2.0.0-next.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/storage-file": {
@@ -9772,6 +9816,9 @@
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/storage-memory": {
@@ -9783,6 +9830,9 @@
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/storage-redis": {
@@ -9797,6 +9847,9 @@
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2",
         "@types/ioredis": "^4.27.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/watcher": {
@@ -9808,6 +9861,9 @@
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     },
     "packages/web-sockets": {
@@ -9817,12 +9873,15 @@
       "dependencies": {
         "@miniflare/core": "2.0.0-next.2",
         "@miniflare/shared": "2.0.0-next.2",
-        "undici": "^4.8.1",
+        "undici": "^4.9.3",
         "ws": "^8.2.2"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0-next.2",
         "@types/ws": "^7.4.7"
+      },
+      "engines": {
+        "node": ">=16.7"
       }
     }
   },
@@ -10911,7 +10970,7 @@
         "@miniflare/web-sockets": "2.0.0-next.2",
         "@types/http-cache-semantics": "^4.0.1",
         "http-cache-semantics": "^4.1.0",
-        "undici": "^4.8.1"
+        "undici": "^4.9.3"
       }
     },
     "@miniflare/cli-parser": {
@@ -10940,7 +10999,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "^4.8.1"
+        "undici": "^4.9.3"
       }
     },
     "@miniflare/durable-objects": {
@@ -10958,21 +11017,20 @@
         "@miniflare/shared": "2.0.0-next.2",
         "@miniflare/shared-test": "2.0.0-next.2",
         "html-rewriter-wasm": "^0.3.2",
-        "undici": "^4.8.1"
+        "undici": "^4.9.3"
       }
     },
     "@miniflare/http-server": {
       "version": "file:packages/http-server",
       "requires": {
         "@miniflare/core": "2.0.0-next.2",
-        "@miniflare/html-rewriter": "2.0.0-next.2",
         "@miniflare/shared": "2.0.0-next.2",
         "@miniflare/shared-test": "2.0.0-next.2",
         "@miniflare/web-sockets": "2.0.0-next.2",
         "@types/node-forge": "^0.10.4",
         "kleur": "^4.1.4",
         "selfsigned": "^1.10.11",
-        "undici": "^4.8.1",
+        "undici": "^4.9.3",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
@@ -11080,7 +11138,7 @@
         "@miniflare/shared": "2.0.0-next.2",
         "@miniflare/shared-test": "2.0.0-next.2",
         "@types/ws": "^7.4.7",
-        "undici": "^4.8.1",
+        "undici": "^4.9.3",
         "ws": "^8.2.2"
       }
     },
@@ -15245,7 +15303,7 @@
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "^4.8.1"
+        "undici": "^4.9.3"
       }
     },
     "minimatch": {
@@ -16786,9 +16844,9 @@
       }
     },
     "undici": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.8.1.tgz",
-      "integrity": "sha512-0HYfUmepa5euTv3ewj9OqJDiBrZrBEr4o8HPdNHeWOsPCLLXZSBVovW+D3D1LoFeGXhe5Bm2V/e7YJatUjeWfQ=="
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.9.3.tgz",
+      "integrity": "sha512-9WbSy4Y2At64gXTOclOjkEgkVrQj09DoH3sgyUYP6e8XCMU/VN8UbjIl+Syd084JgLnlYslgJ0jFM+3hx1ClvQ=="
     },
     "unique-string": {
       "version": "2.0.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -39,7 +39,7 @@
     "@miniflare/core": "2.0.0-next.2",
     "@miniflare/shared": "2.0.0-next.2",
     "http-cache-semantics": "^4.1.0",
-    "undici": "^4.8.1"
+    "undici": "^4.9.3"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.0.0-next.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
     "dotenv": "^10.0.0",
     "kleur": "^4.1.4",
     "set-cookie-parser": "^2.4.8",
-    "undici": "^4.8.1"
+    "undici": "^4.9.3"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.0.0-next.2",

--- a/packages/html-rewriter/package.json
+++ b/packages/html-rewriter/package.json
@@ -39,7 +39,7 @@
     "@miniflare/core": "2.0.0-next.2",
     "@miniflare/shared": "2.0.0-next.2",
     "html-rewriter-wasm": "^0.3.2",
-    "undici": "^4.8.1"
+    "undici": "^4.9.3"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.0.0-next.2"

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -41,7 +41,7 @@
     "@miniflare/web-sockets": "2.0.0-next.2",
     "kleur": "^4.1.4",
     "selfsigned": "^1.10.11",
-    "undici": "^4.8.1",
+    "undici": "^4.9.3",
     "ws": "^8.2.2",
     "youch": "^2.2.2"
   },

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -61,7 +61,7 @@
     "kleur": "^4.1.4",
     "semiver": "^1.1.0",
     "source-map-support": "^0.5.20",
-    "undici": "^4.8.1"
+    "undici": "^4.9.3"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.0.0-next.2",

--- a/packages/web-sockets/package.json
+++ b/packages/web-sockets/package.json
@@ -39,7 +39,7 @@
     "@miniflare/core": "2.0.0-next.2",
     "@miniflare/shared": "2.0.0-next.2",
     "ws": "^8.2.2",
-    "undici": "^4.8.1"
+    "undici": "^4.9.3"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.0.0-next.2",


### PR DESCRIPTION
The `4.9.3` is the first release that includes this PR: https://github.com/nodejs/undici/pull/1081

- Closes #64