### PR TITLE
Bump version for http-server pkg to fix audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6405,11 +6405,11 @@
       "dev": true
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-int64": {
@@ -7469,11 +7469,14 @@
       }
     },
     "node_modules/selfsigned": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
-      "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.0.tgz",
+      "integrity": "sha512-cUdFiCbKoa1mZ6osuJs2uDHrs0k0oprsKveFiiaBKCNq3SYyb5gs2HxhQyDNLCmL51ZZThqi4YNDpCK6GOP1iQ==",
       "dependencies": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semiver": {
@@ -8727,7 +8730,7 @@
         "@miniflare/core": "2.0.0",
         "@miniflare/shared": "2.0.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "^4.12.1"
+        "undici": "4.12.1"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0",
@@ -8767,7 +8770,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "^4.12.1"
+        "undici": "4.12.1"
       },
       "devDependencies": {
         "@miniflare/durable-objects": "2.0.0",
@@ -8798,7 +8801,7 @@
         "@miniflare/core": "2.0.0",
         "@miniflare/shared": "2.0.0",
         "@miniflare/storage-memory": "2.0.0",
-        "undici": "^4.12.1"
+        "undici": "4.12.1"
       },
       "devDependencies": {
         "@miniflare/cache": "2.0.0",
@@ -8817,7 +8820,7 @@
         "@miniflare/core": "2.0.0",
         "@miniflare/shared": "2.0.0",
         "html-rewriter-wasm": "^0.3.2",
-        "undici": "^4.12.1"
+        "undici": "4.12.1"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.0.0"
@@ -8835,8 +8838,8 @@
         "@miniflare/shared": "2.0.0",
         "@miniflare/web-sockets": "2.0.0",
         "kleur": "^4.1.4",
-        "selfsigned": "^1.10.11",
-        "undici": "^4.12.1",
+        "selfsigned": "^2.0.0",
+        "undici": "4.12.1",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
@@ -8877,23 +8880,23 @@
       }
     },
     "packages/jest-environment-miniflare": {
-      "version": "2.0.0-rc.5",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@miniflare/cache": "2.0.0-rc.5",
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/durable-objects": "2.0.0-rc.5",
-        "@miniflare/html-rewriter": "2.0.0-rc.5",
-        "@miniflare/kv": "2.0.0-rc.5",
-        "@miniflare/runner-vm": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/sites": "2.0.0-rc.5",
-        "@miniflare/storage-memory": "2.0.0-rc.5",
-        "@miniflare/web-sockets": "2.0.0-rc.5",
-        "miniflare": "2.0.0-rc.5"
+        "@miniflare/cache": "2.0.0",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/durable-objects": "2.0.0",
+        "@miniflare/html-rewriter": "2.0.0",
+        "@miniflare/kv": "2.0.0",
+        "@miniflare/runner-vm": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/sites": "2.0.0",
+        "@miniflare/storage-memory": "2.0.0",
+        "@miniflare/web-sockets": "2.0.0",
+        "miniflare": "2.0.0"
       },
       "devDependencies": {
-        "@miniflare/shared-test": "2.0.0-rc.5",
+        "@miniflare/shared-test": "2.0.0",
         "jest": "^27.2.1"
       },
       "engines": {
@@ -8939,7 +8942,7 @@
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "^4.12.1"
+        "undici": "4.12.1"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -9112,7 +9115,7 @@
       "dependencies": {
         "@miniflare/core": "2.0.0",
         "@miniflare/shared": "2.0.0",
-        "undici": "^4.12.1",
+        "undici": "4.12.1",
         "ws": "^8.2.2"
       },
       "devDependencies": {
@@ -10040,7 +10043,7 @@
         "@miniflare/web-sockets": "2.0.0",
         "@types/http-cache-semantics": "^4.0.1",
         "http-cache-semantics": "^4.1.0",
-        "undici": "^4.12.1"
+        "undici": "4.12.1"
       }
     },
     "@miniflare/cli-parser": {
@@ -10070,7 +10073,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "^4.12.1"
+        "undici": "4.12.1"
       }
     },
     "@miniflare/durable-objects": {
@@ -10082,7 +10085,7 @@
         "@miniflare/shared": "2.0.0",
         "@miniflare/shared-test": "2.0.0",
         "@miniflare/storage-memory": "2.0.0",
-        "undici": "^4.12.1"
+        "undici": "4.12.1"
       }
     },
     "@miniflare/html-rewriter": {
@@ -10092,7 +10095,7 @@
         "@miniflare/shared": "2.0.0",
         "@miniflare/shared-test": "2.0.0",
         "html-rewriter-wasm": "^0.3.2",
-        "undici": "^4.12.1"
+        "undici": "4.12.1"
       }
     },
     "@miniflare/http-server": {
@@ -10104,8 +10107,8 @@
         "@miniflare/web-sockets": "2.0.0",
         "@types/node-forge": "^0.10.4",
         "kleur": "^4.1.4",
-        "selfsigned": "^1.10.11",
-        "undici": "^4.12.1",
+        "selfsigned": "^2.0.0",
+        "undici": "4.12.1",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
@@ -10202,7 +10205,7 @@
         "@miniflare/shared": "2.0.0",
         "@miniflare/shared-test": "2.0.0",
         "@types/ws": "^8.2.0",
-        "undici": "^4.12.1",
+        "undici": "4.12.1",
         "ws": "^8.2.2"
       }
     },
@@ -13316,19 +13319,19 @@
     "jest-environment-miniflare": {
       "version": "file:packages/jest-environment-miniflare",
       "requires": {
-        "@miniflare/cache": "2.0.0-rc.5",
-        "@miniflare/core": "2.0.0-rc.5",
-        "@miniflare/durable-objects": "2.0.0-rc.5",
-        "@miniflare/html-rewriter": "2.0.0-rc.5",
-        "@miniflare/kv": "2.0.0-rc.5",
-        "@miniflare/runner-vm": "2.0.0-rc.5",
-        "@miniflare/shared": "2.0.0-rc.5",
-        "@miniflare/shared-test": "2.0.0-rc.5",
-        "@miniflare/sites": "2.0.0-rc.5",
-        "@miniflare/storage-memory": "2.0.0-rc.5",
-        "@miniflare/web-sockets": "2.0.0-rc.5",
+        "@miniflare/cache": "2.0.0",
+        "@miniflare/core": "2.0.0",
+        "@miniflare/durable-objects": "2.0.0",
+        "@miniflare/html-rewriter": "2.0.0",
+        "@miniflare/kv": "2.0.0",
+        "@miniflare/runner-vm": "2.0.0",
+        "@miniflare/shared": "2.0.0",
+        "@miniflare/shared-test": "2.0.0",
+        "@miniflare/sites": "2.0.0",
+        "@miniflare/storage-memory": "2.0.0",
+        "@miniflare/web-sockets": "2.0.0",
         "jest": "^27.2.1",
-        "miniflare": "2.0.0-rc.5"
+        "miniflare": "2.0.0"
       }
     },
     "jest-environment-node": {
@@ -14119,7 +14122,7 @@
         "open": "^8.4.0",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "^4.12.1"
+        "undici": "4.12.1"
       }
     },
     "minimatch": {
@@ -14161,9 +14164,9 @@
       "dev": true
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -14935,11 +14938,11 @@
       }
     },
     "selfsigned": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
-      "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.0.tgz",
+      "integrity": "sha512-cUdFiCbKoa1mZ6osuJs2uDHrs0k0oprsKveFiiaBKCNq3SYyb5gs2HxhQyDNLCmL51ZZThqi4YNDpCK6GOP1iQ==",
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.2.0"
       }
     },
     "semiver": {

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -39,7 +39,7 @@
     "@miniflare/shared": "2.0.0",
     "@miniflare/web-sockets": "2.0.0",
     "kleur": "^4.1.4",
-    "selfsigned": "^1.10.11",
+    "selfsigned": "^2.0.0",
     "undici": "4.12.1",
     "ws": "^8.2.2",
     "youch": "^2.2.2"


### PR DESCRIPTION
`@miniflare/http-server` package has deps to `selfsigned` package and it was reported as low severity vulnerabilities.

<details>

<summary>Logs by `npm i miniflare`</summary>

```
~/Codes
❯ mkdir miniflare-deps

~/Codes
❯ cd miniflare-deps

~/Codes/miniflare-deps
❯ npm init -y
Wrote to /Users/leader22/Codes/miniflare-deps/package.json:

{
  "name": "miniflare-deps",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "keywords": [],
  "author": "Yuji Sugiura",
  "license": "MIT"
}



~/Codes/miniflare-deps
❯ npm i miniflare

added 40 packages, and audited 41 packages in 2s

4 low severity vulnerabilities

To address all issues, run:
  npm audit fix

Run `npm audit` for details.

~/Codes/miniflare-deps
❯ npm audit
# npm audit report

node-forge  <1.0.0
Prototype Pollution in node-forge debug API. - https://github.com/advisories/GHSA-5rrq-pxf6-6jx5
fix available via `npm audit fix --force`
Will install miniflare@1.4.1, which is a breaking change
node_modules/node-forge
  selfsigned  1.1.1 - 1.10.14
  Depends on vulnerable versions of node-forge
  node_modules/selfsigned
    @miniflare/http-server  *
    Depends on vulnerable versions of selfsigned
    node_modules/@miniflare/http-server
      miniflare  >=2.0.0-next.1
      Depends on vulnerable versions of @miniflare/http-server
      node_modules/miniflare

4 low severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force
```
</details>

This PR updates `selfsigned` to `2.0.0` (major version up), but actual implementation seems not changed.
https://github.com/jfromaniello/selfsigned/compare/v1.10.11...v2.0.0