### PR TITLE
[WIP] Use the class name as the identifier for Durable Objects

### DIFF
--- a/packages/durable-objects/src/plugin.ts
+++ b/packages/durable-objects/src/plugin.ts
@@ -167,8 +167,8 @@ export class DurableObjectsPlugin
 
   setup(storageFactory: StorageFactory): SetupResult {
     const bindings: Context = {};
-    for (const { name } of this.#processedObjects) {
-      bindings[name] = this.getNamespace(storageFactory, name);
+    for (const { name, className } of this.#processedObjects) {
+      bindings[name] = this.getNamespace(storageFactory, className);
     }
     return {
       bindings,


### PR DESCRIPTION
IDs should be scoped to the class, rather than to whatever they're bound as. This unlocks us communicating between two different services which bind to the same Durable Object.