### PR TITLE
Correct Content-Length for range responses from the cache

### DIFF
--- a/packages/cache/src/range.ts
+++ b/packages/cache/src/range.ts
@@ -96,6 +96,10 @@ export function _getRangeResponse(
       "Content-Range",
       `bytes ${start}-${end}/${responseBody.byteLength}`
     );
+    responseHeaders.set(
+      "Content-Length",
+      `${end-start+1}`
+    );
     return new Response(responseBody.slice(start, end + 1), {
       status: 206, // Partial Content
       headers: responseHeaders,


### PR DESCRIPTION
Responses from the cache for range requests have the original "Content-Length". Additionally this breaks `response.arrayBuffer()` it returns buffer with invalid size. 