### PR TITLE
Ensure cf-connecting-ip header is deleted when calling upstream URL

### DIFF
--- a/packages/core/src/standards/event.ts
+++ b/packages/core/src/standards/event.ts
@@ -8,9 +8,9 @@ import {
   ValueOf,
   prefixError,
 } from "@miniflare/shared";
-import { Response as BaseResponse, fetch as baseFetch } from "undici";
+import { Response as BaseResponse } from "undici";
 import { DOMException } from "./domexception";
-import { Request, Response, _kInner, withWaitUntil } from "./http";
+import { Request, Response, fetch, withWaitUntil } from "./http";
 
 export type FetchErrorCode =
   | "ERR_RESPONSE_TYPE" // respondWith returned non Response promise
@@ -411,7 +411,7 @@ export class ServiceWorkerGlobalScope extends WorkerGlobalScope {
 
     // noinspection ES6MissingAwait
     const waitUntil = Promise.all(event[kWaitUntil]) as Promise<WaitUntil>;
-    return withWaitUntil(await baseFetch(request[_kInner]), waitUntil);
+    return withWaitUntil(await fetch(request), waitUntil);
   }
 
   async [kDispatchScheduled]<WaitUntil extends any[] = any[]>(


### PR DESCRIPTION
Refs: [237](https://github.com/cloudflare/miniflare/issues/237)

When setting the upstream to a domain that is behind Cloudflare, if passThroughOnException is triggered by an error in the handler, a 403 is returned. The same page is retuned fine if fetched using the custom fetch (from http.ts) in the handler. We need to use the custom fetch so that the `cf-connecting-ip` header is deleted as shown [here](https://github.com/cloudflare/miniflare/blob/6c26e320611f5209ba928cb5fba0013b8d4f2a20/packages/core/src/standards/http.ts#L767-L769).
