### PR TITLE
Use native runtime on macOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10745,7 +10745,7 @@
         "acorn": "^8.8.0",
         "acorn-walk": "^8.2.0",
         "capnp-ts": "^0.7.0",
-        "exit-hook": "2",
+        "exit-hook": "^2.2.1",
         "get-port": "^5.1.1",
         "kleur": "^4.1.5",
         "stoppable": "^1.1.0",

--- a/packages/tre/README.md
+++ b/packages/tre/README.md
@@ -7,6 +7,6 @@ runtime... 👀
 
 # Additional Development Setup
 
-1. Copy the open-source runtime binary to `./lib/cfwrkr`
+1. Copy the open-source runtime binary to `./lib/workerd`
 2. Copy the config files `sserve-conf.{capnp,capnp.d.ts,capnp.js,ts}` to
    `./src/runtime/config/`

--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -101,7 +101,7 @@ type PluginRouters = {
 };
 
 // `__dirname` relative to bundled output `dist/src/index.js`
-const RUNTIME_PATH = path.resolve(__dirname, "..", "..", "lib", "cfwrkr");
+const RUNTIME_PATH = path.resolve(__dirname, "..", "..", "lib", "workerd");
 
 type StoppableServer = http.Server & stoppable.WithStop;
 

--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -157,6 +157,7 @@ export const CORE_PLUGIN: Plugin<
         worker: {
           serviceWorkerScript: SCRIPT_ENTRY,
           bindings: serviceEntryBindings,
+          compatibilityDate: "2022-09-01",
         },
       },
     ];

--- a/packages/tre/src/plugins/kv/index.ts
+++ b/packages/tre/src/plugins/kv/index.ts
@@ -106,6 +106,7 @@ export const KV_PLUGIN: Plugin<
             { name: BINDING_TEXT_NAMESPACE, text: id },
             loopbackBinding,
           ],
+          compatibilityDate: "2022-09-01",
         },
       })
     );

--- a/packages/tre/src/plugins/r2/index.ts
+++ b/packages/tre/src/plugins/r2/index.ts
@@ -57,6 +57,7 @@ export const R2_PLUGIN: Plugin<
             { name: BINDING_TEXT_NAMESPACE, text: id },
             loopbackBinding,
           ],
+          compatibilityDate: "2022-09-01",
         },
       })
     );

--- a/packages/tre/src/runtime/index.ts
+++ b/packages/tre/src/runtime/index.ts
@@ -42,7 +42,7 @@ function waitForExit(process: childProcess.ChildProcess): Promise<void> {
 
 class NativeRuntime extends Runtime {
   static isSupported() {
-    return process.platform === "linux"; // TODO: and "darwin"?
+    return process.platform === "linux" || process.platform === "darwin";
   }
   static supportSuggestion = "Run using a Linux or macOS based system";
   static description = "natively ⚡️";


### PR DESCRIPTION
The open-source runtime now supports macOS natively, so we don't need to use Docker anymore. 🎉 
We may be able to completely remove `DockerRuntime` tbh, as WSL is probably better for Windows anyways. 👍 

(@penalosa see the `Workers OSS Runtime` internal space for the new binary)