### PR TITLE
fix: add missing @miniflare/queues dependency references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8728,6 +8728,7 @@
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
+        "@miniflare/queues": "2.8.0",
         "@miniflare/shared": "2.8.0",
         "@miniflare/watcher": "2.8.0",
         "busboy": "^1.6.0",
@@ -8837,15 +8838,16 @@
       }
     },
     "packages/jest-environment-miniflare": {
-      "version": "2.7.1",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "@jest/environment": ">=27",
         "@jest/fake-timers": ">=27",
         "@jest/types": ">=27",
-        "@miniflare/runner-vm": "2.7.1",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/shared-test-environment": "2.7.1",
+        "@miniflare/queues": "2.8.0",
+        "@miniflare/runner-vm": "2.8.0",
+        "@miniflare/shared": "2.8.0",
+        "@miniflare/shared-test-environment": "2.8.0",
         "jest-mock": ">=27",
         "jest-util": ">=27"
       },
@@ -8853,11 +8855,11 @@
         "@jest/environment": "^28.1.0",
         "@jest/fake-timers": "^28.1.0",
         "@jest/types": "^28.1.0",
-        "@miniflare/shared-test": "2.7.1",
+        "@miniflare/shared-test": "2.8.0",
         "jest": "^28.1.0",
         "jest-mock": "^28.1.0",
         "jest-util": "^28.1.0",
-        "miniflare": "2.7.1",
+        "miniflare": "2.8.0",
         "react-dom": "^18.1.0"
       },
       "engines": {
@@ -9845,6 +9847,7 @@
         "@miniflare/html-rewriter": "2.8.0",
         "@miniflare/http-server": "2.8.0",
         "@miniflare/kv": "2.8.0",
+        "@miniflare/queues": "2.8.0",
         "@miniflare/r2": "2.8.0",
         "@miniflare/runner-vm": "2.8.0",
         "@miniflare/scheduler": "2.8.0",
@@ -9968,6 +9971,7 @@
       "dependencies": {
         "@miniflare/cli-parser": "2.8.0",
         "@miniflare/core": "2.8.0",
+        "@miniflare/queues": "2.8.0",
         "@miniflare/runner-vm": "2.8.0",
         "@miniflare/shared": "2.8.0",
         "@miniflare/storage-memory": "2.8.0",
@@ -10061,16 +10065,17 @@
       }
     },
     "packages/vitest-environment-miniflare": {
-      "version": "2.7.1",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
-        "@miniflare/runner-vm": "2.7.1",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/shared-test-environment": "2.7.1"
+        "@miniflare/queues": "2.8.0",
+        "@miniflare/runner-vm": "2.8.0",
+        "@miniflare/shared": "2.8.0",
+        "@miniflare/shared-test-environment": "2.8.0"
       },
       "devDependencies": {
-        "@miniflare/shared-test": "2.7.1",
-        "miniflare": "2.7.1",
+        "@miniflare/shared-test": "2.8.0",
+        "miniflare": "2.8.0",
         "react-dom": "^18.1.0",
         "vitest": "^0.23.1"
       },
@@ -11236,6 +11241,7 @@
       "requires": {
         "@iarna/toml": "^2.2.5",
         "@miniflare/durable-objects": "2.8.0",
+        "@miniflare/queues": "2.8.0",
         "@miniflare/shared": "2.8.0",
         "@miniflare/shared-test": "2.8.0",
         "@miniflare/watcher": "2.8.0",
@@ -11340,6 +11346,7 @@
       "requires": {
         "@miniflare/cli-parser": "2.8.0",
         "@miniflare/core": "2.8.0",
+        "@miniflare/queues": "2.8.0",
         "@miniflare/runner-vm": "2.8.0",
         "@miniflare/shared": "2.8.0",
         "@miniflare/storage-memory": "2.8.0",
@@ -14330,6 +14337,7 @@
         "@jest/environment": "^28.1.0",
         "@jest/fake-timers": "^28.1.0",
         "@jest/types": "^28.1.0",
+        "@miniflare/queues": "2.8.0",
         "@miniflare/runner-vm": "2.8.0",
         "@miniflare/shared": "2.8.0",
         "@miniflare/shared-test": "2.8.0",
@@ -15689,6 +15697,7 @@
         "@miniflare/html-rewriter": "2.8.0",
         "@miniflare/http-server": "2.8.0",
         "@miniflare/kv": "2.8.0",
+        "@miniflare/queues": "2.8.0",
         "@miniflare/r2": "2.8.0",
         "@miniflare/runner-vm": "2.8.0",
         "@miniflare/scheduler": "2.8.0",
@@ -17265,11 +17274,12 @@
     "vitest-environment-miniflare": {
       "version": "file:packages/vitest-environment-miniflare",
       "requires": {
-        "@miniflare/runner-vm": "2.7.1",
-        "@miniflare/shared": "2.7.1",
-        "@miniflare/shared-test": "2.7.1",
-        "@miniflare/shared-test-environment": "2.7.1",
-        "miniflare": "2.7.1",
+        "@miniflare/queues": "2.8.0",
+        "@miniflare/runner-vm": "2.8.0",
+        "@miniflare/shared": "2.8.0",
+        "@miniflare/shared-test": "2.8.0",
+        "@miniflare/shared-test-environment": "2.8.0",
+        "miniflare": "2.8.0",
         "react-dom": "^18.1.0",
         "vitest": "^0.23.1"
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,7 @@
   ],
   "dependencies": {
     "@iarna/toml": "^2.2.5",
+    "@miniflare/queues": "2.8.0",
     "@miniflare/shared": "2.8.0",
     "@miniflare/watcher": "2.8.0",
     "busboy": "^1.6.0",

--- a/packages/jest-environment-miniflare/package.json
+++ b/packages/jest-environment-miniflare/package.json
@@ -35,6 +35,7 @@
     "extends": "../../package.json"
   },
   "dependencies": {
+    "@miniflare/queues": "2.8.0",
     "@miniflare/runner-vm": "2.8.0",
     "@miniflare/shared": "2.8.0",
     "@miniflare/shared-test-environment": "2.8.0",

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -53,6 +53,7 @@
     "@miniflare/html-rewriter": "2.8.0",
     "@miniflare/http-server": "2.8.0",
     "@miniflare/kv": "2.8.0",
+    "@miniflare/queues": "2.8.0",
     "@miniflare/r2": "2.8.0",
     "@miniflare/runner-vm": "2.8.0",
     "@miniflare/scheduler": "2.8.0",

--- a/packages/shared-test/package.json
+++ b/packages/shared-test/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@miniflare/cli-parser": "2.8.0",
     "@miniflare/core": "2.8.0",
+    "@miniflare/queues": "2.8.0",
     "@miniflare/runner-vm": "2.8.0",
     "@miniflare/shared": "2.8.0",
     "@miniflare/storage-memory": "2.8.0",

--- a/packages/vitest-environment-miniflare/package.json
+++ b/packages/vitest-environment-miniflare/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@miniflare/runner-vm": "2.8.0",
+    "@miniflare/queues": "2.8.0",
     "@miniflare/shared": "2.8.0",
     "@miniflare/shared-test-environment": "2.8.0"
   },


### PR DESCRIPTION
fixes: #360 

I'm not sure if I need to do anything to bump the dependency versions or if this is done in a release workflow. Let me know if anything needs to be done on my part.