### PR TITLE
Feature/get range

### DIFF
--- a/packages/shared/src/storage.ts
+++ b/packages/shared/src/storage.ts
@@ -79,7 +79,7 @@ export abstract class Storage {
   ): Awaitable<StorageListResult<StoredKey>>;
 
   // storage-file specific methods
-  abstract getRange?<Meta = unknown>(
+  async getRange?<Meta = unknown>(
     key: string,
     start: number,
     length: number

--- a/packages/shared/src/storage.ts
+++ b/packages/shared/src/storage.ts
@@ -78,6 +78,13 @@ export abstract class Storage {
     skipMetadata: true
   ): Awaitable<StorageListResult<StoredKey>>;
 
+  // storage-file specific methods
+  abstract getRange?<Meta = unknown>(
+    key: string,
+    start: number,
+    length: number
+  ): Promise<StoredValueMeta<Meta> | undefined>;
+
   // Batch functions, default implementations may be overridden to optimise
 
   async hasMany(keys: string[]): Promise<number> {

--- a/packages/storage-file/src/helpers.ts
+++ b/packages/storage-file/src/helpers.ts
@@ -20,6 +20,25 @@ export function readFile(
   return onNotFound(fs.readFile(filePath, decode && "utf8"), undefined);
 }
 
+export async function read(
+  filePath: string,
+  start: number,
+  length: number
+): Promise<Buffer | undefined> {
+  let fd = null;
+  let res: Buffer;
+  try {
+    fd = await fs.open(filePath, "r");
+    res = Buffer.alloc(length);
+    await fd.read(res, 0, length, start);
+  } catch (e) {
+    throw e;
+  } finally {
+    await fd?.close();
+  }
+  return res;
+}
+
 export async function writeFile(
   filePath: string,
   data: Uint8Array | string

--- a/packages/storage-file/src/index.ts
+++ b/packages/storage-file/src/index.ts
@@ -10,7 +10,7 @@ import {
   viewToArray,
 } from "@miniflare/shared";
 import { LocalStorage } from "@miniflare/storage-memory";
-import { deleteFile, readFile, walk, writeFile } from "./helpers";
+import { deleteFile, read, readFile, walk, writeFile } from "./helpers";
 
 const metaSuffix = ".meta.json";
 
@@ -74,6 +74,32 @@ export class FileStorage extends LocalStorage {
       return {
         value: viewToArray(value),
         expiration: meta.expiration,
+        metadata: meta.metadata,
+      };
+    } catch (e: any) {
+      // We'll get this error if we try to get a namespaced key, where the
+      // namespace itself is also a key (e.g. trying to get "key/sub-key" where
+      // "key" is also a key). In this case, "key/sub-key" doesn't exist.
+      if (e.code === "ENOTDIR") return;
+      throw e;
+    }
+  }
+
+  async getRange<Meta = unknown>(
+    key: string,
+    start: number,
+    length: number
+  ): Promise<StoredValueMeta<Meta> | undefined> {
+    const [filePath] = this.keyPath(key);
+    if (!filePath) return;
+
+    try {
+      const value = await read(filePath, start, length);
+
+      if (value === undefined) return;
+      const meta = await this.meta<Meta>(filePath);
+      return {
+        value: viewToArray(value),
         metadata: meta.metadata,
       };
     } catch (e: any) {


### PR DESCRIPTION
First step towards R2.

This is a proposal to avoid a behavior mismatch, since large files and `storage-file` package with a range request would be performantly slow.

In order to properly handle range requests for large files, I came up with this idea to be as minimally invasive as possible.

With this method, you can check if `getRange` is a function in storage, and if not just do a normal full `get` + `slice` on the data. Otherwise, you can specify the start and length.

Note this method also ignores `expiration` as it specifically exists for R2.