### PR TITLE
Reuse Docker container between reloads, closes #369

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3975,6 +3975,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9411,6 +9422,7 @@
         "acorn": "^8.8.0",
         "acorn-walk": "^8.2.0",
         "capnp-ts": "^0.7.0",
+        "exit-hook": "^2.2.1",
         "get-port": "^5.1.1",
         "kleur": "^4.1.5",
         "stoppable": "^1.1.0",
@@ -10733,6 +10745,7 @@
         "acorn": "^8.8.0",
         "acorn-walk": "^8.2.0",
         "capnp-ts": "^0.7.0",
+        "exit-hook": "2",
         "get-port": "^5.1.1",
         "kleur": "^4.1.5",
         "stoppable": "^1.1.0",
@@ -12684,6 +12697,11 @@
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
+    },
+    "exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/packages/tre/lib/.gitignore
+++ b/packages/tre/lib/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!restart.sh

--- a/packages/tre/lib/restart.sh
+++ b/packages/tre/lib/restart.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Restarts a process on receiving SIGUSR1.
+# Usage: ./restart.sh <command> <...args>
+
+# Start process and record its PID
+"$@" &
+PID=$!
+echo "[*] Started $PID"
+
+# Trap SIGUSR1 to set $RECEIVED_USR1 to 1, then terminate $PID.
+# Setting $RECEIVED_USR1 will cause the process to be restarted.
+RECEIVED_USR1=0
+trap 'RECEIVED_USR1=1 && kill -TERM $PID' USR1
+
+# Trap SIGINT and SIGTERM to also terminate $PID for cleanup.
+# By not setting $RECEIVED_USR1, we ensure this script exits
+# when $PID exits.
+trap 'kill -TERM $PID' INT TERM
+
+while true
+do
+  # Wait for the started process to exit
+  wait $PID
+  EXIT_CODE=$?
+
+  # If the process exited for any reason other than this script
+  # receiving SIGUSR1, exit the script with the same exit code.
+  if [ $RECEIVED_USR1 -eq 0 ]
+  then
+    echo "[*] Exited with status $EXIT_CODE"
+    exit $EXIT_CODE
+  fi
+
+  # Otherwise, if this script received SIGUSR1, reset the flag,
+  # restart the process, and record its new PID.
+  RECEIVED_USR1=0
+  "$@" &
+  PID=$!
+  echo "[*] Restarted $PID"
+done

--- a/packages/tre/package.json
+++ b/packages/tre/package.json
@@ -39,6 +39,7 @@
     "acorn": "^8.8.0",
     "acorn-walk": "^8.2.0",
     "capnp-ts": "^0.7.0",
+    "exit-hook": "^2.2.1",
     "get-port": "^5.1.1",
     "kleur": "^4.1.5",
     "stoppable": "^1.1.0",

--- a/packages/tre/src/runtime/index.ts
+++ b/packages/tre/src/runtime/index.ts
@@ -102,7 +102,7 @@ class NativeRuntime extends Runtime {
     runtimeProcess.stdin.end();
   }
 
-  dispose() {
+  dispose(): Awaitable<void> {
     this.#process?.kill();
     return this.#processExitPromise;
   }
@@ -190,7 +190,7 @@ class DockerRuntime extends Runtime {
     runtimeProcess.stderr.pipe(process.stderr);
   }
 
-  dispose() {
+  dispose(): Awaitable<void> {
     this.#process?.kill();
     try {
       fs.unlinkSync(this.#configPath);

--- a/packages/tre/src/runtime/index.ts
+++ b/packages/tre/src/runtime/index.ts
@@ -84,7 +84,7 @@ class NativeRuntime extends Runtime {
     // TODO: what happens if runtime crashes?
 
     // 2. Start new process
-    const runtimeProcess = await childProcess.spawn(this.#command, this.#args, {
+    const runtimeProcess = childProcess.spawn(this.#command, this.#args, {
       stdio: "pipe",
       shell: true,
     });
@@ -158,7 +158,7 @@ class DockerRuntime extends Runtime {
     }
 
     // 3. Otherwise, start new process
-    const runtimeProcess = await childProcess.spawn(
+    const runtimeProcess = childProcess.spawn(
       "docker",
       [
         "run",

--- a/packages/tre/src/runtime/index.ts
+++ b/packages/tre/src/runtime/index.ts
@@ -1,10 +1,20 @@
 import childProcess from "child_process";
-import { Awaitable, MiniflareError } from "../helpers";
+import crypto from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Awaitable, MiniflareCoreError } from "../helpers";
 import { SERVICE_LOOPBACK, SOCKET_ENTRY } from "../plugins";
 
-export interface Runtime {
-  updateConfig(configBuffer: Buffer): Awaitable<void>;
-  dispose(): Awaitable<void>;
+export abstract class Runtime {
+  constructor(
+    protected readonly runtimeBinaryPath: string,
+    protected readonly entryPort: number,
+    protected readonly loopbackPort: number
+  ) {}
+
+  abstract updateConfig(configBuffer: Buffer): Awaitable<void>;
+  abstract dispose(): Awaitable<void>;
 }
 
 export interface RuntimeConstructor {
@@ -21,14 +31,16 @@ export interface RuntimeConstructor {
 }
 
 const COMMON_RUNTIME_ARGS = ["serve", "--binary", "--verbose"];
+// `__dirname` relative to bundled output `dist/src/index.js`
+const RESTART_PATH = path.resolve(__dirname, "..", "..", "lib", "restart.sh");
 
-function waitForExit(process: childProcess.ChildProcess): Promise<number> {
+function waitForExit(process: childProcess.ChildProcess): Promise<void> {
   return new Promise((resolve) => {
-    process.once("exit", (code) => resolve(code ?? -1));
+    process.once("exit", () => resolve());
   });
 }
 
-class NativeRuntime implements Runtime {
+class NativeRuntime extends Runtime {
   static isSupported() {
     return process.platform === "linux"; // TODO: and "darwin"?
   }
@@ -40,13 +52,14 @@ class NativeRuntime implements Runtime {
   readonly #args: string[];
 
   #process?: childProcess.ChildProcess;
-  #processExitPromise?: Promise<number>;
+  #processExitPromise?: Promise<void>;
 
   constructor(
-    protected readonly runtimeBinaryPath: string,
-    protected readonly entryPort: number,
-    protected readonly loopbackPort: number
+    runtimeBinaryPath: string,
+    entryPort: number,
+    loopbackPort: number
   ) {
+    super(runtimeBinaryPath, entryPort, loopbackPort);
     const [command, ...args] = this.getCommand();
     this.#command = command;
     this.#args = args;
@@ -86,11 +99,12 @@ class NativeRuntime implements Runtime {
 
     // 3. Write config
     runtimeProcess.stdin.write(configBuffer);
+    runtimeProcess.stdin.end();
   }
 
-  async dispose() {
+  dispose() {
     this.#process?.kill();
-    await this.#processExitPromise;
+    return this.#processExitPromise;
   }
 }
 
@@ -112,7 +126,7 @@ class WSLRuntime extends NativeRuntime {
   }
 }
 
-class DockerRuntime extends NativeRuntime {
+class DockerRuntime extends Runtime {
   static isSupported() {
     const result = childProcess.spawnSync("docker", ["--version"]); // TODO: check daemon running too?
     return result.error === undefined;
@@ -123,23 +137,68 @@ class DockerRuntime extends NativeRuntime {
   static description = "using Docker 🐳";
   static distribution = `linux-${process.arch}`;
 
-  getCommand(): string[] {
-    // TODO: consider reusing container, but just restarting process within
-    return [
+  #configPath = path.join(
+    os.tmpdir(),
+    `miniflare-config-${crypto.randomBytes(16).toString("hex")}.bin`
+  );
+
+  #process?: childProcess.ChildProcess;
+  #processExitPromise?: Promise<void>;
+
+  async updateConfig(configBuffer: Buffer) {
+    // 1. Write config to file (this is much easier than trying to buffer STDIN
+    //    in the restart script)
+    fs.writeFileSync(this.#configPath, configBuffer);
+
+    // 2. If process running, send SIGUSR1 to restart runtime with new config
+    //    (see `lib/restart.sh`)
+    if (this.#process) {
+      this.#process.kill("SIGUSR1");
+      return;
+    }
+
+    // 3. Otherwise, start new process
+    const runtimeProcess = await childProcess.spawn(
       "docker",
-      "run",
-      "--platform=linux/amd64",
-      "--interactive",
-      "--rm",
-      `--volume=${this.runtimeBinaryPath}:/runtime`,
-      `--publish=127.0.0.1:${this.entryPort}:8787`,
-      "debian:bullseye-slim",
-      "/runtime",
-      ...COMMON_RUNTIME_ARGS,
-      `--socket-addr=${SOCKET_ENTRY}=*:8787`,
-      `--external-addr=${SERVICE_LOOPBACK}=host.docker.internal:${this.loopbackPort}`,
-      "-",
-    ];
+      [
+        "run",
+        "--platform=linux/amd64",
+        "--interactive",
+        "--rm",
+        `--volume=${RESTART_PATH}:/restart.sh`,
+        `--volume=${this.runtimeBinaryPath}:/runtime`,
+        `--volume=${this.#configPath}:/miniflare-config.bin`,
+        `--publish=127.0.0.1:${this.entryPort}:8787`,
+        "debian:bullseye-slim",
+        "/restart.sh",
+        "/runtime",
+        ...COMMON_RUNTIME_ARGS,
+        `--socket-addr=${SOCKET_ENTRY}=*:8787`,
+        `--external-addr=${SERVICE_LOOPBACK}=host.docker.internal:${this.loopbackPort}`,
+        "/miniflare-config.bin",
+      ],
+      {
+        stdio: "pipe",
+        shell: true,
+      }
+    );
+    this.#process = runtimeProcess;
+    this.#processExitPromise = waitForExit(runtimeProcess);
+
+    // TODO: may want to proxy these and prettify ✨
+    runtimeProcess.stdout.pipe(process.stdout);
+    runtimeProcess.stderr.pipe(process.stderr);
+  }
+
+  dispose() {
+    this.#process?.kill();
+    try {
+      fs.unlinkSync(this.#configPath);
+    } catch (e: any) {
+      // Ignore not found errors if we called dispose() without updateConfig()
+      if (e.code !== "ENOENT") throw e;
+    }
+    return this.#processExitPromise;
   }
 }
 
@@ -160,7 +219,7 @@ export function getSupportedRuntime(): RuntimeConstructor {
   const suggestions = RUNTIMES.map(
     ({ supportSuggestion }) => `- ${supportSuggestion}`
   );
-  throw new MiniflareError(
+  throw new MiniflareCoreError(
     "ERR_RUNTIME_UNSUPPORTED",
     `The 🦄 Cloudflare Workers Runtime 🦄 does not support your system (${
       process.platform


### PR DESCRIPTION
Instead of creating a new container whenever we change the config, we now start a single container with a custom entrypoint script. On receiving `SIGUSR1`, this script restarts the runtime process. This change reduces reload time from ~1.5s to ~400ms on my machine.