### PR TITLE
implement `[data_blobs]`

### DIFF
--- a/packages/shared/src/wrangler.ts
+++ b/packages/shared/src/wrangler.ts
@@ -34,8 +34,9 @@ export interface WranglerEnvironmentConfig {
     crons?: string[];
   }; // inherited
   usage_model?: "bundled" | "unbound"; // inherited
-  wasm_modules?: Record<string, string>; // (probably) inherited
-  text_blobs?: Record<string, string>;
+  wasm_modules?: Record<string, string>; // inherited
+  text_blobs?: Record<string, string>; // inherited
+  data_blobs?: Record<string, string>; // inherited
   experimental_services?: {
     name: string;
     service: string;


### PR DESCRIPTION
This implements support for `[data_blobs]` for service workers, which lets you bind some data from a file as an ArrayBuffer in service-worker format workers. It also adds a `--data-blob` cli argument for the same.

Fixes #231 

--- 

I implemented this mechanically by mirroring the implementation from `text_blobs` in https://github.com/cloudflare/miniflare/pull/228. Happy to iterate!