### PR TITLE
Forward cdn-cgi/scripts paths to Cloudflare

### DIFF
--- a/packages/http-server/src/index.ts
+++ b/packages/http-server/src/index.ts
@@ -5,6 +5,7 @@ import http from "http";
 import https from "https";
 import net from "net";
 import { Transform, Writable } from "stream";
+import consumers from "stream/consumers";
 import { ReadableStream } from "stream/web";
 import { URL } from "url";
 import zlib from "zlib";
@@ -288,6 +289,15 @@ export function createRequestListener<Plugins extends HTTPPluginSignatures>(
           url
         );
         status = 200;
+      } else if (pathname.startsWith("/cdn-cgi/scripts/") {
+        response = await fetch(new URL(pathname, "https://cloudflare.com"));
+        status = response.status;
+        if (res) {
+          const bytes = consumers.buffer(response.body);
+          const body = String.fromCharCode.apply(null, bytes);
+          response = new Response(body);
+          await writeResponse(response, res, HTTPPlugin2.liveReload, mf.log);
+        }
       } else {
         status = 404;
       }


### PR DESCRIPTION
This addresses issue #421.

Right now, Miniflare 404s on attempts to download `rocket-loader.min.js`. For folks who've set up a Worker in front of Cloudflare Pages (e.g. to handle API requests on the same domain), this breaks their web app during local development: it renders as a white screen.

This PR adds a small amount of logic to simply forward those requests onto Cloudflare.