### PR TITLE
[jest-environment-miniflare] Add Buffer to global

### DIFF
--- a/packages/jest-environment-miniflare/src/index.ts
+++ b/packages/jest-environment-miniflare/src/index.ts
@@ -75,6 +75,7 @@ export default class MiniflareEnvironment implements JestEnvironment {
     const global = (this.global = vm.runInContext("this", this.context));
     global.global = global;
     global.self = global;
+    global.Buffer = Buffer;
     global.clearInterval = clearInterval;
     global.clearTimeout = clearTimeout;
     global.setInterval = setInterval;


### PR DESCRIPTION
This is to fix an error that came up in my test suite:

> ReferenceError: Buffer is not defined
>
>    at Object.<anonymous> (node_modules/undici/lib/client.js:409:19)
>    at Object.<anonymous> (node_modules/undici/index.js:3:16)