### PR TITLE
Add support for dead letter queues

### DIFF
--- a/packages/queues/src/broker.ts
+++ b/packages/queues/src/broker.ts
@@ -18,8 +18,9 @@ export type QueueErrorCode = "ERR_CONSUMER_ALREADY_SET";
 
 export class QueueError extends MiniflareError<QueueErrorCode> {}
 
-export const MAX_ATTEMPTS = 3;
-const kShouldAttemptRetry = Symbol("kShouldAttemptRetry");
+const kGetPendingRetry = Symbol("kGetPendingRetry");
+const kPrepareForRetry = Symbol("kPrepareForRetry");
+const kGetFailedAttempts = Symbol("kGetFailedAttempts");
 
 export class Message<Body = unknown> implements MessageInterface<Body> {
   readonly body: Body;
@@ -48,24 +49,17 @@ export class Message<Body = unknown> implements MessageInterface<Body> {
     this.#pendingRetry = true;
   }
 
-  [kShouldAttemptRetry](): boolean {
-    if (!this.#pendingRetry) {
-      return false;
-    }
-
-    this.#failedAttempts++;
-    if (this.#failedAttempts >= MAX_ATTEMPTS) {
-      this.#log?.warn(
-        `Dropped message "${this.id}" after ${
-          this.#failedAttempts
-        } failed attempts!`
-      );
-      return false;
-    }
-
-    this.#log?.debug(`Retrying message "${this.id}"...`);
+  [kPrepareForRetry]() {
     this.#pendingRetry = false;
-    return true;
+    this.#failedAttempts++;
+  }
+
+  [kGetPendingRetry](): boolean {
+    return this.#pendingRetry;
+  }
+
+  [kGetFailedAttempts](): number {
+    return this.#failedAttempts;
   }
 }
 
@@ -96,6 +90,7 @@ enum FlushType {
 export const kSetFlushCallback = Symbol("kSetFlushCallback");
 
 export class Queue<Body = unknown> implements QueueInterface<Body> {
+  readonly #broker: QueueBroker;
   readonly #queueName: string;
   readonly #log?: Log;
 
@@ -109,7 +104,8 @@ export class Queue<Body = unknown> implements QueueInterface<Body> {
   // A callback to run after a flush() has been executed: useful for testing.
   #flushCallback?: () => void;
 
-  constructor(queueName: string, log?: Log) {
+  constructor(broker: QueueBroker, queueName: string, log?: Log) {
+    this.#broker = broker;
     this.#queueName = queueName;
     this.#log = log;
 
@@ -202,6 +198,8 @@ export class Queue<Body = unknown> implements QueueInterface<Body> {
     if (!this.#consumer) {
       return;
     }
+    const maxAttempts = this.#consumer.maxRetries + 1;
+    const deadLetterQueue = this.#consumer.deadLetterQueue;
 
     // Create a batch and execute the queue event handler
     const batch = new MessageBatch<Body>(this.#queueName, [...this.#messages]);
@@ -216,12 +214,41 @@ export class Queue<Body = unknown> implements QueueInterface<Body> {
     // Reset state and check for any messages to retry
     this.#pendingFlush = FlushType.NONE;
     this.#timeout = undefined;
-    const messagesToRetry = batch.messages.filter((msg) =>
-      msg[kShouldAttemptRetry]()
-    );
-    this.#messages.push(...messagesToRetry);
-    if (this.#messages.length > 0) {
-      this.#ensurePendingFlush();
+
+    const toRetry: Message<Body>[] = [];
+    const toDLQ: Message<Body>[] = [];
+    batch.messages.forEach((msg) => {
+      if (!msg[kGetPendingRetry]()) {
+        return;
+      }
+
+      msg[kPrepareForRetry]();
+      if (msg[kGetFailedAttempts]() < maxAttempts) {
+        this.#log?.debug(`Retrying message "${msg.id}"...`);
+        toRetry.push(msg);
+      } else if (deadLetterQueue) {
+        this.#log?.warn(
+          `Moving message "${msg.id}" to dead letter queue "${deadLetterQueue}"...`
+        );
+        toDLQ.push(msg);
+      } else {
+        this.#log?.warn(
+          `Dropped message "${msg.id}" after ${maxAttempts} failed attempts!`
+        );
+      }
+    });
+
+    if (toRetry.length) {
+      this.#messages.push(...toRetry);
+      if (this.#messages.length > 0) {
+        this.#ensurePendingFlush();
+      }
+    }
+
+    if (deadLetterQueue) {
+      toDLQ.forEach((msg) => {
+        this.#broker.getOrCreateQueue(deadLetterQueue).send(msg.body);
+      });
     }
   }
 
@@ -242,7 +269,7 @@ export class QueueBroker implements QueueBrokerInterface {
   getOrCreateQueue(name: string): Queue {
     let queue = this.#queues.get(name);
     if (queue === undefined) {
-      this.#queues.set(name, (queue = new Queue(name, this.#log)));
+      this.#queues.set(name, (queue = new Queue(this, name, this.#log)));
     }
     return queue;
   }

--- a/packages/queues/src/plugin.ts
+++ b/packages/queues/src/plugin.ts
@@ -11,6 +11,7 @@ import {
 
 export const DEFAULT_BATCH_SIZE = 5;
 export const DEFAULT_WAIT_MS = 1000;
+export const DEFAULT_RETRIES = 2;
 
 export interface BindingOptions {
   name: string;
@@ -106,6 +107,8 @@ export class QueuesPlugin
         queueName: opts.queueName,
         maxBatchSize: opts.maxBatchSize ?? DEFAULT_BATCH_SIZE,
         maxWaitMs: opts.maxWaitMs ?? DEFAULT_WAIT_MS,
+        maxRetries: opts.maxRetries ?? DEFAULT_RETRIES,
+        deadLetterQueue: opts.deadLetterQueue,
         dispatcher: this.ctx.queueEventDispatcher,
       };
 

--- a/packages/shared/src/queues.ts
+++ b/packages/shared/src/queues.ts
@@ -15,6 +15,8 @@ export interface Consumer {
   queueName: string;
   maxBatchSize: number;
   maxWaitMs: number;
+  maxRetries: number;
+  deadLetterQueue?: string;
   dispatcher: QueueEventDispatcher;
 }
 


### PR DESCRIPTION
* Queue broker now respects the configured number of max retries for a consumer
* Queue broker now respects the configured "dead letter queue". After reaching the max number of attempts, "failed" messages are placed on this queue.