### PR TITLE
In-Memory Durable Objects

### DIFF
--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -96,10 +96,12 @@ function getDurableObjectClassNames(
   const serviceClassNames = new Map<string, string[]>();
   for (const workerOpts of allWorkerOpts) {
     const workerServiceName = getUserServiceName(workerOpts.core.name);
-    for (const klass of Object.values(workerOpts.do.durableObjects ?? {})) {
+    for (const designator of Object.values(
+      workerOpts.do.durableObjects ?? {}
+    )) {
       // Fallback to current worker service if name not defined
       const [className, serviceName = workerServiceName] =
-        normaliseDurableObject(klass);
+        normaliseDurableObject(designator);
       let classNames = serviceClassNames.get(serviceName);
       if (classNames === undefined) {
         serviceClassNames.set(serviceName, (classNames = []));

--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 import { Request, Response } from "undici";
 import { z } from "zod";
 import { Awaitable, JsonSchema } from "../../helpers";
-import { Service, Worker_Binding, Worker_Module } from "../../runtime";
+import { Service, Worker_Binding, Worker_Module, kVoid } from "../../runtime";
 import { BINDING_SERVICE_LOOPBACK, Plugin } from "../shared";
 import {
   ModuleDefinitionSchema,
@@ -59,6 +59,10 @@ const SERVICE_USER_PREFIX = `${CORE_PLUGIN_NAME}:user`;
 // Service prefix for custom fetch functions defined in `serviceBindings` option
 const SERVICE_CUSTOM_PREFIX = `${CORE_PLUGIN_NAME}:custom`;
 
+export function getUserServiceName(name = "") {
+  return `${SERVICE_USER_PREFIX}:${name}`;
+}
+
 export const HEADER_PROBE = "MF-Probe";
 export const HEADER_CUSTOM_SERVICE = "MF-Custom-Service";
 
@@ -89,12 +93,7 @@ export const SCRIPT_CUSTOM_SERVICE = `addEventListener("fetch", (event) => {
   event.respondWith(${BINDING_SERVICE_LOOPBACK}.fetch(request));
 })`;
 
-const now = new Date();
-const fallbackCompatibilityDate = [
-  now.getFullYear(),
-  (now.getMonth() + 1).toString().padStart(2, "0"),
-  now.getDate().toString().padStart(2, "0"),
-].join("-");
+const FALLBACK_COMPATIBILITY_DATE = "2000-01-01";
 
 export const CORE_PLUGIN: Plugin<
   typeof CoreOptionsSchema,
@@ -150,7 +149,13 @@ export const CORE_PLUGIN: Plugin<
 
     return Promise.all(bindings);
   },
-  async getServices({ options, optionsVersion, workerBindings, workerIndex }) {
+  async getServices({
+    options,
+    optionsVersion,
+    workerBindings,
+    workerIndex,
+    durableObjectClassNames,
+  }) {
     // Define core/shared services.
     // Services get de-duped by name, so only the first worker's
     // SERVICE_LOOPBACK and SERVICE_ENTRY will be used
@@ -165,7 +170,6 @@ export const CORE_PLUGIN: Plugin<
           serviceWorkerScript: SCRIPT_ENTRY,
           compatibilityDate: "2022-09-01",
           bindings: serviceEntryBindings,
-          compatibilityDate: "2022-09-01",
         },
       },
     ];
@@ -173,15 +177,22 @@ export const CORE_PLUGIN: Plugin<
     // Define regular user worker if script is set
     const workerScript = getWorkerScript(options);
     if (workerScript !== undefined) {
-      const name = `${SERVICE_USER_PREFIX}:${options.name ?? ""}`;
+      const name = getUserServiceName(options.name);
+      const classNames = durableObjectClassNames.get(name) ?? [];
+
       services.push({
         name,
         worker: {
           ...workerScript,
           compatibilityDate:
-            options.compatibilityDate ?? fallbackCompatibilityDate,
+            options.compatibilityDate ?? FALLBACK_COMPATIBILITY_DATE,
           compatibilityFlags: options.compatibilityFlags,
           bindings: workerBindings,
+          durableObjectNamespaces: classNames.map((className) => ({
+            className,
+            uniqueKey: className,
+          })),
+          durableObjectStorage: { inMemory: kVoid },
         },
       });
       serviceEntryBindings.push({

--- a/packages/tre/src/plugins/do/index.ts
+++ b/packages/tre/src/plugins/do/index.ts
@@ -1,7 +1,13 @@
 import { z } from "zod";
+import { MiniflareError } from "../../helpers";
+import { Worker_Binding } from "../../runtime";
+import { getUserServiceName } from "../core";
 import { PersistenceSchema, Plugin } from "../shared";
 import { DurableObjectsStorageGateway } from "./gateway";
 import { DurableObjectsStorageRouter } from "./router";
+
+export type DurableObjectsErrorCode = "ERR_PERSIST_UNSUPPORTED"; // Durable Object persistence is not yet supported
+export class DurableObjectsError extends MiniflareError<DurableObjectsErrorCode> {}
 
 export const DurableObjectsOptionsSchema = z.object({
   durableObjects: z
@@ -20,6 +26,20 @@ export const DurableObjectsSharedOptionsSchema = z.object({
   durableObjectsPersist: PersistenceSchema,
 });
 
+export function normaliseDurableObject(
+  klass: NonNullable<
+    z.infer<typeof DurableObjectsOptionsSchema>["durableObjects"]
+  >[string]
+): [className: string, serviceName: string | undefined] {
+  const isObject = typeof klass === "object";
+  const className = isObject ? klass.className : klass;
+  const serviceName =
+    isObject && klass.scriptName !== undefined
+      ? getUserServiceName(klass.scriptName)
+      : undefined;
+  return [className, serviceName];
+}
+
 export const DURABLE_OBJECTS_PLUGIN_NAME = "do";
 export const DURABLE_OBJECTS_PLUGIN: Plugin<
   typeof DurableObjectsOptionsSchema,
@@ -31,10 +51,29 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin<
   options: DurableObjectsOptionsSchema,
   sharedOptions: DurableObjectsSharedOptionsSchema,
   getBindings(options) {
-    return undefined;
+    return Object.entries(options.durableObjects ?? {}).map<Worker_Binding>(
+      ([name, klass]) => {
+        const [className, serviceName] = normaliseDurableObject(klass);
+        return {
+          name,
+          durableObjectNamespace: { className, serviceName },
+        };
+      }
+    );
   },
-  getServices(options) {
-    return undefined;
+  getServices({ options, sharedOptions }) {
+    if (
+      // If we have Durable Object bindings...
+      Object.keys(options.durableObjects ?? {}).length > 0 &&
+      // ...and persistence is enabled...
+      sharedOptions.durableObjectsPersist
+    ) {
+      // ...throw, as Durable-Durable Objects are not yet supported
+      throw new DurableObjectsError(
+        "ERR_PERSIST_UNSUPPORTED",
+        "Persisted Durable Objects are not yet supported"
+      );
+    }
   },
 };
 

--- a/packages/tre/src/plugins/do/index.ts
+++ b/packages/tre/src/plugins/do/index.ts
@@ -27,15 +27,15 @@ export const DurableObjectsSharedOptionsSchema = z.object({
 });
 
 export function normaliseDurableObject(
-  klass: NonNullable<
+  designator: NonNullable<
     z.infer<typeof DurableObjectsOptionsSchema>["durableObjects"]
   >[string]
 ): [className: string, serviceName: string | undefined] {
-  const isObject = typeof klass === "object";
-  const className = isObject ? klass.className : klass;
+  const isObject = typeof designator === "object";
+  const className = isObject ? designator.className : designator;
   const serviceName =
-    isObject && klass.scriptName !== undefined
-      ? getUserServiceName(klass.scriptName)
+    isObject && designator.scriptName !== undefined
+      ? getUserServiceName(designator.scriptName)
       : undefined;
   return [className, serviceName];
 }

--- a/packages/tre/src/plugins/kv/index.ts
+++ b/packages/tre/src/plugins/kv/index.ts
@@ -46,7 +46,7 @@ export const KV_PLUGIN: Plugin<
   sharedOptions: KVSharedOptionsSchema,
   async getBindings(options) {
     const bindings = Object.entries(
-      options.kvNamespaces ?? []
+      options.kvNamespaces ?? {}
     ).map<Worker_Binding>(([name, id]) => ({
       name,
       kvNamespace: { name: `${SERVICE_NAMESPACE_PREFIX}:${id}` },
@@ -75,7 +75,6 @@ export const KV_PLUGIN: Plugin<
               service: { name: SERVICE_LOOPBACK },
             },
           ],
-          compatibilityDate: "2022-09-01",
         },
       })
     );

--- a/packages/tre/src/plugins/shared/index.ts
+++ b/packages/tre/src/plugins/shared/index.ts
@@ -4,6 +4,8 @@ import { Service, Worker_Binding } from "../../runtime";
 import { GatewayConstructor } from "./gateway";
 import { RouterConstructor } from "./router";
 
+export type DurableObjectClassNames = Map<string, string[]>;
+
 export interface PluginServicesOptions<
   Options extends z.ZodType,
   SharedOptions extends z.ZodType | undefined
@@ -13,6 +15,7 @@ export interface PluginServicesOptions<
   sharedOptions: OptionalZodTypeOf<SharedOptions>;
   workerBindings: Worker_Binding[];
   workerIndex: number;
+  durableObjectClassNames: DurableObjectClassNames;
 }
 
 export interface PluginBase<
@@ -20,12 +23,10 @@ export interface PluginBase<
   SharedOptions extends z.ZodType | undefined
 > {
   options: Options;
-  getBindings(
-    options: z.infer<Options>
-  ): Awaitable<Worker_Binding[] | undefined>;
+  getBindings(options: z.infer<Options>): Awaitable<Worker_Binding[] | void>;
   getServices(
     options: PluginServicesOptions<Options, SharedOptions>
-  ): Awaitable<Service[] | undefined>;
+  ): Awaitable<Service[] | void>;
 }
 
 export type Plugin<

--- a/packages/tre/src/runtime/config/.gitignore
+++ b/packages/tre/src/runtime/config/.gitignore
@@ -1,2 +1,3 @@
 # TODO: remove prior to release
 sserve-conf*
+workerd*


### PR DESCRIPTION
This PR adds support for non-durable Durable Objects. The open-source runtime does not yet support persisted objects. Data is lost when calling `setOptions()` or restarting. Closes #366.