### PR TITLE
preserve file path in FormData objects

### DIFF
--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -302,7 +302,10 @@ export class Body<Inner extends BaseRequest | BaseResponse> {
     const formData = new FormData();
     await new Promise<void>(async (resolve) => {
       const Busboy: typeof import("busboy") = require("busboy");
-      const busboy = Busboy({ headers: headers as http.IncomingHttpHeaders, preservePath: true });
+      const busboy = Busboy({
+        headers: headers as http.IncomingHttpHeaders,
+        preservePath: true,
+      });
       busboy.on("field", (name, value) => {
         formData.append(name, value);
       });

--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -302,7 +302,7 @@ export class Body<Inner extends BaseRequest | BaseResponse> {
     const formData = new FormData();
     await new Promise<void>(async (resolve) => {
       const Busboy: typeof import("busboy") = require("busboy");
-      const busboy = Busboy({ headers: headers as http.IncomingHttpHeaders });
+      const busboy = Busboy({ headers: headers as http.IncomingHttpHeaders, preservePath: true });
       busboy.on("field", (name, value) => {
         formData.append(name, value);
       });

--- a/packages/core/test/standards/http.spec.ts
+++ b/packages/core/test/standards/http.spec.ts
@@ -340,6 +340,26 @@ test("Body: formData: parses files as File objects by default", async (t) => {
   t.is(await file.text(), "file contents");
   t.is(file.name, "test.txt");
 });
+test("Body: formData: preserves path of File objects", async (t) => {
+  const body = new Body(
+    new BaseResponse(
+      [
+        "--boundary",
+        'Content-Disposition: form-data; name="key"; filename="directory/test.txt"',
+        "Content-Type: text/plain",
+        "",
+        "file contents",
+        "--boundary--",
+      ].join("\r\n"),
+      { headers: { "content-type": 'multipart/form-data;boundary="boundary"' } }
+    )
+  );
+  const formData = await body.formData();
+  const file = formData.get("key");
+  assert(file instanceof File);
+  t.is(await file.text(), "file contents");
+  t.is(file.name, "directory/test.txt");
+});
 test("Body: formData: parses files as strings if option set", async (t) => {
   let body = new Body(
     new BaseResponse(


### PR DESCRIPTION
Hi, I'm working on a project that pulls `File` objects out of multipart `FormData` uploads and needs the full file path in order to correctly calculate some hashes and so on.

In a real CF worker, `File` objects from multipart uploads include the full path in their `name` property, e.g. `directory/foo.txt`, but Miniflare just sets the basename (`foo.txt`).

This PR just sets `preservePath: true` when constructing a `Busboy` instance, to make the behavior line up with the real worker env.

Let me know if there's any changes you'd want, or if you'd like me to file an issue to track the bug.

Cheers :)