### PR TITLE
Fix some premature reloads with chokidar awaitWriteFinish

### DIFF
--- a/src/options/watcher.ts
+++ b/src/options/watcher.ts
@@ -112,6 +112,9 @@ export class OptionsWatcher {
     this._watcher = chokidar
       .watch([...this._watchedPaths], {
         ...this.watchOptions,
+        awaitWriteFinish: {
+          stabilityThreshold: 100
+        },
         ignoreInitial: true,
       })
       .on("add", boundCallback)


### PR DESCRIPTION
Fixes some cases of #34 where miniflare reloads the worker js file as it is being written to (e.g. by webpack), rather than when it has finished emitting. Seems to particularly be a problem on Windows.