### PR TITLE
Support `siteInclude`/`siteExclude` options and populate `__STATIC_CONTENT_MANIFEST`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1684,6 +1684,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-S0mIukll6fbF0tvrKic/jj+jI8SHoSvGU+Cs95b/jzZEnBYCbj+7aJtQ9yeABuK3xP1okwA3jEH9qIRayijnvQ==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -4269,6 +4275,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/global-dirs": {
       "version": "3.0.0",
@@ -9424,6 +9435,7 @@
         "capnp-ts": "^0.7.0",
         "exit-hook": "^2.2.1",
         "get-port": "^5.1.1",
+        "glob-to-regexp": "^0.4.1",
         "kleur": "^4.1.5",
         "stoppable": "^1.1.0",
         "zod": "^3.18.0"
@@ -9431,6 +9443,7 @@
       "devDependencies": {
         "@types/debug": "^4.1.7",
         "@types/estree": "^1.0.0",
+        "@types/glob-to-regexp": "^0.4.1",
         "@types/stoppable": "^1.1.1"
       },
       "engines": {
@@ -10741,12 +10754,14 @@
         "@miniflare/shared": "3.0.0-next.1",
         "@types/debug": "^4.1.7",
         "@types/estree": "^1.0.0",
+        "@types/glob-to-regexp": "^0.4.1",
         "@types/stoppable": "^1.1.1",
         "acorn": "^8.8.0",
         "acorn-walk": "^8.2.0",
         "capnp-ts": "^0.7.0",
-        "exit-hook": "2",
+        "exit-hook": "^2.2.1",
         "get-port": "^5.1.1",
+        "glob-to-regexp": "^0.4.1",
         "kleur": "^4.1.5",
         "stoppable": "^1.1.0",
         "zod": "^3.18.0"
@@ -10969,6 +10984,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-S0mIukll6fbF0tvrKic/jj+jI8SHoSvGU+Cs95b/jzZEnBYCbj+7aJtQ9yeABuK3xP1okwA3jEH9qIRayijnvQ==",
+      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -12921,6 +12942,11 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "global-dirs": {
       "version": "3.0.0",

--- a/packages/tre/package.json
+++ b/packages/tre/package.json
@@ -41,13 +41,16 @@
     "capnp-ts": "^0.7.0",
     "exit-hook": "^2.2.1",
     "get-port": "^5.1.1",
+    "glob-to-regexp": "^0.4.1",
     "kleur": "^4.1.5",
     "stoppable": "^1.1.0",
+    "undici": "5.8.2",
     "zod": "^3.18.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/estree": "^1.0.0",
+    "@types/glob-to-regexp": "^0.4.1",
     "@types/stoppable": "^1.1.1"
   }
 }

--- a/packages/tre/src/helpers.ts
+++ b/packages/tre/src/helpers.ts
@@ -1,3 +1,4 @@
+import globToRegexp from "glob-to-regexp";
 import { z } from "zod";
 
 export type Awaitable<T> = T | Promise<T>;
@@ -46,7 +47,8 @@ export type MiniflareCoreErrorCode =
   | "ERR_MODULE_PARSE" // SyntaxError when attempting to parse/locate modules
   | "ERR_MODULE_STRING_SCRIPT" // Attempt to resolve module within string script
   | "ERR_MODULE_DYNAMIC_SPEC" // Attempted to import/require a module without a literal spec
-  | "ERR_MODULE_RULE"; // No matching module rule for file
+  | "ERR_MODULE_RULE" // No matching module rule for file
+  | "ERR_PERSIST_UNSUPPORTED"; // Unsupported storage persistence protocol
 export class MiniflareCoreError extends MiniflareError<MiniflareCoreErrorCode> {}
 
 export class HttpError extends MiniflareError<number> {
@@ -73,4 +75,62 @@ export class DeferredPromise<T> extends Promise<T> {
     this.resolve = promiseResolve!;
     this.reject = promiseReject!;
   }
+}
+
+// Split conversion to RegExps and testing to allow RegExps to be serialised
+// into Workers Sites KV namespace script. This will apply filtering, before
+// passing back to Miniflare's loopback server for storage access.
+export interface MatcherRegExps {
+  include: RegExp[];
+  exclude: RegExp[];
+}
+export interface SerialisableMatcherRegExps {
+  include: string[];
+  exclude: string[];
+}
+export function globsToRegExps(globs: string[] = []): MatcherRegExps {
+  const include: RegExp[] = [];
+  const exclude: RegExp[] = [];
+  // Setting `flags: "g"` removes "^" and "$" from the generated regexp,
+  // allowing matches anywhere in the path...
+  // (https://github.com/fitzgen/glob-to-regexp/blob/2abf65a834259c6504ed3b80e85f893f8cd99127/index.js#L123-L127)
+  const opts: globToRegexp.Options = { globstar: true, flags: "g" };
+  for (const glob of globs) {
+    // ...however, we don't actually want to include the "g" flag, since it will
+    // change `lastIndex` as paths are matched, and we want to reuse `RegExp`s.
+    // So, reconstruct each `RegExp` without any flags.
+    if (glob.startsWith("!")) {
+      exclude.push(new RegExp(globToRegexp(glob.slice(1), opts), ""));
+    } else {
+      include.push(new RegExp(globToRegexp(glob, opts), ""));
+    }
+  }
+  return { include, exclude };
+}
+// NOTE: this function will be `toString()`ed and must not have dependencies
+export function testRegExps(matcher: MatcherRegExps, value: string): boolean {
+  for (const exclude of matcher.exclude) if (exclude.test(value)) return false;
+  for (const include of matcher.include) if (include.test(value)) return true;
+  return false;
+}
+function serialiseRegExp(regExp: RegExp): string {
+  const str = regExp.toString();
+  return str.substring(str.indexOf("/") + 1, str.lastIndexOf("/"));
+}
+export function serialiseRegExps(
+  matcher: MatcherRegExps
+): SerialisableMatcherRegExps {
+  return {
+    include: matcher.include.map(serialiseRegExp),
+    exclude: matcher.exclude.map(serialiseRegExp),
+  };
+}
+// NOTE: this function will be `toString()`ed and must not have dependencies
+export function deserialiseRegExps(
+  matcher: SerialisableMatcherRegExps
+): MatcherRegExps {
+  return {
+    include: matcher.include.map((regExp) => new RegExp(regExp)),
+    exclude: matcher.exclude.map((regExp) => new RegExp(regExp)),
+  };
 }

--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -89,6 +89,13 @@ export const SCRIPT_CUSTOM_SERVICE = `addEventListener("fetch", (event) => {
   event.respondWith(${BINDING_SERVICE_LOOPBACK}.fetch(request));
 })`;
 
+const now = new Date();
+const fallbackCompatibilityDate = [
+  now.getFullYear(),
+  (now.getMonth() + 1).toString().padStart(2, "0"),
+  now.getDate().toString().padStart(2, "0"),
+].join("-");
+
 export const CORE_PLUGIN: Plugin<
   typeof CoreOptionsSchema,
   typeof CoreSharedOptionsSchema
@@ -156,6 +163,7 @@ export const CORE_PLUGIN: Plugin<
         name: SERVICE_ENTRY,
         worker: {
           serviceWorkerScript: SCRIPT_ENTRY,
+          compatibilityDate: "2022-09-01",
           bindings: serviceEntryBindings,
         },
       },
@@ -169,7 +177,8 @@ export const CORE_PLUGIN: Plugin<
         name,
         worker: {
           ...workerScript,
-          compatibilityDate: options.compatibilityDate,
+          compatibilityDate:
+            options.compatibilityDate ?? fallbackCompatibilityDate,
           compatibilityFlags: options.compatibilityFlags,
           bindings: workerBindings,
         },
@@ -188,6 +197,7 @@ export const CORE_PLUGIN: Plugin<
             name: `${SERVICE_CUSTOM_PREFIX}:${name}`,
             worker: {
               serviceWorkerScript: SCRIPT_CUSTOM_SERVICE,
+              compatibilityDate: "2022-09-01",
               bindings: [
                 {
                   name: BINDING_TEXT_CUSTOM_SERVICE,

--- a/packages/tre/src/plugins/kv/constants.ts
+++ b/packages/tre/src/plugins/kv/constants.ts
@@ -1,3 +1,5 @@
+export const KV_PLUGIN_NAME = "kv";
+
 export const MIN_CACHE_TTL = 60; /* 60s */
 export const MAX_LIST_KEYS = 1000;
 export const MAX_KEY_SIZE = 512; /* 512B */

--- a/packages/tre/src/plugins/kv/index.ts
+++ b/packages/tre/src/plugins/kv/index.ts
@@ -4,17 +4,16 @@ import { SERVICE_LOOPBACK } from "../core";
 import {
   BINDING_SERVICE_LOOPBACK,
   BINDING_TEXT_NAMESPACE,
-  BINDING_TEXT_PERSIST,
   BINDING_TEXT_PLUGIN,
-  HEADER_PERSIST,
   PersistenceSchema,
   Plugin,
   SCRIPT_PLUGIN_NAMESPACE_PERSIST,
   encodePersist,
 } from "../shared";
-import { HEADER_SITES } from "./constants";
+import { KV_PLUGIN_NAME } from "./constants";
 import { KVGateway } from "./gateway";
 import { KVRouter } from "./router";
+import { SitesOptions, getSitesBindings, getSitesService } from "./sites";
 
 export const KVOptionsSchema = z.object({
   kvNamespaces: z.record(z.string()).optional(),
@@ -28,34 +27,13 @@ export const KVSharedOptionsSchema = z.object({
   kvPersist: PersistenceSchema,
 });
 
-export const KV_PLUGIN_NAME = "kv";
 const SERVICE_NAMESPACE_PREFIX = `${KV_PLUGIN_NAME}:ns`;
-const SERVICE_NAMESPACE_SITE = `${KV_PLUGIN_NAME}:site`;
 
-// Workers Sites
-const BINDING_KV_NAMESPACE_SITE = "__STATIC_CONTENT";
-const BINDING_JSON_SITE_MANIFEST = "__STATIC_CONTENT_MANIFEST";
-// TODO: add header(s) for key filter, then filter keys in KVRouter
-const SCRIPT_SITE = `addEventListener("fetch", (event) => {
-  let request = event.request;
-  
-  if (request.method === "PUT" || request.method === "DELETE") {
-    const message = \`Cannot \${request.method.toLowerCase()}() with read-only Workers Sites namespace\`;
-    return event.respondWith(new Response(message, {
-      status: 400,
-      statusText: message,
-    }));
-  }
-
-  const url = new URL(event.request.url);
-  url.pathname = \`/${KV_PLUGIN_NAME}/${BINDING_KV_NAMESPACE_SITE}\${url.pathname}\`;
-  
-  request = new Request(url, event.request);
-  request.headers.set("${HEADER_PERSIST}", ${BINDING_TEXT_PERSIST});
-  request.headers.set("${HEADER_SITES}", "true");
-  
-  event.respondWith(${BINDING_SERVICE_LOOPBACK}.fetch(request));
-})`;
+function isWorkersSitesEnabled(
+  options: z.infer<typeof KVOptionsSchema>
+): options is SitesOptions {
+  return options.sitePath !== undefined;
+}
 
 export const KV_PLUGIN: Plugin<
   typeof KVOptionsSchema,
@@ -66,7 +44,7 @@ export const KV_PLUGIN: Plugin<
   router: KVRouter,
   options: KVOptionsSchema,
   sharedOptions: KVSharedOptionsSchema,
-  getBindings(options) {
+  async getBindings(options) {
     const bindings = Object.entries(
       options.kvNamespaces ?? []
     ).map<Worker_Binding>(([name, id]) => ({
@@ -74,27 +52,14 @@ export const KV_PLUGIN: Plugin<
       kvNamespace: { name: `${SERVICE_NAMESPACE_PREFIX}:${id}` },
     }));
 
-    if (options.sitePath !== undefined) {
-      bindings.push(
-        {
-          name: BINDING_KV_NAMESPACE_SITE,
-          kvNamespace: { name: SERVICE_NAMESPACE_SITE },
-        },
-        // TODO: actually populate manifest here, respecting key filters:
-        //  - https://github.com/cloudflare/miniflare/issues/233
-        //  - https://github.com/cloudflare/miniflare/issues/326
-        { name: BINDING_JSON_SITE_MANIFEST, json: "{}" }
-      );
+    if (isWorkersSitesEnabled(options)) {
+      bindings.push(...(await getSitesBindings(options)));
     }
 
     return bindings;
   },
   getServices({ options, sharedOptions }) {
     const persistBinding = encodePersist(sharedOptions.kvPersist);
-    const loopbackBinding: Worker_Binding = {
-      name: BINDING_SERVICE_LOOPBACK,
-      service: { name: SERVICE_LOOPBACK },
-    };
     const services = Object.entries(options.kvNamespaces ?? []).map<Service>(
       ([_, id]) => ({
         name: `${SERVICE_NAMESPACE_PREFIX}:${id}`,
@@ -104,33 +69,17 @@ export const KV_PLUGIN: Plugin<
             ...persistBinding,
             { name: BINDING_TEXT_PLUGIN, text: KV_PLUGIN_NAME },
             { name: BINDING_TEXT_NAMESPACE, text: id },
-            loopbackBinding,
+            {
+              name: BINDING_SERVICE_LOOPBACK,
+              service: { name: SERVICE_LOOPBACK },
+            },
           ],
         },
       })
     );
 
-    if (options.sitePath !== undefined) {
-      if (
-        options.siteInclude !== undefined ||
-        options.siteExclude !== undefined
-      ) {
-        throw new Error("Workers Sites include/exclude not yet implemented!");
-      }
-
-      services.push({
-        name: SERVICE_NAMESPACE_SITE,
-        worker: {
-          serviceWorkerScript: SCRIPT_SITE,
-          bindings: [
-            {
-              name: BINDING_TEXT_PERSIST,
-              text: JSON.stringify(options.sitePath),
-            },
-            loopbackBinding,
-          ],
-        },
-      });
+    if (isWorkersSitesEnabled(options)) {
+      services.push(getSitesService(options));
     }
 
     return services;
@@ -138,3 +87,4 @@ export const KV_PLUGIN: Plugin<
 };
 
 export * from "./gateway";
+export { KV_PLUGIN_NAME };

--- a/packages/tre/src/plugins/kv/sites.ts
+++ b/packages/tre/src/plugins/kv/sites.ts
@@ -1,0 +1,211 @@
+import assert from "assert";
+import { pathToFileURL } from "url";
+import { FileStorage } from "@miniflare/storage-file";
+import {
+  MatcherRegExps,
+  deserialiseRegExps,
+  globsToRegExps,
+  serialiseRegExps,
+  testRegExps,
+} from "../../helpers";
+import { Service, Worker_Binding } from "../../runtime";
+import { SERVICE_LOOPBACK } from "../core";
+import {
+  BINDING_SERVICE_LOOPBACK,
+  BINDING_TEXT_PERSIST,
+  HEADER_PERSIST,
+  PARAM_FILE_UNSANITISE,
+} from "../shared";
+import { HEADER_SITES, KV_PLUGIN_NAME, PARAM_URL_ENCODED } from "./constants";
+
+export interface SitesOptions {
+  sitePath: string;
+  siteInclude?: string[];
+  siteExclude?: string[];
+}
+export interface SiteMatcherRegExps {
+  include?: MatcherRegExps;
+  exclude?: MatcherRegExps;
+}
+// Cache glob RegExps between `getBindings` and `getServices` calls
+const sitesRegExpsCache = new WeakMap<SitesOptions, SiteMatcherRegExps>();
+
+function testSiteRegExps(regExps: SiteMatcherRegExps, key: string): boolean {
+  return (
+    // Either include globs undefined, or name matches them
+    (regExps.include === undefined || testRegExps(regExps.include, key)) &&
+    // Either exclude globs undefined, or name doesn't match them
+    (regExps.exclude === undefined || !testRegExps(regExps.exclude, key))
+  );
+}
+
+// Magic prefix: if a URLs pathname starts with this, it shouldn't be cached.
+// This ensures edge caching of Workers Sites files is disabled, and the latest
+// local version is always served.
+export const SITES_NO_CACHE_PREFIX = "$__MINIFLARE_SITES__$/";
+function encodeSitesKey(key: string): string {
+  // `encodeURIComponent()` ensures `ETag`s used by `@cloudflare/kv-asset-handler`
+  // are always byte strings.
+  // TODO: this was required by `undici`, but depending on our new cache
+  //  implementation, we may not need it anymore. Once we've implemented cache,
+  //  try remove this extra URI encoding step.
+  return SITES_NO_CACHE_PREFIX + encodeURIComponent(key);
+}
+function decodeSitesKey(key: string): string {
+  return key.startsWith(SITES_NO_CACHE_PREFIX)
+    ? decodeURIComponent(key.substring(SITES_NO_CACHE_PREFIX.length))
+    : key;
+}
+
+const SERVICE_NAMESPACE_SITE = `${KV_PLUGIN_NAME}:site`;
+
+const BINDING_KV_NAMESPACE_SITE = "__STATIC_CONTENT";
+const BINDING_JSON_SITE_MANIFEST = "__STATIC_CONTENT_MANIFEST";
+const BINDING_JSON_SITE_FILTER = "MINIFLARE_SITE_FILTER";
+
+const SCRIPT_SITE = `
+// Inject key encoding/decoding functions
+const SITES_NO_CACHE_PREFIX = "${SITES_NO_CACHE_PREFIX}";
+const encodeSitesKey = ${encodeSitesKey.toString()};
+const decodeSitesKey = ${decodeSitesKey.toString()};
+
+// Inject glob matching RegExp functions
+const deserialiseRegExps = ${deserialiseRegExps.toString()};
+const testRegExps = ${testRegExps.toString()};
+const testSiteRegExps = ${testSiteRegExps.toString()};
+
+// Deserialise glob matching RegExps
+const serialisedSiteRegExps = ${BINDING_JSON_SITE_FILTER};
+const siteRegExps = {
+  include: serialisedSiteRegExps.include && deserialiseRegExps(serialisedSiteRegExps.include),
+  exclude: serialisedSiteRegExps.exclude && deserialiseRegExps(serialisedSiteRegExps.exclude),
+};
+
+async function handleRequest(request) {
+  // Only permit reads
+  if (request.method !== "GET") {
+    const message = \`Cannot \${request.method.toLowerCase()}() with read-only Workers Sites namespace\`;
+    return new Response(message, { status: 400, statusText: message });
+  }
+
+  // Decode key (empty if listing)
+  const url = new URL(request.url);
+  let key = url.pathname.substring(1); // Strip leading "/"
+  if (url.searchParams.get("${PARAM_URL_ENCODED}")?.toLowerCase() === "true") {
+    key = decodeURIComponent(key);
+  }
+  
+  // Strip SITES_NO_CACHE_PREFIX
+  key = decodeSitesKey(key);
+  
+  // If not listing keys, check key is included, returning not found if not
+  if (key !== "" && !testSiteRegExps(siteRegExps, key)) {
+    return new Response("Not Found", { status: 404, statusText: "Not Found" })
+  }
+  
+  // Re-encode key
+  key = encodeURIComponent(key);
+  url.pathname = \`/${KV_PLUGIN_NAME}/${BINDING_KV_NAMESPACE_SITE}/\${key}\`;
+  url.searchParams.set("${PARAM_URL_ENCODED}", "true"); // Always URL encoded now
+  
+  // Send request to loopback server
+  request = new Request(url, request);
+  request.headers.set("${HEADER_PERSIST}", ${BINDING_TEXT_PERSIST});
+  // Add magic header to indicate namespace should be ignored, and persist
+  // should be used as the root without any additional namespace
+  request.headers.set("${HEADER_SITES}", "true");
+  const response = await ${BINDING_SERVICE_LOOPBACK}.fetch(request);
+  
+  // If listing keys, only return included keys, and add SITES_NO_CACHE_PREFIX
+  // to all result keys
+  if (key === "" && response.ok) {
+    const { keys, list_complete, cursor } = await response.json();
+    return Response.json({
+      keys: keys.filter((key) => {
+        if (!testSiteRegExps(siteRegExps, key)) return false;
+        key.name = encodeSitesKey(key.name);
+        return true;
+      }),
+      list_complete,
+      cursor,
+    });
+  }
+  
+  return response;
+}
+
+addEventListener("fetch", (event) => event.respondWith(handleRequest(event.request)));
+`;
+
+export async function getSitesBindings(
+  options: SitesOptions
+): Promise<Worker_Binding[]> {
+  // Convert include/exclude globs to RegExps
+  const siteRegExps: SiteMatcherRegExps = {
+    include: options.siteInclude && globsToRegExps(options.siteInclude),
+    exclude: options.siteExclude && globsToRegExps(options.siteExclude),
+  };
+  sitesRegExpsCache.set(options, siteRegExps);
+
+  // Build __STATIC_CONTENT_MANIFEST contents
+  const staticContentManifest: Record<string, string> = {};
+  const storage = new FileStorage(options.sitePath, /* sanitise */ false);
+  const result = await storage.list();
+  assert.strictEqual(result.cursor, "");
+  for (const { name } of result.keys) {
+    if (testSiteRegExps(siteRegExps, name)) {
+      staticContentManifest[name] = encodeSitesKey(name);
+    }
+  }
+  const __STATIC_CONTENT_MANIFEST = JSON.stringify(staticContentManifest);
+
+  return [
+    {
+      name: BINDING_KV_NAMESPACE_SITE,
+      kvNamespace: { name: SERVICE_NAMESPACE_SITE },
+    },
+    {
+      name: BINDING_JSON_SITE_MANIFEST,
+      json: __STATIC_CONTENT_MANIFEST,
+    },
+  ];
+}
+
+export function getSitesService(options: SitesOptions): Service {
+  // `siteRegExps` should've been set in `getSitesBindings()`, and `options`
+  // should be the same object reference as before.
+  const siteRegExps = sitesRegExpsCache.get(options);
+  assert(siteRegExps !== undefined);
+  // Ensure `siteRegExps` is JSON-serialisable
+  const serialisedSiteRegExps = {
+    include: siteRegExps.include && serialiseRegExps(siteRegExps.include),
+    exclude: siteRegExps.exclude && serialiseRegExps(siteRegExps.exclude),
+  };
+
+  // Use unsanitised file storage to ensure file names containing e.g. dots
+  // resolve correctly.
+  const persist = pathToFileURL(options.sitePath);
+  persist.searchParams.set(PARAM_FILE_UNSANITISE, "true");
+
+  return {
+    name: SERVICE_NAMESPACE_SITE,
+    worker: {
+      serviceWorkerScript: SCRIPT_SITE,
+      compatibilityDate: "2022-09-01",
+      bindings: [
+        {
+          name: BINDING_TEXT_PERSIST,
+          text: JSON.stringify(persist),
+        },
+        {
+          name: BINDING_SERVICE_LOOPBACK,
+          service: { name: SERVICE_LOOPBACK },
+        },
+        {
+          name: BINDING_JSON_SITE_FILTER,
+          json: JSON.stringify(serialisedSiteRegExps),
+        },
+      ],
+    },
+  };
+}

--- a/packages/tre/test/helpers.spec.ts
+++ b/packages/tre/test/helpers.spec.ts
@@ -1,0 +1,29 @@
+import path from "path";
+import { globsToRegExps, testRegExps } from "@miniflare/tre";
+import test from "ava";
+
+test("globsToRegExps/testRegExps: matches glob patterns", (t) => {
+  const globs = ["**/*.txt", "src/**/*.js", "!src/bad.js", "thing/*/*.jpg"];
+  const matcherRegExps = globsToRegExps(globs);
+
+  // Check `*.txt`
+  t.true(testRegExps(matcherRegExps, "test.txt"));
+  t.true(testRegExps(matcherRegExps, "dist/test.txt"));
+
+  // Check `src/**/*.js`
+  t.true(testRegExps(matcherRegExps, "src/index.js"));
+  t.true(testRegExps(matcherRegExps, "src/lib/add.js"));
+  t.false(testRegExps(matcherRegExps, "src/image.jpg"));
+
+  // Check `!src/bad.js`
+  t.false(testRegExps(matcherRegExps, "src/bad.js"));
+
+  // Check `thing/*/*.txt`
+  t.true(testRegExps(matcherRegExps, "thing/thing2/thing3.jpg"));
+  t.false(testRegExps(matcherRegExps, "thing/thing2.jpg"));
+
+  // Check absolute paths (`ModuleLinker` will `path.resolve` to absolute paths)
+  // (see https://github.com/cloudflare/miniflare/issues/244)
+  t.true(testRegExps(matcherRegExps, "/one/two/three.txt"));
+  t.true(testRegExps(matcherRegExps, path.join(process.cwd(), "src/index.js")));
+});


### PR DESCRIPTION
This PR adds support for the `siteInclude`/`siteExclude` options by adding additional logic to the `__STATIC_CONTENT` KV namespace service. It also populates `__STATIC_CONTENT_MANIFEST` using the same process recently added to Miniflare 2. We don't want to cache Workers Sites files, as when developing, the latest local file should always be returned.