### PR TITLE
Fix null status body response

### DIFF
--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -480,8 +480,9 @@ export interface ResponseInit extends BaseResponseInit {
 
 const kWaitUntil = Symbol("kWaitUntil");
 
-// From https://github.com/nodejs/undici/blob/3f6b564b7d3023d506cad75b16207006b23956a8/lib/fetch/constants.js#L28, minus 101
-const nullBodyStatus: (number | undefined)[] = [204, 205, 304];
+// From https://github.com/nodejs/undici/blob/3f6b564b7d3023d506cad75b16207006b23956a8/lib/fetch/constants.js#L28
+// https://fetch.spec.whatwg.org/#null-body-status
+const nullBodyStatus: (number | undefined)[] = [101, 204, 205, 304];
 
 const enumerableResponseKeys: (keyof Response)[] = [
   "encodeBody",
@@ -796,7 +797,11 @@ export async function fetch(
       headers,
     });
   } else {
-    res = new Response(baseRes.body, baseRes);
+    // https://fetch.spec.whatwg.org/#null-body-status
+    res = new Response(
+      nullBodyStatus.includes(baseRes.status) ? null : baseRes.body,
+      baseRes
+    );
   }
 
   await waitForOpenInputGate();

--- a/packages/core/test/standards/http.spec.ts
+++ b/packages/core/test/standards/http.spec.ts
@@ -873,6 +873,18 @@ test("fetch: can fetch from existing Request", async (t) => {
   const res = await fetch(req);
   t.is(await res.text(), "upstream");
 });
+test("fetch: gives a null body for upstream null body status codes", async (t) => {
+  const upstream = (
+    await useServer(t, (req, res) => {
+      res.statusCode = 304;
+      res.end();
+    })
+  ).http;
+  const req = new Request(upstream);
+  const res = await fetch(req);
+  t.is(res.status, 304);
+  t.is(await res.text(), "");
+});
 test("fetch: increments subrequest count", async (t) => {
   const upstream = (await useServer(t, (req, res) => res.end("upstream"))).http;
   const ctx = new RequestContext();


### PR DESCRIPTION
```ts
import { fetch } from '@miniflare/core'

await fetch('https://some/url/which/returns/304')
```

fails because `response.body` always returns a `ReadableStream`, but the `new Response()` constructor expects `null` when setting some status codes.