### PR TITLE
Actually respect `port` and `host` option

### DIFF
--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -216,13 +216,11 @@ export class Miniflare {
     const loopbackPort = address.port;
 
     // Start runtime
-    const entryPort = await getPort({ port: this.#sharedOpts.core.port });
-
-    // TODO: respect entry `host` option
-    this.#runtime = new this.#runtimeConstructor(entryPort, loopbackPort);
+    const host = this.#sharedOpts.core.host ?? "127.0.0.1";
+    const port = this.#sharedOpts.core.port ?? (await getPort({ port: 8787 }));
+    this.#runtime = new this.#runtimeConstructor(host, port, loopbackPort);
     this.#removeRuntimeExitHook = exitHook(() => void this.#runtime?.dispose());
-
-    this.#runtimeEntryURL = new URL(`http://127.0.0.1:${entryPort}`);
+    this.#runtimeEntryURL = new URL(`http://127.0.0.1:${port}`);
 
     const config = await this.#assembleConfig();
     assert(config !== undefined);

--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -229,7 +229,7 @@ export class Miniflare {
 
     // Wait for runtime to start
     if (await this.#waitForRuntime()) {
-      console.log(bold(green(`Ready on ${this.#runtimeEntryURL}! 🎉`)));
+      console.log(bold(green(`Ready on ${this.#runtimeEntryURL} 🎉`)));
     }
   }
 
@@ -480,7 +480,7 @@ export class Miniflare {
 
     if (await this.#waitForRuntime()) {
       console.log(
-        bold(green(`Updated and ready on ${this.#runtimeEntryURL}! 🎉`))
+        bold(green(`Updated and ready on ${this.#runtimeEntryURL} 🎉`))
       );
     }
     updatePromise.resolve();


### PR DESCRIPTION
Previously, `port` was being passed through `get-port` before being used. This meant that if `Miniflare` was disposed and then immediately created again (as opposed to using `setOptions`), it couldn't use the same `port`, as `get-port` deliberately doesn't allocate recently allocated ports.

Notably, Wrangler does exactly this: re-create `Miniflare` instances. Ideally, we should be using `setOptions` there, but this at least means the port stays the same between reloads.

This PR also passes the `host` option to `workerd`, now that we're not putting an HTTP proxy in front of `workerd` in Miniflare.