### PR TITLE
Add support for live reload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -437,6 +437,15 @@
       "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
       "dev": true
     },
+    "node_modules/@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.9.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.1.tgz",
@@ -4818,6 +4827,26 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -5359,6 +5388,7 @@
         "stoppable": "^1.1.0",
         "undici": "^5.10.0",
         "workerd": "^1.20220926.3",
+        "ws": "^8.11.0",
         "zod": "^3.18.0"
       },
       "devDependencies": {
@@ -5366,7 +5396,8 @@
         "@types/estree": "^1.0.0",
         "@types/glob-to-regexp": "^0.4.1",
         "@types/http-cache-semantics": "^4.0.1",
-        "@types/stoppable": "^1.1.1"
+        "@types/stoppable": "^1.1.1",
+        "@types/ws": "^8.5.3"
       },
       "engines": {
         "node": ">=16.13"
@@ -5587,6 +5618,7 @@
         "@types/glob-to-regexp": "^0.4.1",
         "@types/http-cache-semantics": "^4.0.1",
         "@types/stoppable": "^1.1.1",
+        "@types/ws": "^8.5.3",
         "acorn": "^8.8.0",
         "acorn-walk": "^8.2.0",
         "capnp-ts": "^0.7.0",
@@ -5598,6 +5630,7 @@
         "stoppable": "^1.1.0",
         "undici": "^5.10.0",
         "workerd": "^1.20220926.3",
+        "ws": "^8.11.0",
         "zod": "^3.18.0"
       },
       "dependencies": {
@@ -5778,6 +5811,15 @@
       "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
       "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
       "dev": true
+    },
+    "@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.9.1",
@@ -8898,6 +8940,12 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       }
+    },
+    "ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",

--- a/packages/tre/package.json
+++ b/packages/tre/package.json
@@ -46,13 +46,15 @@
     "stoppable": "^1.1.0",
     "undici": "^5.10.0",
     "workerd": "^1.20220926.3",
+    "ws": "^8.11.0",
     "zod": "^3.18.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/estree": "^1.0.0",
     "@types/glob-to-regexp": "^0.4.1",
+    "@types/http-cache-semantics": "^4.0.1",
     "@types/stoppable": "^1.1.1",
-    "@types/http-cache-semantics": "^4.0.1"
+    "@types/ws": "^8.5.3"
   }
 }

--- a/packages/tre/src/plugins/shared/index.ts
+++ b/packages/tre/src/plugins/shared/index.ts
@@ -17,6 +17,7 @@ export interface PluginServicesOptions<
   workerIndex: number;
   durableObjectClassNames: DurableObjectClassNames;
   additionalModules: Worker_Module[];
+  loopbackPort: number;
 }
 
 export interface PluginBase<


### PR DESCRIPTION
This PR brings over Miniflare 2's live reload feature to Miniflare 3. This automatically reloads pages whenever options are changed or the server is restarted.

Note that instead of terminating WebSocket's in `workerd`, we terminate them in `Miniflare`. This allows us to instantly send messages to all connected clients once options are applied, reducing the reload latency. :zap: