### PR TITLE
Fix cases where BYOB readers don't notice end of stream

### DIFF
--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -281,7 +281,7 @@ export class Body<Inner extends BaseRequest | BaseResponse> {
           // we need to tell it that there was 0 bytes delivered so that it unblocks
           // and notices the end of stream.
           controller.byobRequest?.respond(0);
-	}
+	       }
       },
       cancel: (reason) => reader.cancel(reason),
     };

--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -275,7 +275,13 @@ export class Body<Inner extends BaseRequest | BaseResponse> {
         }
 
         // If the body is finished, close this stream too
-        if (done) controller.close();
+        if (done) {
+          controller.close();
+          // Not documented in MDN but if there's an ongoing request that's waiting,
+          // we need to tell it that there was 0 bytes delivered so that it unblocks
+          // and notices the end of stream.
+          controller.byobRequest?.respond(0);
+	}
       },
       cancel: (reason) => reader.cancel(reason),
     };

--- a/packages/http-server/src/index.ts
+++ b/packages/http-server/src/index.ts
@@ -78,7 +78,7 @@ export async function convertNodeRequest(
             // we need to tell it that there was 0 bytes delivered so that it unblocks
             // and notices the end of stream.
             controller.byobRequest?.respond(0);
-	  });
+	         });
         } else {
           const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value);
           controller.enqueue(new Uint8Array(buffer));

--- a/packages/kv/src/namespace.ts
+++ b/packages/kv/src/namespace.ts
@@ -137,7 +137,7 @@ function convertStoredToGetValue(stored: Uint8Array, type: KVGetValueType) {
           // Not documented in MDN but if there's an ongoing request that's waiting,
           // we need to tell it that there was 0 bytes delivered so that it unblocks
           // and notices the end of stream.
-	  controller.byobRequest?.respond(0);
+	        controller.byobRequest?.respond(0);
         },
       });
   }

--- a/packages/kv/src/namespace.ts
+++ b/packages/kv/src/namespace.ts
@@ -137,7 +137,7 @@ function convertStoredToGetValue(stored: Uint8Array, type: KVGetValueType) {
           // Not documented in MDN but if there's an ongoing request that's waiting,
           // we need to tell it that there was 0 bytes delivered so that it unblocks
           // and notices the end of stream.
-	        controller.byobRequest?.respond(0);
+	         controller.byobRequest?.respond(0);
         },
       });
   }

--- a/packages/kv/src/namespace.ts
+++ b/packages/kv/src/namespace.ts
@@ -134,6 +134,10 @@ function convertStoredToGetValue(stored: Uint8Array, type: KVGetValueType) {
           await waitForOpenInputGate();
           controller.enqueue(stored);
           controller.close();
+          // Not documented in MDN but if there's an ongoing request that's waiting,
+          // we need to tell it that there was 0 bytes delivered so that it unblocks
+          // and notices the end of stream.
+	  controller.byobRequest?.respond(0);
         },
       });
   }


### PR DESCRIPTION
This resolves issue #192. The R2 project had tests that were hanging
because the await on the BYOB reader was never returning done even
though the controller was being signalled. All credit to @jasnell who
had pointed me towards this in our own internal code that was
polyfilling on Miniflare 1.4.