### PR TITLE
Upgrade undici to `v5.8.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7607,9 +7607,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
-      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.0.tgz",
+      "integrity": "sha512-1F7Vtcez5w/LwH2G2tGnFIihuWUlc58YidwLiCv+jR2Z50x0tNXpRRw7eOIJ+GvqCqIkg9SB7NWAJ/T9TLfv8Q==",
       "engines": {
         "node": ">=12.18"
       }
@@ -7986,7 +7986,7 @@
         "@miniflare/core": "2.6.0",
         "@miniflare/shared": "2.6.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.5.1"
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.6.0",
@@ -8003,7 +8003,8 @@
       "license": "MIT",
       "dependencies": {
         "@miniflare/shared": "2.6.0",
-        "kleur": "^4.1.4"
+        "kleur": "^4.1.4",
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/core": "2.6.0",
@@ -8027,7 +8028,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.5.1",
+        "undici": "5.8.0",
         "urlpattern-polyfill": "^4.0.3"
       },
       "devDependencies": {
@@ -8051,7 +8052,7 @@
         "@miniflare/core": "2.6.0",
         "@miniflare/shared": "2.6.0",
         "@miniflare/storage-memory": "2.6.0",
-        "undici": "5.5.1"
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/cache": "2.6.0",
@@ -8070,7 +8071,7 @@
         "@miniflare/core": "2.6.0",
         "@miniflare/shared": "2.6.0",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.5.1"
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.6.0"
@@ -8089,7 +8090,7 @@
         "@miniflare/web-sockets": "2.6.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.5.1",
+        "undici": "5.8.0",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
@@ -8148,7 +8149,8 @@
         "@miniflare/web-sockets": "2.6.0",
         "jest-mock": ">=27",
         "jest-util": ">=27",
-        "miniflare": "2.6.0"
+        "miniflare": "2.6.0",
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@jest/environment": "^28.1.0",
@@ -9125,7 +9127,8 @@
       "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
-        "@miniflare/shared": "2.6.0"
+        "@miniflare/shared": "2.6.0",
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.6.0"
@@ -9156,7 +9159,7 @@
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.5.1"
+        "undici": "5.8.0"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -9192,7 +9195,7 @@
       "license": "MIT",
       "dependencies": {
         "@miniflare/shared": "2.6.0",
-        "undici": "5.5.1"
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.6.0"
@@ -9206,7 +9209,8 @@
       "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
-        "@miniflare/shared": "2.6.0"
+        "@miniflare/shared": "2.6.0",
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.6.0"
@@ -9222,7 +9226,8 @@
       "dependencies": {
         "@miniflare/core": "2.6.0",
         "@miniflare/shared": "2.6.0",
-        "cron-schedule": "^3.0.4"
+        "cron-schedule": "^3.0.4",
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.6.0"
@@ -9237,7 +9242,8 @@
       "license": "MIT",
       "dependencies": {
         "ignore": "^5.1.8",
-        "kleur": "^4.1.4"
+        "kleur": "^4.1.4",
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.6.0"
@@ -9256,6 +9262,7 @@
         "@miniflare/runner-vm": "2.6.0",
         "@miniflare/shared": "2.6.0",
         "@miniflare/storage-memory": "2.6.0",
+        "undici": "5.8.0",
         "ws": "^8.2.2"
       },
       "engines": {
@@ -9269,7 +9276,8 @@
       "dependencies": {
         "@miniflare/kv": "2.6.0",
         "@miniflare/shared": "2.6.0",
-        "@miniflare/storage-file": "2.6.0"
+        "@miniflare/storage-file": "2.6.0",
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@cloudflare/kv-asset-handler": "^0.1.3",
@@ -9286,7 +9294,8 @@
       "license": "MIT",
       "dependencies": {
         "@miniflare/shared": "2.6.0",
-        "@miniflare/storage-memory": "2.6.0"
+        "@miniflare/storage-memory": "2.6.0",
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.6.0"
@@ -9300,7 +9309,8 @@
       "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
-        "@miniflare/shared": "2.6.0"
+        "@miniflare/shared": "2.6.0",
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.6.0"
@@ -9316,7 +9326,8 @@
       "dependencies": {
         "@miniflare/shared": "2.6.0",
         "@miniflare/storage-memory": "2.6.0",
-        "ioredis": "^4.27.9"
+        "ioredis": "^4.27.9",
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.6.0",
@@ -9331,7 +9342,8 @@
       "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
-        "@miniflare/shared": "2.6.0"
+        "@miniflare/shared": "2.6.0",
+        "undici": "5.8.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.6.0"
@@ -9347,7 +9359,7 @@
       "dependencies": {
         "@miniflare/core": "2.6.0",
         "@miniflare/shared": "2.6.0",
-        "undici": "5.5.1",
+        "undici": "5.8.0",
         "ws": "^8.2.2"
       },
       "devDependencies": {
@@ -10455,7 +10467,7 @@
         "@miniflare/web-sockets": "2.6.0",
         "@types/http-cache-semantics": "^4.0.1",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.5.1"
+        "undici": "5.8.0"
       }
     },
     "@miniflare/cli-parser": {
@@ -10466,7 +10478,8 @@
         "@miniflare/shared-test": "2.6.0",
         "@types/mri": "^1.1.1",
         "kleur": "^4.1.4",
-        "mri": "^1.1.6"
+        "mri": "^1.1.6",
+        "undici": "5.8.0"
       }
     },
     "@miniflare/core": {
@@ -10485,7 +10498,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.5.1",
+        "undici": "5.8.0",
         "urlpattern-polyfill": "^4.0.3"
       }
     },
@@ -10498,7 +10511,7 @@
         "@miniflare/shared": "2.6.0",
         "@miniflare/shared-test": "2.6.0",
         "@miniflare/storage-memory": "2.6.0",
-        "undici": "5.5.1"
+        "undici": "5.8.0"
       }
     },
     "@miniflare/html-rewriter": {
@@ -10508,7 +10521,7 @@
         "@miniflare/shared": "2.6.0",
         "@miniflare/shared-test": "2.6.0",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.5.1"
+        "undici": "5.8.0"
       }
     },
     "@miniflare/http-server": {
@@ -10521,7 +10534,7 @@
         "@types/node-forge": "^0.10.4",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.5.1",
+        "undici": "5.8.0",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
@@ -10530,7 +10543,8 @@
       "version": "file:packages/kv",
       "requires": {
         "@miniflare/shared": "2.6.0",
-        "@miniflare/shared-test": "2.6.0"
+        "@miniflare/shared-test": "2.6.0",
+        "undici": "5.8.0"
       }
     },
     "@miniflare/r2": {
@@ -10538,14 +10552,15 @@
       "requires": {
         "@miniflare/shared": "2.6.0",
         "@miniflare/shared-test": "2.6.0",
-        "undici": "5.5.1"
+        "undici": "5.8.0"
       }
     },
     "@miniflare/runner-vm": {
       "version": "file:packages/runner-vm",
       "requires": {
         "@miniflare/shared": "2.6.0",
-        "@miniflare/shared-test": "2.6.0"
+        "@miniflare/shared-test": "2.6.0",
+        "undici": "5.8.0"
       }
     },
     "@miniflare/scheduler": {
@@ -10554,7 +10569,8 @@
         "@miniflare/core": "2.6.0",
         "@miniflare/shared": "2.6.0",
         "@miniflare/shared-test": "2.6.0",
-        "cron-schedule": "^3.0.4"
+        "cron-schedule": "^3.0.4",
+        "undici": "5.8.0"
       }
     },
     "@miniflare/shared": {
@@ -10562,7 +10578,8 @@
       "requires": {
         "@miniflare/shared-test": "2.6.0",
         "ignore": "^5.1.8",
-        "kleur": "^4.1.4"
+        "kleur": "^4.1.4",
+        "undici": "5.8.0"
       }
     },
     "@miniflare/shared-test": {
@@ -10573,6 +10590,7 @@
         "@miniflare/runner-vm": "2.6.0",
         "@miniflare/shared": "2.6.0",
         "@miniflare/storage-memory": "2.6.0",
+        "undici": "5.8.0",
         "ws": "^8.2.2"
       }
     },
@@ -10584,7 +10602,8 @@
         "@miniflare/kv": "2.6.0",
         "@miniflare/shared": "2.6.0",
         "@miniflare/shared-test": "2.6.0",
-        "@miniflare/storage-file": "2.6.0"
+        "@miniflare/storage-file": "2.6.0",
+        "undici": "5.8.0"
       }
     },
     "@miniflare/storage-file": {
@@ -10592,14 +10611,16 @@
       "requires": {
         "@miniflare/shared": "2.6.0",
         "@miniflare/shared-test": "2.6.0",
-        "@miniflare/storage-memory": "2.6.0"
+        "@miniflare/storage-memory": "2.6.0",
+        "undici": "5.8.0"
       }
     },
     "@miniflare/storage-memory": {
       "version": "file:packages/storage-memory",
       "requires": {
         "@miniflare/shared": "2.6.0",
-        "@miniflare/shared-test": "2.6.0"
+        "@miniflare/shared-test": "2.6.0",
+        "undici": "5.8.0"
       }
     },
     "@miniflare/storage-redis": {
@@ -10609,14 +10630,16 @@
         "@miniflare/shared-test": "2.6.0",
         "@miniflare/storage-memory": "2.6.0",
         "@types/ioredis": "^4.27.2",
-        "ioredis": "^4.27.9"
+        "ioredis": "^4.27.9",
+        "undici": "5.8.0"
       }
     },
     "@miniflare/watcher": {
       "version": "file:packages/watcher",
       "requires": {
         "@miniflare/shared": "2.6.0",
-        "@miniflare/shared-test": "2.6.0"
+        "@miniflare/shared-test": "2.6.0",
+        "undici": "5.8.0"
       }
     },
     "@miniflare/web-sockets": {
@@ -10626,7 +10649,7 @@
         "@miniflare/shared": "2.6.0",
         "@miniflare/shared-test": "2.6.0",
         "@types/ws": "^8.2.0",
-        "undici": "5.5.1",
+        "undici": "5.8.0",
         "ws": "^8.2.2"
       }
     },
@@ -13357,7 +13380,8 @@
         "jest-mock": "^28.1.0",
         "jest-util": "^28.1.0",
         "miniflare": "2.6.0",
-        "react-dom": "^18.1.0"
+        "react-dom": "^18.1.0",
+        "undici": "5.8.0"
       },
       "dependencies": {
         "@jest/console": {
@@ -14707,7 +14731,7 @@
         "open": "^8.4.0",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.5.1"
+        "undici": "5.8.0"
       }
     },
     "minimatch": {
@@ -16028,9 +16052,9 @@
       }
     },
     "undici": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
-      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw=="
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.0.tgz",
+      "integrity": "sha512-1F7Vtcez5w/LwH2G2tGnFIihuWUlc58YidwLiCv+jR2Z50x0tNXpRRw7eOIJ+GvqCqIkg9SB7NWAJ/T9TLfv8Q=="
     },
     "unique-string": {
       "version": "2.0.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.6.0",
     "@miniflare/shared": "2.6.0",
     "http-cache-semantics": "^4.1.0",
-    "undici": "5.5.1"
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0",

--- a/packages/cli-parser/package.json
+++ b/packages/cli-parser/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "@miniflare/shared": "2.6.0",
-    "kleur": "^4.1.4"
+    "kleur": "^4.1.4",
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/core": "2.6.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
     "dotenv": "^10.0.0",
     "kleur": "^4.1.4",
     "set-cookie-parser": "^2.4.8",
-    "undici": "5.5.1",
+    "undici": "5.8.0",
     "urlpattern-polyfill": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/durable-objects/package.json
+++ b/packages/durable-objects/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.6.0",
     "@miniflare/shared": "2.6.0",
     "@miniflare/storage-memory": "2.6.0",
-    "undici": "5.5.1"
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/cache": "2.6.0",

--- a/packages/html-rewriter/package.json
+++ b/packages/html-rewriter/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.6.0",
     "@miniflare/shared": "2.6.0",
     "html-rewriter-wasm": "^0.4.1",
-    "undici": "5.5.1"
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0"

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -40,7 +40,7 @@
     "@miniflare/web-sockets": "2.6.0",
     "kleur": "^4.1.4",
     "selfsigned": "^2.0.0",
-    "undici": "5.5.1",
+    "undici": "5.8.0",
     "ws": "^8.2.2",
     "youch": "^2.2.2"
   },

--- a/packages/jest-environment-miniflare/package.json
+++ b/packages/jest-environment-miniflare/package.json
@@ -35,6 +35,9 @@
     "extends": "../../package.json"
   },
   "dependencies": {
+    "@jest/environment": ">=27",
+    "@jest/fake-timers": ">=27",
+    "@jest/types": ">=27",
     "@miniflare/cache": "2.6.0",
     "@miniflare/core": "2.6.0",
     "@miniflare/durable-objects": "2.6.0",
@@ -45,12 +48,10 @@
     "@miniflare/sites": "2.6.0",
     "@miniflare/storage-memory": "2.6.0",
     "@miniflare/web-sockets": "2.6.0",
-    "miniflare": "2.6.0",
-    "@jest/environment": ">=27",
-    "@jest/fake-timers": ">=27",
-    "@jest/types": ">=27",
     "jest-mock": ">=27",
-    "jest-util": ">=27"
+    "jest-util": ">=27",
+    "miniflare": "2.6.0",
+    "undici": "5.8.0"
   },
   "peerDependencies": {
     "jest": ">=27"

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -35,7 +35,8 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "@miniflare/shared": "2.6.0"
+    "@miniflare/shared": "2.6.0",
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0"

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -64,7 +64,7 @@
     "kleur": "^4.1.4",
     "semiver": "^1.1.0",
     "source-map-support": "^0.5.20",
-    "undici": "5.5.1"
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0",

--- a/packages/r2/package.json
+++ b/packages/r2/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@miniflare/shared": "2.6.0",
-    "undici": "5.5.1"
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0"

--- a/packages/runner-vm/package.json
+++ b/packages/runner-vm/package.json
@@ -35,7 +35,8 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "@miniflare/shared": "2.6.0"
+    "@miniflare/shared": "2.6.0",
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0"

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "@miniflare/core": "2.6.0",
     "@miniflare/shared": "2.6.0",
-    "cron-schedule": "^3.0.4"
+    "cron-schedule": "^3.0.4",
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0"

--- a/packages/shared-test/package.json
+++ b/packages/shared-test/package.json
@@ -38,6 +38,7 @@
     "@miniflare/runner-vm": "2.6.0",
     "@miniflare/shared": "2.6.0",
     "@miniflare/storage-memory": "2.6.0",
+    "undici": "5.8.0",
     "ws": "^8.2.2"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "ignore": "^5.1.8",
-    "kleur": "^4.1.4"
+    "kleur": "^4.1.4",
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0"

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "@miniflare/kv": "2.6.0",
     "@miniflare/shared": "2.6.0",
-    "@miniflare/storage-file": "2.6.0"
+    "@miniflare/storage-file": "2.6.0",
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@cloudflare/kv-asset-handler": "^0.1.3",

--- a/packages/storage-file/package.json
+++ b/packages/storage-file/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "@miniflare/shared": "2.6.0",
-    "@miniflare/storage-memory": "2.6.0"
+    "@miniflare/storage-memory": "2.6.0",
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0"

--- a/packages/storage-memory/package.json
+++ b/packages/storage-memory/package.json
@@ -35,7 +35,8 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "@miniflare/shared": "2.6.0"
+    "@miniflare/shared": "2.6.0",
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0"

--- a/packages/storage-redis/package.json
+++ b/packages/storage-redis/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "@miniflare/shared": "2.6.0",
     "@miniflare/storage-memory": "2.6.0",
-    "ioredis": "^4.27.9"
+    "ioredis": "^4.27.9",
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0",

--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -35,7 +35,8 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "@miniflare/shared": "2.6.0"
+    "@miniflare/shared": "2.6.0",
+    "undici": "5.8.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0"

--- a/packages/web-sockets/package.json
+++ b/packages/web-sockets/package.json
@@ -37,8 +37,8 @@
   "dependencies": {
     "@miniflare/core": "2.6.0",
     "@miniflare/shared": "2.6.0",
-    "ws": "^8.2.2",
-    "undici": "5.5.1"
+    "undici": "5.8.0",
+    "ws": "^8.2.2"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.6.0",


### PR DESCRIPTION
Hi! Upgraded *undici* to `v5.8.0`. This release fixed the vulnerabilities.

https://github.com/nodejs/undici/releases/tag/v5.8.0
