### PR TITLE
Protect `#init()` and `setOptions()` with mutex

### DIFF
--- a/packages/tre/src/shared/index.ts
+++ b/packages/tre/src/shared/index.ts
@@ -3,4 +3,5 @@ export * from "./data";
 export * from "./deferred";
 export * from "./error";
 export * from "./matcher";
+export * from "./mutex";
 export * from "./types";

--- a/packages/tre/src/shared/mutex.ts
+++ b/packages/tre/src/shared/mutex.ts
@@ -1,0 +1,40 @@
+import assert from "assert";
+import { Awaitable } from "./types";
+
+export class Mutex {
+  private locked = false;
+  private resolveQueue: (() => void)[] = [];
+
+  private lock(): Awaitable<void> {
+    if (!this.locked) {
+      this.locked = true;
+      return;
+    }
+    return new Promise((resolve) => this.resolveQueue.push(resolve));
+  }
+
+  private unlock(): void {
+    assert(this.locked);
+    if (this.resolveQueue.length > 0) {
+      this.resolveQueue.shift()?.();
+    } else {
+      this.locked = false;
+    }
+  }
+
+  get hasWaiting(): boolean {
+    return this.resolveQueue.length > 0;
+  }
+
+  async runWith<T>(closure: () => Awaitable<T>): Promise<T> {
+    const acquireAwaitable = this.lock();
+    if (acquireAwaitable instanceof Promise) await acquireAwaitable;
+    try {
+      const awaitable = closure();
+      if (awaitable instanceof Promise) return await awaitable;
+      return awaitable;
+    } finally {
+      this.unlock();
+    }
+  }
+}


### PR DESCRIPTION
This will ensure multiple calls to `setOptions()` are applied in invocation order. We now only resolve the `ready` `Promise` when all previous calls to `setOptions()` have completed. Finally, we also now only log a ready/updated message if there are no pending options updates to apply.