### PR TITLE
fix: windows tests with `process.execPath`

### DIFF
--- a/packages/core/test/plugins/build.spec.ts
+++ b/packages/core/test/plugins/build.spec.ts
@@ -149,7 +149,7 @@ test("BuildPlugin: beforeSetup: includes MINIFLARE environment variable", async 
   const tmp = await useTmp(t);
   const plugin = new BuildPlugin(ctx, {
     // Cross-platform get environment variable
-    buildCommand: `${process.execPath} -e "console.log(JSON.stringify(process.env))" > env.json`,
+    buildCommand: `"${process.execPath}" -e "console.log(JSON.stringify(process.env))" > env.json`,
     buildBasePath: tmp,
   });
   await plugin.beforeSetup();


### PR DESCRIPTION
If you have Node installed to a path on Windows with a space (such as `C:/Program Files`), this test previously failed. Wrapping the `execPath` in quotes resolves that.