### PR TITLE
Bugfix: Sites does not parse URI encoding properly

### DIFF
--- a/packages/sites/src/filtered.ts
+++ b/packages/sites/src/filtered.ts
@@ -41,6 +41,7 @@ export class FilteredKVNamespace extends KVNamespace {
     key: string,
     options?: KVGetValueType | Partial<KVGetOptions>
   ): KVValue<any> {
+    key = decodeURI(key);
     if (!this.#included(key)) return Promise.resolve(null);
     return super.get(key, options as any);
   }
@@ -49,6 +50,7 @@ export class FilteredKVNamespace extends KVNamespace {
     key: string,
     options?: KVGetValueType | Partial<KVGetOptions>
   ): KVValueMeta<any, Meta> {
+    key = decodeURI(key);
     if (!this.#included(key)) {
       return Promise.resolve({ value: null, metadata: null });
     }
@@ -60,6 +62,7 @@ export class FilteredKVNamespace extends KVNamespace {
     value: KVPutValueType,
     options?: KVPutOptions
   ): Promise<void> {
+    key = decodeURI(key);
     if (this.#options.readOnly) {
       throw new TypeError("Unable to put into read-only namespace");
     }
@@ -67,6 +70,7 @@ export class FilteredKVNamespace extends KVNamespace {
   }
 
   async delete(key: string): Promise<void> {
+    key = decodeURI(key);
     if (this.#options.readOnly) {
       throw new TypeError("Unable to delete from read-only namespace");
     }

--- a/packages/sites/test/plugin.spec.ts
+++ b/packages/sites/test/plugin.spec.ts
@@ -111,6 +111,7 @@ const routeContents = {
   "/": "<p>Index</p>",
   "/a.txt": "a",
   "/b/b.txt": "b",
+  "/ń.html": "ń",
 };
 
 const getMacro: Macro<[SitesOptions, Set<Route>]> = async (
@@ -146,7 +147,7 @@ test(
   "gets all assets with no filter",
   getMacro,
   {},
-  new Set<Route>(["/", "/a.txt", "/b/b.txt"])
+  new Set<Route>(["/", "/a.txt", "/b/b.txt", "/ń.html"])
 );
 test(
   "gets included assets with include filter",
@@ -158,7 +159,7 @@ test(
   "gets all but excluded assets with include filter",
   getMacro,
   { siteExclude: ["b"] },
-  new Set<Route>(["/", "/a.txt"])
+  new Set<Route>(["/", "/a.txt", "/ń.html"])
 );
 test(
   "gets included assets with include and exclude filters",


### PR DESCRIPTION
fixes https://github.com/cloudflare/miniflare/issues/326

When a browser accepts a request, it first converts anything not within utf-8 like so:
My request: `http://localhost:8788/ń.html`
What the server sees: `http://localhost:8788/%C5%84.html`
What miniflare looks for: `%C5%84.html`

Fix:
What miniflare looks for: `ń.html`

Not sure if I have to decode for every single KV event, just did it incase.