### PR TITLE
Disable R2 persist in `shared-test-environment`

### DIFF
--- a/packages/shared-test-environment/src/index.ts
+++ b/packages/shared-test-environment/src/index.ts
@@ -58,6 +58,7 @@ export async function createMiniflareEnvironment(
       // - Persistence must be disabled for stacked storage to work
       kvPersist: false,
       d1Persist: false,
+      r2Persist: false,
       cachePersist: false,
       durableObjectsPersist: false,
       // - Allow all global operations, tests will be outside of a request


### PR DESCRIPTION
This fixes a bug where currently `shared-test-environment` throws an exception when `miniflare#r2_persit = true`

I've run into this in the reproduction below 

https://github.com/hanford/miniflare-shared-test-environment

Without this change the reproduction yields:

<img width="1840" alt="Screen Shot 2022-10-19 at 3 16 44 PM" src="https://user-images.githubusercontent.com/2148168/196815105-5e1ade0f-84db-4cd0-9877-f9bd4d59e63d.png">

With this change miniflare doesn't throw an exception and my tests pass as expected

<img width="1840" alt="Screen Shot 2022-10-19 at 3 17 19 PM" src="https://user-images.githubusercontent.com/2148168/196815182-9c26a7ca-1004-4ea5-9a26-14d86bc49a9b.png">
