### PR TITLE
fix: bump undici version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5829,9 +5829,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mri": {
@@ -5864,9 +5864,9 @@
       "dev": true
     },
     "node_modules/node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -7603,9 +7603,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
-      "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
       "engines": {
         "node": ">=12.18"
       }
@@ -7982,7 +7982,7 @@
         "@miniflare/core": "2.5.0",
         "@miniflare/shared": "2.5.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.3.0"
+        "undici": "5.5.1"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.5.0",
@@ -8023,7 +8023,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.3.0",
+        "undici": "5.5.1",
         "urlpattern-polyfill": "^4.0.3"
       },
       "devDependencies": {
@@ -8047,7 +8047,7 @@
         "@miniflare/core": "2.5.0",
         "@miniflare/shared": "2.5.0",
         "@miniflare/storage-memory": "2.5.0",
-        "undici": "5.3.0"
+        "undici": "5.5.1"
       },
       "devDependencies": {
         "@miniflare/cache": "2.5.0",
@@ -8066,7 +8066,7 @@
         "@miniflare/core": "2.5.0",
         "@miniflare/shared": "2.5.0",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.3.0"
+        "undici": "5.5.1"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.5.0"
@@ -8085,7 +8085,7 @@
         "@miniflare/web-sockets": "2.5.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.3.0",
+        "undici": "5.5.1",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
@@ -8126,31 +8126,31 @@
       }
     },
     "packages/jest-environment-miniflare": {
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@jest/environment": ">=27",
         "@jest/fake-timers": ">=27",
         "@jest/types": ">=27",
-        "@miniflare/cache": "2.4.0",
-        "@miniflare/core": "2.4.0",
-        "@miniflare/durable-objects": "2.4.0",
-        "@miniflare/html-rewriter": "2.4.0",
-        "@miniflare/kv": "2.4.0",
-        "@miniflare/runner-vm": "2.4.0",
-        "@miniflare/shared": "2.4.0",
-        "@miniflare/sites": "2.4.0",
-        "@miniflare/storage-memory": "2.4.0",
-        "@miniflare/web-sockets": "2.4.0",
+        "@miniflare/cache": "2.5.0",
+        "@miniflare/core": "2.5.0",
+        "@miniflare/durable-objects": "2.5.0",
+        "@miniflare/html-rewriter": "2.5.0",
+        "@miniflare/kv": "2.5.0",
+        "@miniflare/runner-vm": "2.5.0",
+        "@miniflare/shared": "2.5.0",
+        "@miniflare/sites": "2.5.0",
+        "@miniflare/storage-memory": "2.5.0",
+        "@miniflare/web-sockets": "2.5.0",
         "jest-mock": ">=27",
         "jest-util": ">=27",
-        "miniflare": "2.4.0"
+        "miniflare": "2.5.0"
       },
       "devDependencies": {
         "@jest/environment": "^28.1.0",
         "@jest/fake-timers": "^28.1.0",
         "@jest/types": "^28.1.0",
-        "@miniflare/shared-test": "2.4.0",
+        "@miniflare/shared-test": "2.5.0",
         "jest": "^28.1.0",
         "jest-mock": "^28.1.0",
         "jest-util": "^28.1.0",
@@ -9151,7 +9151,7 @@
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.3.0"
+        "undici": "5.5.1"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -9327,7 +9327,7 @@
       "dependencies": {
         "@miniflare/core": "2.5.0",
         "@miniflare/shared": "2.5.0",
-        "undici": "5.3.0",
+        "undici": "5.5.1",
         "ws": "^8.2.2"
       },
       "devDependencies": {
@@ -10435,7 +10435,7 @@
         "@miniflare/web-sockets": "2.5.0",
         "@types/http-cache-semantics": "^4.0.1",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.3.0"
+        "undici": "5.5.1"
       }
     },
     "@miniflare/cli-parser": {
@@ -10465,7 +10465,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.3.0",
+        "undici": "5.5.1",
         "urlpattern-polyfill": "^4.0.3"
       }
     },
@@ -10478,7 +10478,7 @@
         "@miniflare/shared": "2.5.0",
         "@miniflare/shared-test": "2.5.0",
         "@miniflare/storage-memory": "2.5.0",
-        "undici": "5.3.0"
+        "undici": "5.5.1"
       }
     },
     "@miniflare/html-rewriter": {
@@ -10488,7 +10488,7 @@
         "@miniflare/shared": "2.5.0",
         "@miniflare/shared-test": "2.5.0",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.3.0"
+        "undici": "5.5.1"
       }
     },
     "@miniflare/http-server": {
@@ -10501,7 +10501,7 @@
         "@types/node-forge": "^0.10.4",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.3.0",
+        "undici": "5.5.1",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
@@ -10598,7 +10598,7 @@
         "@miniflare/shared": "2.5.0",
         "@miniflare/shared-test": "2.5.0",
         "@types/ws": "^8.2.0",
-        "undici": "5.3.0",
+        "undici": "5.5.1",
         "ws": "^8.2.2"
       }
     },
@@ -14678,7 +14678,7 @@
         "open": "^8.4.0",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.3.0"
+        "undici": "5.5.1"
       }
     },
     "minimatch": {
@@ -14691,9 +14691,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mri": {
@@ -14720,9 +14720,9 @@
       "dev": true
     },
     "node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -15999,9 +15999,9 @@
       }
     },
     "undici": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.3.0.tgz",
-      "integrity": "sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ=="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw=="
     },
     "unique-string": {
       "version": "2.0.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.5.0",
     "@miniflare/shared": "2.5.0",
     "http-cache-semantics": "^4.1.0",
-    "undici": "5.3.0"
+    "undici": "5.5.1"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
     "dotenv": "^10.0.0",
     "kleur": "^4.1.4",
     "set-cookie-parser": "^2.4.8",
-    "undici": "5.3.0",
+    "undici": "5.5.1",
     "urlpattern-polyfill": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -53,20 +53,6 @@ import {
 } from "./helpers";
 import { kContentLength } from "./streams";
 
-// `undici` restricts which headers can be added to/gotten from a `Headers`
-// object in `Request`/`Response`s. Whilst this restriction makes sense for
-// security reasons in the browser, it doesn't server side.
-//
-// Note: this is a massive hack. I'm fully expecting it to break in future
-// `undici` versions and need to be updated, but that's why we pin our `undici`
-// version and have tests... :) Right?
-const constants: {
-  readonly forbiddenHeaderNames: string[];
-  readonly forbiddenResponseHeaderNames: string[];
-} = require("undici/lib/fetch/constants.js");
-constants.forbiddenHeaderNames.length = 0;
-constants.forbiddenResponseHeaderNames.length = 0;
-
 // We need these for making Request's Headers immutable
 const fetchSymbols: {
   readonly kState: unique symbol;

--- a/packages/durable-objects/package.json
+++ b/packages/durable-objects/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.5.0",
     "@miniflare/shared": "2.5.0",
     "@miniflare/storage-memory": "2.5.0",
-    "undici": "5.3.0"
+    "undici": "5.5.1"
   },
   "devDependencies": {
     "@miniflare/cache": "2.5.0",

--- a/packages/html-rewriter/package.json
+++ b/packages/html-rewriter/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.5.0",
     "@miniflare/shared": "2.5.0",
     "html-rewriter-wasm": "^0.4.1",
-    "undici": "5.3.0"
+    "undici": "5.5.1"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.5.0"

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -40,7 +40,7 @@
     "@miniflare/web-sockets": "2.5.0",
     "kleur": "^4.1.4",
     "selfsigned": "^2.0.0",
-    "undici": "5.3.0",
+    "undici": "5.5.1",
     "ws": "^8.2.2",
     "youch": "^2.2.2"
   },

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -63,7 +63,7 @@
     "kleur": "^4.1.4",
     "semiver": "^1.1.0",
     "source-map-support": "^0.5.20",
-    "undici": "5.3.0"
+    "undici": "5.5.1"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.5.0",

--- a/packages/web-sockets/package.json
+++ b/packages/web-sockets/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.5.0",
     "@miniflare/shared": "2.5.0",
     "ws": "^8.2.2",
-    "undici": "5.3.0"
+    "undici": "5.5.1"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.5.0",


### PR DESCRIPTION
This PR bumps `undici` to `5.5.1` which resolves https://github.com/advisories/GHSA-pgw7-wx7w-2w33. This doesn't impact miniflare directly, but gets rid of the scary "vulnerabilities" warning when installing.

In doing this, `undici` no longer does header filtering, which means the massive hack that was overriding its constants can now be removed! 🎉See https://github.com/nodejs/undici/pull/1469 for more info.