### PR TITLE
Return runtime entry URL from `Miniflare#ready`

### DIFF
--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -438,8 +438,11 @@ export class Miniflare {
     return { services, sockets };
   }
 
-  get ready() {
-    return this.#initPromise;
+  get ready(): Promise<URL> {
+    // Cannot use async/await with getters.
+    // Safety: `#runtimeEntryURL` is assigned in `#init()`. `#initPromise`
+    // doesn't resolve until `#init()` returns.
+    return this.#initPromise.then(() => this.#runtimeEntryURL!);
   }
 
   #checkDisposed() {

--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -4,8 +4,14 @@ import exitHook from "exit-hook";
 import getPort from "get-port";
 import { bold, green, grey } from "kleur/colors";
 import stoppable from "stoppable";
-import { RequestInfo, RequestInit, fetch } from "undici";
-import { HeadersInit, Request, Response } from "undici";
+import {
+  HeadersInit,
+  Request,
+  RequestInfo,
+  RequestInit,
+  Response,
+  fetch,
+} from "undici";
 import workerd from "workerd";
 import { z } from "zod";
 import { setupCf } from "./cf";
@@ -190,10 +196,6 @@ export class Miniflare {
     }
   }
 
-  startServer(): Promise<void> {
-    return this.ready;
-  }
-
   async dispatchFetch(
     input: RequestInfo,
     init?: RequestInit
@@ -204,6 +206,7 @@ export class Miniflare {
     url.host = this.#runtimeEntryURL!.host;
     return fetch(url, forward as RequestInit);
   }
+
   async #init() {
     // Start loopback server (how the runtime accesses with Miniflare's storage)
     this.#loopbackServer = await this.#startLoopbackServer(0, "127.0.0.1");

--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -147,7 +147,7 @@ export const CORE_PLUGIN: Plugin<
             name:
               typeof service === "function"
                 ? `${SERVICE_CUSTOM_PREFIX}:${name}` // Custom `fetch` function
-                : `${SERVICE_USER_PREFIX}:${name}`, // Regular user worker
+                : `${SERVICE_USER_PREFIX}:${service}`, // Regular user worker
           },
         }))
       );


### PR DESCRIPTION
This PR resolves the `Miniflare#ready` `Promise` with the runtime entry URL. This allows users to get the port that Miniflare actually allocated for the runtime (needed by `wrangler`'s `unstable_dev`), or make WebSocket requests using `ws` for instance (until we figure out a proper solution for this).

I've also removed `startServer()`, since it was just an alias for `ready`, doesn't actually start a server, and was going to be a breaking change anyway (as we no longer return an `http.Server` instance).