### PR TITLE
fix: bump `busboy` to resolve security issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1459,9 +1459,9 @@
       }
     },
     "node_modules/@types/busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-8BPLNy4x+7lbTOGkAyUIZrrPEZ7WzbO7YlVGMf9EZi9J9mqILEkYbt/kgVWQ7fizOISo1hM/7cAsWVTa7EhQDg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.0.tgz",
+      "integrity": "sha512-ncOOhwmyFDW76c/Tuvv9MA9VGYUCn8blzyWmzYELcNGDb0WXWLSmFi7hJq25YdRBYJrmMBB5jZZwUjlJe9HCjQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -2490,14 +2490,14 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "dependencies": {
-        "dicer": "0.3.0"
+        "streamsearch": "^1.1.0"
       },
       "engines": {
-        "node": ">=4.5.0"
+        "node": ">=10.16.0"
       }
     },
     "node_modules/cacheable-request": {
@@ -3191,17 +3191,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "dependencies": {
-        "streamsearch": "0.1.2"
-      },
-      "engines": {
-        "node": ">=4.5.0"
       }
     },
     "node_modules/diff-sequences": {
@@ -7855,11 +7844,11 @@
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -8793,7 +8782,7 @@
         "@iarna/toml": "^2.2.5",
         "@miniflare/shared": "2.4.0",
         "@miniflare/watcher": "2.4.0",
-        "busboy": "^0.3.1",
+        "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
@@ -8805,7 +8794,7 @@
         "@miniflare/shared-test": "2.4.0",
         "@miniflare/watcher": "2.4.0",
         "@miniflare/web-sockets": "2.4.0",
-        "@types/busboy": "^0.3.1",
+        "@types/busboy": "^1.5.0",
         "@types/set-cookie-parser": "^2.4.1",
         "dequal": "^2.0.2"
       },
@@ -10103,9 +10092,9 @@
         "@miniflare/shared-test": "2.4.0",
         "@miniflare/watcher": "2.4.0",
         "@miniflare/web-sockets": "2.4.0",
-        "@types/busboy": "^0.3.1",
+        "@types/busboy": "^1.5.0",
         "@types/set-cookie-parser": "^2.4.1",
-        "busboy": "^0.3.1",
+        "busboy": "^1.6.0",
         "dequal": "^2.0.2",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -10407,9 +10396,9 @@
       }
     },
     "@types/busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-8BPLNy4x+7lbTOGkAyUIZrrPEZ7WzbO7YlVGMf9EZi9J9mqILEkYbt/kgVWQ7fizOISo1hM/7cAsWVTa7EhQDg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.0.tgz",
+      "integrity": "sha512-ncOOhwmyFDW76c/Tuvv9MA9VGYUCn8blzyWmzYELcNGDb0WXWLSmFi7hJq25YdRBYJrmMBB5jZZwUjlJe9HCjQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -11182,11 +11171,11 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "busboy": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
-      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "requires": {
-        "dicer": "0.3.0"
+        "streamsearch": "^1.1.0"
       }
     },
     "cacheable-request": {
@@ -11721,14 +11710,6 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
-    },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "requires": {
-        "streamsearch": "0.1.2"
-      }
     },
     "diff-sequences": {
       "version": "27.0.6",
@@ -15255,9 +15236,9 @@
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "@iarna/toml": "^2.2.5",
     "@miniflare/shared": "2.4.0",
     "@miniflare/watcher": "2.4.0",
-    "busboy": "^0.3.1",
+    "busboy": "^1.6.0",
     "dotenv": "^10.0.0",
     "kleur": "^4.1.4",
     "set-cookie-parser": "^2.4.8",
@@ -53,7 +53,7 @@
     "@miniflare/shared-test": "2.4.0",
     "@miniflare/watcher": "2.4.0",
     "@miniflare/web-sockets": "2.4.0",
-    "@types/busboy": "^0.3.1",
+    "@types/busboy": "^1.5.0",
     "@types/set-cookie-parser": "^2.4.1",
     "dequal": "^2.0.2"
   }


### PR DESCRIPTION
This PR bumps `busboy` to the latest version to resolve the advisory at https://github.com/advisories/GHSA-wm7h-9275-46v2.

Very minor code changes as per `busboy` updates, but all tests are now passing. Full list of `busboy` changes: https://github.com/mscdex/busboy/issues/266

Fixes #267 