### PR TITLE
Add `getMiniflareDurableObjectIds` global test function

### DIFF
--- a/packages/durable-objects/src/plugin.ts
+++ b/packages/durable-objects/src/plugin.ts
@@ -267,6 +267,15 @@ export class DurableObjectsPlugin
     }).runWith(() => state[kAlarm]());
   }
 
+  getObjects(
+    storageFactory: StorageFactory,
+    namespace: string
+  ): DurableObjectId[] {
+    return [...this.#objectStates.keys()]
+      .map(getObjectIdFromKey)
+      .filter((id) => id[kObjectName] === namespace);
+  }
+
   async beforeReload(): Promise<void> {
     // Clear instance map, this should cause old instances to be GCed
     this.#objectStorages.clear();

--- a/packages/jest-environment-miniflare/test/fixtures/durableobjects.module.spec.js
+++ b/packages/jest-environment-miniflare/test/fixtures/durableobjects.module.spec.js
@@ -1,3 +1,5 @@
+import { DurableObjectId } from "@miniflare/durable-objects";
+
 beforeAll(async () => {
   const { TEST_OBJECT } = getMiniflareBindings();
   const id = TEST_OBJECT.idFromName("test");
@@ -53,10 +55,15 @@ test("Durable Objects list", async () => {
   const id = env.TEST_OBJECT.idFromName("test");
   env.TEST_OBJECT.get(id);
   expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toHaveLength(1);
-  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toContainEqual(id);
+  expect((await getMiniflareDurableObjectIds("TEST_OBJECT"))[0]).toMatchObject(
+    new DurableObjectId("TEST_OBJECT", id.toString())
+  );
 
   const id2 = env.TEST_OBJECT.idFromName("test2");
-  env.TEST_OBJECT.get(id2);
+  const stub = env.TEST_OBJECT.get(id2);
+  await stub.fetch("https://object/");
   expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toHaveLength(2);
-  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toContainEqual(id2);
+  expect((await getMiniflareDurableObjectIds("TEST_OBJECT"))[1]).toMatchObject(
+    new DurableObjectId("TEST_OBJECT", id2.toString())
+  );
 });

--- a/packages/jest-environment-miniflare/test/fixtures/durableobjects.module.spec.js
+++ b/packages/jest-environment-miniflare/test/fixtures/durableobjects.module.spec.js
@@ -43,3 +43,20 @@ test("Durable Objects direct", async () => {
   expect(await res1.text()).toBe("0");
   expect(await res2.text()).toBe("1");
 });
+
+test("Durable Objects list", async () => {
+  const env = getMiniflareBindings();
+
+  // From beforeAll
+  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toHaveLength(1);
+
+  const id = env.TEST_OBJECT.idFromName("test");
+  env.TEST_OBJECT.get(id);
+  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toHaveLength(1);
+  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toContainEqual(id);
+
+  const id2 = env.TEST_OBJECT.idFromName("test2");
+  env.TEST_OBJECT.get(id2);
+  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toHaveLength(2);
+  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toContainEqual(id2);
+});

--- a/packages/shared-test-environment/src/globals.ts
+++ b/packages/shared-test-environment/src/globals.ts
@@ -43,6 +43,9 @@ declare global {
   function flushMiniflareDurableObjectAlarms(
     ids: DurableObjectId[]
   ): Promise<void>;
+  function getMiniflareDurableObjectIds(
+    namespace: string
+  ): Promise<DurableObjectId[]>;
 }
 
 export interface MiniflareEnvironmentUtilities {
@@ -62,6 +65,7 @@ export interface MiniflareEnvironmentUtilities {
     event: FetchEvent | ScheduledEvent | ExecutionContext
   ): Promise<WaitUntil>;
   flushMiniflareDurableObjectAlarms(ids: DurableObjectId[]): Promise<void>;
+  getMiniflareDurableObjectIds(namespace: string): Promise<DurableObjectId[]>;
 }
 
 export async function createMiniflareEnvironmentUtilities(
@@ -105,6 +109,13 @@ export async function createMiniflareEnvironmentUtilities(
       const plugin = (await mf.getPlugins()).DurableObjectsPlugin;
       const factory = mf.getPluginStorage("DurableObjectsPlugin");
       return plugin.flushAlarms(factory, ids);
+    },
+    async getMiniflareDurableObjectIds(
+      namespace: string
+    ): Promise<DurableObjectId[]> {
+      const plugin = (await mf.getPlugins()).DurableObjectsPlugin;
+      const factory = mf.getPluginStorage("DurableObjectsPlugin");
+      return plugin.getObjects(factory, namespace);
     },
   };
 }

--- a/packages/vitest-environment-miniflare/test/fixtures/modules/durableobjects.module.spec.js
+++ b/packages/vitest-environment-miniflare/test/fixtures/modules/durableobjects.module.spec.js
@@ -46,3 +46,20 @@ test("Durable Objects direct", async () => {
   expect(await res1.text()).toBe("0");
   expect(await res2.text()).toBe("1");
 });
+
+test("Durable Objects list", async () => {
+  const env = getMiniflareBindings();
+
+  // From beforeAll
+  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toHaveLength(1);
+
+  const id = env.TEST_OBJECT.idFromName("test");
+  env.TEST_OBJECT.get(id);
+  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toHaveLength(1);
+  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toContainEqual(id);
+
+  const id2 = env.TEST_OBJECT.idFromName("test2");
+  env.TEST_OBJECT.get(id2);
+  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toHaveLength(2);
+  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toContainEqual(id2);
+});

--- a/packages/vitest-environment-miniflare/test/fixtures/modules/durableobjects.module.spec.js
+++ b/packages/vitest-environment-miniflare/test/fixtures/modules/durableobjects.module.spec.js
@@ -1,3 +1,4 @@
+import { DurableObjectId } from "@miniflare/durable-objects";
 import { beforeAll, expect, test } from "vitest";
 setupMiniflareIsolatedStorage();
 
@@ -56,10 +57,15 @@ test("Durable Objects list", async () => {
   const id = env.TEST_OBJECT.idFromName("test");
   env.TEST_OBJECT.get(id);
   expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toHaveLength(1);
-  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toContainEqual(id);
+  expect((await getMiniflareDurableObjectIds("TEST_OBJECT"))[0]).toMatchObject(
+    new DurableObjectId("TEST_OBJECT", id.toString())
+  );
 
   const id2 = env.TEST_OBJECT.idFromName("test2");
-  env.TEST_OBJECT.get(id2);
+  const stub = env.TEST_OBJECT.get(id2);
+  await stub.fetch("https://object/");
   expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toHaveLength(2);
-  expect(await getMiniflareDurableObjectIds("TEST_OBJECT")).toContainEqual(id2);
+  expect((await getMiniflareDurableObjectIds("TEST_OBJECT"))[1]).toMatchObject(
+    new DurableObjectId("TEST_OBJECT", id2.toString())
+  );
 });

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -23,7 +23,8 @@ function isMiniflarePkg(name) {
   return (
     name.startsWith(scope) ||
     name === "miniflare" ||
-    name === "jest-environment-miniflare"
+    name === "jest-environment-miniflare" ||
+    name === "vitest-environment-miniflare"
   );
 }
 


### PR DESCRIPTION
As discussed, it also includes a fix to `vitest-environment-miniflare` versioning.

Resolves #384.