### PR TITLE
Fallback to `workerd` compatibility date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5761,9 +5761,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20220926.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20220926.0.tgz",
-      "integrity": "sha512-pJmF9adeO0/Utbs3Fq/u9H6can6SxtWtSEKGpxPekBlUECwNhUoVYxjFFx1aS6BpIa1bgugvc1JMJA+td6QTcQ==",
+      "version": "1.20220926.3",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20220926.3.tgz",
+      "integrity": "sha512-/lmXRhgLixIkNNwsrFquPlT+qgFD71QbYJ8qroYQVL2hQVOuqw5N4TzMZS6gaNtVW+EUUnps+t/zbz98vjeuTg==",
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -5771,10 +5771,10 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20220926.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20220926.0",
-        "@cloudflare/workerd-linux-64": "1.20220926.0",
-        "@cloudflare/workerd-linux-arm64": "1.20220926.0"
+        "@cloudflare/workerd-darwin-64": "^1.20220926.0",
+        "@cloudflare/workerd-darwin-arm64": "^1.20220926.0",
+        "@cloudflare/workerd-linux-64": "^1.20220926.0",
+        "@cloudflare/workerd-linux-arm64": "^1.20220926.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -6352,7 +6352,7 @@
         "kleur": "^4.1.5",
         "stoppable": "^1.1.0",
         "undici": "^5.10.0",
-        "workerd": "^1.20220926.0",
+        "workerd": "^1.20220926.3",
         "zod": "^3.18.0"
       },
       "devDependencies": {
@@ -6666,7 +6666,7 @@
         "kleur": "^4.1.5",
         "stoppable": "^1.1.0",
         "undici": "^5.10.0",
-        "workerd": "^1.20220926.0",
+        "workerd": "^1.20220926.3",
         "zod": "^3.18.0"
       },
       "dependencies": {
@@ -10693,14 +10693,14 @@
       "dev": true
     },
     "workerd": {
-      "version": "1.20220926.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20220926.0.tgz",
-      "integrity": "sha512-pJmF9adeO0/Utbs3Fq/u9H6can6SxtWtSEKGpxPekBlUECwNhUoVYxjFFx1aS6BpIa1bgugvc1JMJA+td6QTcQ==",
+      "version": "1.20220926.3",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20220926.3.tgz",
+      "integrity": "sha512-/lmXRhgLixIkNNwsrFquPlT+qgFD71QbYJ8qroYQVL2hQVOuqw5N4TzMZS6gaNtVW+EUUnps+t/zbz98vjeuTg==",
       "requires": {
-        "@cloudflare/workerd-darwin-64": "1.20220926.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20220926.0",
-        "@cloudflare/workerd-linux-64": "1.20220926.0",
-        "@cloudflare/workerd-linux-arm64": "1.20220926.0"
+        "@cloudflare/workerd-darwin-64": "^1.20220926.0",
+        "@cloudflare/workerd-darwin-arm64": "^1.20220926.0",
+        "@cloudflare/workerd-linux-64": "^1.20220926.0",
+        "@cloudflare/workerd-linux-arm64": "^1.20220926.0"
       }
     },
     "wrap-ansi": {

--- a/packages/tre/package.json
+++ b/packages/tre/package.json
@@ -44,7 +44,7 @@
     "kleur": "^4.1.5",
     "stoppable": "^1.1.0",
     "undici": "^5.10.0",
-    "workerd": "^1.20220926.0",
+    "workerd": "^1.20220926.3",
     "zod": "^3.18.0"
   },
   "devDependencies": {

--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -6,7 +6,6 @@ import { bold, green, grey } from "kleur/colors";
 import stoppable from "stoppable";
 import { RequestInfo, RequestInit, fetch } from "undici";
 import { HeadersInit, Request, Response } from "undici";
-import workerd from "workerd";
 import { z } from "zod";
 import { setupCf } from "./cf";
 
@@ -217,11 +216,7 @@ export class Miniflare {
     const entryPort = await getPort({ port: this.#sharedOpts.core.port });
 
     // TODO: respect entry `host` option
-    this.#runtime = new this.#runtimeConstructor(
-      workerd,
-      entryPort,
-      loopbackPort
-    );
+    this.#runtime = new this.#runtimeConstructor(entryPort, loopbackPort);
     this.#removeRuntimeExitHook = exitHook(() => void this.#runtime?.dispose());
 
     this.#runtimeEntryURL = new URL(`http://127.0.0.1:${entryPort}`);

--- a/packages/tre/src/runtime/index.ts
+++ b/packages/tre/src/runtime/index.ts
@@ -3,12 +3,12 @@ import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import workerdPath from "workerd";
 import { SERVICE_LOOPBACK, SOCKET_ENTRY } from "../plugins";
 import { Awaitable, MiniflareCoreError } from "../shared";
 
 export abstract class Runtime {
   constructor(
-    protected readonly runtimeBinaryPath: string,
     protected readonly entryPort: number,
     protected readonly loopbackPort: number
   ) {}
@@ -19,11 +19,7 @@ export abstract class Runtime {
 }
 
 export interface RuntimeConstructor {
-  new (
-    runtimeBinaryPath: string,
-    entryPort: number,
-    loopbackPort: number
-  ): Runtime;
+  new (entryPort: number, loopbackPort: number): Runtime;
 
   isSupported(): boolean;
   supportSuggestion: string;
@@ -77,12 +73,8 @@ class NativeRuntime extends Runtime {
   #process?: childProcess.ChildProcess;
   #processExitPromise?: Promise<void>;
 
-  constructor(
-    runtimeBinaryPath: string,
-    entryPort: number,
-    loopbackPort: number
-  ) {
-    super(runtimeBinaryPath, entryPort, loopbackPort);
+  constructor(entryPort: number, loopbackPort: number) {
+    super(entryPort, loopbackPort);
     const [command, ...args] = this.getCommand();
     this.#command = command;
     this.#args = args;
@@ -90,7 +82,7 @@ class NativeRuntime extends Runtime {
 
   getCommand(): string[] {
     return [
-      this.runtimeBinaryPath,
+      workerdPath,
       ...COMMON_RUNTIME_ARGS,
       `--socket-addr=${SOCKET_ENTRY}=127.0.0.1:${this.entryPort}`,
       `--external-addr=${SERVICE_LOOPBACK}=127.0.0.1:${this.loopbackPort}`,
@@ -188,7 +180,7 @@ class DockerRuntime extends Runtime {
         "--interactive",
         "--rm",
         `--volume=${RESTART_PATH}:/restart.sh`,
-        `--volume=${this.runtimeBinaryPath}:/runtime`,
+        `--volume=${workerdPath}:/runtime`,
         `--volume=${this.#configPath}:/miniflare-config.bin`,
         `--publish=127.0.0.1:${this.entryPort}:8787`,
         "debian:bullseye-slim",

--- a/packages/tre/src/runtime/index.ts
+++ b/packages/tre/src/runtime/index.ts
@@ -3,7 +3,9 @@ import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import workerdPath from "workerd";
+import workerdPath, {
+  compatibilityDate as supportedCompatibilityDate,
+} from "workerd";
 import { SERVICE_LOOPBACK, SOCKET_ENTRY } from "../plugins";
 import { Awaitable, MiniflareCoreError } from "../shared";
 
@@ -243,3 +245,4 @@ export function getSupportedRuntime(): RuntimeConstructor {
 }
 
 export * from "./config";
+export { supportedCompatibilityDate };

--- a/packages/tre/src/shared/error.ts
+++ b/packages/tre/src/shared/error.ts
@@ -18,7 +18,8 @@ export type MiniflareCoreErrorCode =
   | "ERR_MODULE_STRING_SCRIPT" // Attempt to resolve module within string script
   | "ERR_MODULE_DYNAMIC_SPEC" // Attempted to import/require a module without a literal spec
   | "ERR_MODULE_RULE" // No matching module rule for file
-  | "ERR_PERSIST_UNSUPPORTED"; // Unsupported storage persistence protocol
+  | "ERR_PERSIST_UNSUPPORTED" // Unsupported storage persistence protocol
+  | "ERR_FUTURE_COMPATIBILITY_DATE"; // Compatibility date in the future
 export class MiniflareCoreError extends MiniflareError<MiniflareCoreErrorCode> {}
 
 export class HttpError extends MiniflareError<number> {

--- a/types/workerd.d.ts
+++ b/types/workerd.d.ts
@@ -1,4 +1,5 @@
 declare module "workerd" {
   const path: string;
   export default path;
+  export const compatibilityDate: string;
 }


### PR DESCRIPTION
Previously, if the user set a compatibility date greater than the latest supported compatibility date of `workerd` but not in the future, `workerd` would error. Now, we log a warning, and fallback to the latest supported date instead.

Notably, `wrangler` sets the current date as the default compatibility date, so this was causing issues with the default setup.