### PR TITLE
Add support for devtools inspector protocol

### DIFF
--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -31,6 +31,7 @@ import {
   Config,
   Runtime,
   RuntimeConstructor,
+  RuntimeOptions,
   Service,
   Socket,
   Worker_Binding,
@@ -218,11 +219,16 @@ export class Miniflare {
     const loopbackPort = address.port;
 
     // Start runtime
-    const host = this.#sharedOpts.core.host ?? "127.0.0.1";
-    const port = this.#sharedOpts.core.port ?? (await getPort({ port: 8787 }));
-    this.#runtime = new this.#runtimeConstructor(host, port, loopbackPort);
+    const opts: RuntimeOptions = {
+      entryHost: this.#sharedOpts.core.host ?? "127.0.0.1",
+      entryPort: this.#sharedOpts.core.port ?? (await getPort({ port: 8787 })),
+      loopbackPort,
+      inspectorPort: this.#sharedOpts.core.inspectorPort,
+      verbose: this.#sharedOpts.core.verbose,
+    };
+    this.#runtime = new this.#runtimeConstructor(opts);
     this.#removeRuntimeExitHook = exitHook(() => void this.#runtime?.dispose());
-    this.#runtimeEntryURL = new URL(`http://127.0.0.1:${port}`);
+    this.#runtimeEntryURL = new URL(`http://127.0.0.1:${opts.entryPort}`);
 
     const config = await this.#assembleConfig();
     assert(config !== undefined);

--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -49,12 +49,17 @@ export const CoreOptionsSchema = z.object({
   wasmBindings: z.record(z.string()).optional(),
   textBlobBindings: z.record(z.string()).optional(),
   dataBlobBindings: z.record(z.string()).optional(),
+  // TODO: add support for workerd network/external/disk services here
   serviceBindings: z.record(z.union([z.string(), ServiceFetch])).optional(),
 });
 
 export const CoreSharedOptionsSchema = z.object({
   host: z.string().optional(),
   port: z.number().optional(),
+
+  inspectorPort: z.number().optional(),
+  verbose: z.boolean().optional(),
+
   // TODO: add back validation of cf object
   cf: z.union([z.boolean(), z.string(), z.record(z.any())]).optional(),
 });


### PR DESCRIPTION
Adds a new `inspectorPort` option, passed to `workerd`'s `--inspector-addr`. Also disables `--verbose` by default, unless the `verbose: true` option is set, as we don't want logging by default if we could use the inspector for this instead.