### PR TITLE
Add `__STATIC_CONTENT_MANIFEST` module allowing module mode sites

### DIFF
--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -209,6 +209,7 @@ export const CORE_PLUGIN: Plugin<
     workerIndex,
     sharedOptions,
     durableObjectClassNames,
+    additionalModules,
   }) {
     // Define core/shared services.
     // Services get de-duped by name, so only the first worker's
@@ -232,6 +233,11 @@ export const CORE_PLUGIN: Plugin<
     // Define regular user worker if script is set
     const workerScript = getWorkerScript(options);
     if (workerScript !== undefined) {
+      // Add additional modules (e.g. "__STATIC_CONTENT_MANIFEST") if any
+      if ("modules" in workerScript) {
+        workerScript.modules.push(...additionalModules);
+      }
+
       const name = getUserServiceName(options.name);
       const classNames = durableObjectClassNames.get(name) ?? [];
       const compatibilityDate = validateCompatibilityDate(

--- a/packages/tre/src/plugins/kv/index.ts
+++ b/packages/tre/src/plugins/kv/index.ts
@@ -88,4 +88,5 @@ export const KV_PLUGIN: Plugin<
 };
 
 export * from "./gateway";
+export { maybeGetSitesManifestModule } from "./sites";
 export { KV_PLUGIN_NAME };

--- a/packages/tre/src/plugins/kv/sites.ts
+++ b/packages/tre/src/plugins/kv/sites.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { pathToFileURL } from "url";
-import { Service, Worker_Binding } from "../../runtime";
+import { Service, Worker_Binding, Worker_Module } from "../../runtime";
 import {
   MatcherRegExps,
   deserialiseRegExps,
@@ -169,6 +169,17 @@ export async function getSitesBindings(
       json: __STATIC_CONTENT_MANIFEST,
     },
   ];
+}
+
+export function maybeGetSitesManifestModule(
+  bindings: Worker_Binding[]
+): Worker_Module | undefined {
+  for (const binding of bindings) {
+    if (binding.name === BINDING_JSON_SITE_MANIFEST) {
+      assert("json" in binding && binding.json !== undefined);
+      return { name: BINDING_JSON_SITE_MANIFEST, text: binding.json };
+    }
+  }
 }
 
 export function getSitesService(options: SitesOptions): Service {

--- a/packages/tre/src/plugins/shared/index.ts
+++ b/packages/tre/src/plugins/shared/index.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { Service, Worker_Binding } from "../../runtime";
+import { Service, Worker_Binding, Worker_Module } from "../../runtime";
 import { Awaitable, OptionalZodTypeOf } from "../../shared";
 import { GatewayConstructor } from "./gateway";
 import { RouterConstructor } from "./router";
@@ -16,6 +16,7 @@ export interface PluginServicesOptions<
   workerBindings: Worker_Binding[];
   workerIndex: number;
   durableObjectClassNames: DurableObjectClassNames;
+  additionalModules: Worker_Module[];
 }
 
 export interface PluginBase<


### PR DESCRIPTION
Wrangler injects a text `__STATIC_CONTENT_MANIFEST` module in modules mode for use with `@cloudflare/kv-asset-handler`.

See https://github.com/cloudflare/kv-asset-handler#es-modules.