### PR TITLE
Feature: Alarm Flush

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2653,14 +2653,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001271",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
+      "version": "1.0.30001373",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
+      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -11540,9 +11546,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001271",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
+      "version": "1.0.30001373",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
+      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==",
       "dev": true
     },
     "chalk": {

--- a/packages/durable-objects/test/plugin.spec.ts
+++ b/packages/durable-objects/test/plugin.spec.ts
@@ -4,7 +4,6 @@ import { Response } from "@miniflare/core";
 import {
   DurableObject,
   DurableObjectError,
-  DurableObjectId,
   DurableObjectNamespace,
   DurableObjectState,
   DurableObjectsPlugin,

--- a/packages/durable-objects/test/plugin.spec.ts
+++ b/packages/durable-objects/test/plugin.spec.ts
@@ -4,6 +4,7 @@ import { Response } from "@miniflare/core";
 import {
   DurableObject,
   DurableObjectError,
+  DurableObjectId,
   DurableObjectNamespace,
   DurableObjectState,
   DurableObjectsPlugin,
@@ -362,4 +363,88 @@ test("DurableObjectsPlugin: set alarm and run list filters out alarm", async (t)
   const ns1: DurableObjectNamespace = result.bindings?.OBJECT1;
   const res1 = await ns1.get(ns1.newUniqueId()).fetch("/");
   t.is(await res1.text(), "{}");
+});
+
+test("DurableObjectsPlugin: flush alarms", async (t) => {
+  class TestObject implements DurableObject {
+    constructor(private readonly state: DurableObjectState) {}
+
+    fetch = async () => {
+      await this.state.storage.setAlarm(Date.now() + 60 * 1000);
+      return new Response("ok");
+    };
+    alarm = async () => {
+      await this.state.storage.put("a", 1);
+    };
+  }
+
+  const map = new Map<string, StoredValue>();
+  const factory = new MemoryStorageFactory({
+    [`test://map:TEST:${testId.toString()}`]: map,
+  });
+  const plugin = new DurableObjectsPlugin(ctx, {
+    durableObjects: { TEST: "TestObject" },
+    durableObjectsPersist: "test://map",
+    durableObjectsAlarms: true,
+  });
+  await plugin.setup(factory);
+  plugin.beforeReload();
+  plugin.reload({}, { TestObject }, new Map());
+
+  const ns = plugin.getNamespace(factory, "TEST");
+  const res = await ns.get(testId).fetch("/");
+  t.is(await res.text(), "ok");
+  // now flush
+  await plugin.flushAlarms(factory);
+  // check storage "a" is 1
+  const state = await plugin.getObject(factory, testId);
+  t.is(await state.storage.get("a"), 1);
+});
+
+test("DurableObjectsPlugin: flush a specific alarm", async (t) => {
+  class TestObject implements DurableObject {
+    constructor(private readonly state: DurableObjectState) {}
+
+    fetch = async () => {
+      await this.state.storage.setAlarm(Date.now() + 60 * 1000);
+      return new Response("ok");
+    };
+    alarm = async () => {
+      await this.state.storage.put("key", 1);
+    };
+  }
+
+  const mapA = new Map<string, StoredValue>();
+  const mapB = new Map<string, StoredValue>();
+  const factory = new MemoryStorageFactory({
+    [`test://map:TEST:a`]: mapA,
+    [`test://map:TEST:b`]: mapB,
+  });
+  const plugin = new DurableObjectsPlugin(ctx, {
+    durableObjects: { TEST: "TestObject" },
+    durableObjectsPersist: "test://map",
+    durableObjectsAlarms: true,
+  });
+  await plugin.setup(factory);
+  plugin.beforeReload();
+  plugin.reload({}, { TestObject }, new Map());
+
+  const ns = plugin.getNamespace(factory, "TEST");
+  const idA = ns.idFromName("a");
+  const idB = ns.idFromName("b");
+
+  const resA = await ns.get(idA).fetch("/");
+  t.is(await resA.text(), "ok");
+  const resB = await ns.get(idB).fetch("/");
+  t.is(await resB.text(), "ok");
+  // now flush
+  await plugin.flushAlarms(factory, [idA]);
+  // check storage "a" is 1
+  const stateA = await plugin.getObject(factory, idA);
+  t.is(await stateA.storage.get("key"), 1);
+  // check that storage "b" is still empty
+  const stateB = await plugin.getObject(factory, idB);
+  t.is(await stateB.storage.get("key"), undefined);
+  // dispose
+  plugin.dispose();
 });

--- a/packages/jest-environment-miniflare/src/index.ts
+++ b/packages/jest-environment-miniflare/src/index.ts
@@ -29,7 +29,9 @@ declare global {
   function getMiniflareDurableObjectStorage(
     id: DurableObjectId
   ): Promise<DurableObjectStorage>;
-  function flushDurableObjectAlarms(ids: DurableObjectId[]): Promise<void>;
+  function flushMiniflareDurableObjectAlarms(
+    ids: DurableObjectId[]
+  ): Promise<void>;
 }
 
 // MiniflareCore will ensure CorePlugin is first and BindingsPlugin is last,
@@ -224,7 +226,7 @@ export default class MiniflareEnvironment implements JestEnvironment<Timer> {
       const state = await plugin.getObject(storage, id);
       return state.storage;
     };
-    global.flushDurableObjectAlarms = async (
+    global.flushMiniflareDurableObjectAlarms = async (
       ids?: DurableObjectId[]
     ): Promise<void> => {
       const plugin = (await mf.getPlugins()).DurableObjectsPlugin;

--- a/packages/jest-environment-miniflare/src/index.ts
+++ b/packages/jest-environment-miniflare/src/index.ts
@@ -231,7 +231,7 @@ export default class MiniflareEnvironment implements JestEnvironment<Timer> {
     ): Promise<void> => {
       const plugin = (await mf.getPlugins()).DurableObjectsPlugin;
       const storage = mf.getPluginStorage("DurableObjectsPlugin");
-      plugin.flushAlarms(storage, ids);
+      return plugin.flushAlarms(storage, ids);
     };
   }
 

--- a/packages/jest-environment-miniflare/src/index.ts
+++ b/packages/jest-environment-miniflare/src/index.ts
@@ -29,6 +29,7 @@ declare global {
   function getMiniflareDurableObjectStorage(
     id: DurableObjectId
   ): Promise<DurableObjectStorage>;
+  function flushDurableObjectAlarms(ids: DurableObjectId[]): Promise<void>;
 }
 
 // MiniflareCore will ensure CorePlugin is first and BindingsPlugin is last,
@@ -222,6 +223,13 @@ export default class MiniflareEnvironment implements JestEnvironment<Timer> {
       const storage = mf.getPluginStorage("DurableObjectsPlugin");
       const state = await plugin.getObject(storage, id);
       return state.storage;
+    };
+    global.flushDurableObjectAlarms = async (
+      ids?: DurableObjectId[]
+    ): Promise<void> => {
+      const plugin = (await mf.getPlugins()).DurableObjectsPlugin;
+      const storage = mf.getPluginStorage("DurableObjectsPlugin");
+      plugin.flushAlarms(storage, ids);
     };
   }
 


### PR DESCRIPTION
Closes https://github.com/cloudflare/miniflare/issues/322

* Adds function `flushAlarms(storage: StorageFactory, ids: DurableObjectID[])` to the Durable Object Plugin
* Adds jest global function `flushDurableObjectAlarms(ids: DurableObjectId[]): Promise<void>`

If no `ids` are provided, all alarms are called + deleted.
If `ids` is provided: for each id provided, call the alarm + delete.