### PR TITLE
Fix incorrect request body when intercepting fetch with getMiniflareFetchMock

### DIFF
--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -736,6 +736,15 @@ class MiniflareDispatcher extends Dispatcher {
     // @ts-expect-error just want to pass through to global dispatcher here
     return this.inner.destroy(...args);
   }
+
+  /**
+   * Required for some testing utilities.
+   * For context see: https://github.com/nodejs/undici/issues/1756#issuecomment-1304711596
+   */
+  get isMockActive(): boolean {
+    // @ts-expect-error Missing type on MockAgent, but exists at runtime
+    return this.inner.isMockActive ?? false;
+  }
 }
 
 export async function fetch(

--- a/packages/jest-environment-miniflare/test/fixtures/core.module.spec.js
+++ b/packages/jest-environment-miniflare/test/fixtures/core.module.spec.js
@@ -13,3 +13,31 @@ test("handles requests with mocked upstream", async () => {
   const res = await fetch(new Request("https://random.mf"));
   expect(await res.text()).toBe("Hello World!");
 });
+
+test("reply callback options has expected data", async () => {
+  const mockAgent = getMiniflareFetchMock();
+  mockAgent.disableNetConnect();
+  const client = mockAgent.get("https://random.mf");
+  client.intercept({ path: "/", method: "POST" }).reply(200, (opts) => {
+    return opts;
+  });
+  const res = await fetch("https://random.mf", {
+    method: "POST",
+    body: JSON.stringify({ foo: "bar" }),
+  });
+  expect(await res.json()).toEqual({
+    body: '{"foo":"bar"}',
+    bodyTimeout: 300000,
+    headers: {
+      "accept-encoding": "br, gzip, deflate",
+      "content-length": "13",
+      "content-type": "text/plain;charset=UTF-8",
+      "mf-loop": "1",
+    },
+    headersTimeout: 300000,
+    maxRedirections: 0,
+    method: "POST",
+    origin: "https://random.mf",
+    path: "/",
+  });
+});

--- a/packages/vitest-environment-miniflare/test/fixtures/modules/core.module.spec.js
+++ b/packages/vitest-environment-miniflare/test/fixtures/modules/core.module.spec.js
@@ -17,3 +17,31 @@ test("handles requests with mocked upstream", async () => {
   const res = await fetch(new Request("https://random.mf"));
   expect(await res.text()).toBe("Hello World!");
 });
+
+test("reply callback options has expected data", async () => {
+  const mockAgent = getMiniflareFetchMock();
+  mockAgent.disableNetConnect();
+  const client = mockAgent.get("https://random.mf");
+  client.intercept({ path: "/", method: "POST" }).reply(200, (opts) => {
+    return opts;
+  });
+  const res = await fetch("https://random.mf", {
+    method: "POST",
+    body: JSON.stringify({ foo: "bar" }),
+  });
+  expect(await res.json()).toEqual({
+    body: '{"foo":"bar"}',
+    bodyTimeout: 300000,
+    headers: {
+      "accept-encoding": "br, gzip, deflate",
+      "content-length": "13",
+      "content-type": "text/plain;charset=UTF-8",
+      "mf-loop": "1",
+    },
+    headersTimeout: 300000,
+    maxRedirections: 0,
+    method: "POST",
+    origin: "https://random.mf",
+    path: "/",
+  });
+});


### PR DESCRIPTION
Hey there!

I am using `miniflare` with `jest` to test a Workers library. I need to write a simple unit test that intercepts a request body and returns it in response.

Example ([full code here](https://github.com/robertcepa/toucan-js/blob/undici-issue-1756/test/index.spec.ts)):
```
fetchMock.get('...')
  .intercept({
    method: () => true,
    path: () => true,
  })
  .reply(200, (opts) => {
    return opts;
  });
```
The issue I'm encountering is that `opts.body` doesn't contain request body string, as expected per https://undici.nodejs.org/#/docs/best-practices/mocking-request?id=reply-with-data-based-on-request , but `AsyncGenerator`.

I first thought that this was an issue in `undici` but after discussion with their team (https://github.com/nodejs/undici/issues/1756) it seems that the solution is to expose `isMockActive` property on `Dispatcher` for test utilities on `MockAgent` to work properly.

This PR adds a new `MiniflareDispatcherMock` class that extends the base `MiniflareDispatcher` with `isMockActive` getter. I decided to not add the getter directly to `MiniflareDispatcher`, because it's a testing function that doesn't exist on real dispatchers.

This class is used on `fetch` polyfill to instantiate dispatcher when bound with `MockAgent`.