### PR TITLE
Support remote KV storage

### DIFF
--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -187,13 +187,13 @@ export class Miniflare {
     // Initialise plugin gateway factories and routers
     this.#gatewayFactories = {} as PluginGatewayFactories;
     this.#routers = {} as PluginRouters;
-    this.#initPlugins();
 
     // Split and validate options
     const [sharedOpts, workerOpts] = validateOptions(opts);
     this.#optionsVersion = 1;
     this.#sharedOpts = sharedOpts;
     this.#workerOpts = workerOpts;
+    this.#initPlugins();
 
     // Get supported shell for executing runtime binary
     // TODO: allow this to be configured if necessary
@@ -213,7 +213,12 @@ export class Miniflare {
   #initPlugins() {
     for (const [key, plugin] of PLUGIN_ENTRIES) {
       if (plugin.gateway !== undefined && plugin.router !== undefined) {
-        const gatewayFactory = new GatewayFactory<any>(key, plugin.gateway);
+        const gatewayFactory = new GatewayFactory<any>(
+          this.#sharedOpts.core.cloudflareFetch,
+          key,
+          plugin.gateway,
+          plugin.remoteStorage
+        );
         const router = new plugin.router(gatewayFactory);
         // @ts-expect-error this.#gatewayFactories[key] could be any plugin's
         this.#gatewayFactories[key] = gatewayFactory;

--- a/packages/tre/src/plugins/kv/gateway.ts
+++ b/packages/tre/src/plugins/kv/gateway.ts
@@ -91,7 +91,7 @@ export class KVGateway {
         `Invalid ${PARAM_CACHE_TTL} of ${cacheTtl}. Cache TTL must be at least ${MIN_CACHE_TTL}.`
       );
     }
-    return this.storage.get(key);
+    return this.storage.get(key, false, cacheTtl);
   }
 
   async put(
@@ -187,7 +187,12 @@ export class KVGateway {
     const cursor = options.cursor;
     const res = await this.storage.list({ limit, prefix, cursor });
     return {
-      keys: res.keys,
+      keys: res.keys.map((key) => ({
+        ...key,
+        // workerd expects metadata to be a JSON-serialised string
+        metadata:
+          key.metadata === undefined ? undefined : JSON.stringify(key.metadata),
+      })),
       cursor: res.cursor === "" ? undefined : res.cursor,
       list_complete: res.cursor === "",
     };

--- a/packages/tre/src/plugins/kv/index.ts
+++ b/packages/tre/src/plugins/kv/index.ts
@@ -12,10 +12,12 @@ import {
 } from "../shared";
 import { KV_PLUGIN_NAME } from "./constants";
 import { KVGateway } from "./gateway";
+import { KVRemoteStorage } from "./remote";
 import { KVRouter } from "./router";
 import { SitesOptions, getSitesBindings, getSitesService } from "./sites";
 
 export const KVOptionsSchema = z.object({
+  // TODO: also allow array like Miniflare 2
   kvNamespaces: z.record(z.string()).optional(),
 
   // Workers Sites
@@ -42,6 +44,7 @@ export const KV_PLUGIN: Plugin<
 > = {
   gateway: KVGateway,
   router: KVRouter,
+  remoteStorage: KVRemoteStorage,
   options: KVOptionsSchema,
   sharedOptions: KVSharedOptionsSchema,
   async getBindings(options) {

--- a/packages/tre/src/plugins/kv/remote.ts
+++ b/packages/tre/src/plugins/kv/remote.ts
@@ -1,0 +1,272 @@
+import assert from "assert";
+import { Blob } from "buffer";
+import { BodyInit, FormData, Response } from "undici";
+import { z } from "zod";
+import { Clock, millisToSeconds } from "../../shared";
+import {
+  RemoteStorage,
+  StorageListOptions,
+  StorageListResult,
+  StoredValueMeta,
+} from "../../storage";
+import { KVError } from "./gateway";
+
+interface RemoteCacheMetadata {
+  // UNIX timestamp in seconds when this key was last modified. KV allows you
+  // to reduce the cache TTL if it was previously set too high
+  // (https://developers.cloudflare.com/workers/runtime-apis/kv/#cache-ttl).
+  // This is used to check if the data should be revalidated from the remote.
+  storedAt: number;
+  // Whether this key represents a deleted value and should be treated as
+  // `undefined`.
+  tombstone?: true;
+  // The actual user-specified expiration of this key, if any. We want to return
+  // this to users instead of our cache expiration.
+  actualExpiration?: number;
+  // The actual user-specified metadata of this key, if any. We want to return
+  // this to users instead of this object.
+  actualMetadata?: unknown;
+}
+
+const APIEnvelopeSchema = z.object({
+  success: z.boolean(),
+  errors: z.array(z.object({ code: z.number(), message: z.string() })),
+  messages: z.array(z.object({ code: z.number(), message: z.string() })),
+});
+
+const KVGetMetadataResponseSchema = z.intersection(
+  APIEnvelopeSchema,
+  z.object({ result: z.unknown() })
+);
+
+const KVListResponseSchema = z.intersection(
+  APIEnvelopeSchema,
+  z.object({
+    result: z.array(
+      z.object({
+        name: z.string(),
+        expiration: z.onumber(),
+        metadata: z.unknown(),
+      })
+    ),
+    result_info: z.optional(
+      z.object({
+        count: z.onumber(),
+        cursor: z.ostring(),
+      })
+    ),
+  })
+);
+
+async function assertSuccessfulResponse(response: Response) {
+  if (response.ok) return;
+
+  // If this wasn't a successful response, throw a KVError
+  const contentType = response.headers.get("Content-Type");
+  if (contentType?.toLowerCase().includes("application/json")) {
+    const envelope = APIEnvelopeSchema.parse(await response.json());
+    throw new KVError(
+      response.status,
+      envelope.errors.map(({ message }) => message).join("\n")
+    );
+  } else {
+    throw new KVError(response.status, await response.text());
+  }
+}
+
+const DEFAULT_CACHE_TTL = 60;
+// Returns seconds since UNIX epoch key should expire, using the specified
+// expiration only if it is sooner than the cache TTL
+function getCacheExpiration(
+  clock: Clock,
+  expiration?: number,
+  cacheTtl = DEFAULT_CACHE_TTL
+): number {
+  // Return minimum expiration
+  const cacheExpiration = millisToSeconds(clock()) + cacheTtl;
+  if (expiration === undefined || isNaN(expiration)) return cacheExpiration;
+  else return Math.min(cacheExpiration, expiration);
+}
+
+export class KVRemoteStorage extends RemoteStorage {
+  async get(
+    key: string,
+    skipMetadata?: boolean,
+    cacheTtl = DEFAULT_CACHE_TTL
+  ): Promise<StoredValueMeta | undefined> {
+    // If this key is cached, return it
+    const cachedValue = await this.cache.get<RemoteCacheMetadata>(key);
+    if (cachedValue?.metadata?.storedAt !== undefined) {
+      // cacheTtl may have changed between the original get call that cached
+      // this value and now, so check the cache is still fresh with the new TTL
+      const newExpiration = cachedValue.metadata.storedAt + cacheTtl;
+      if (newExpiration >= millisToSeconds(this.clock())) {
+        // If the cache is still fresh, update the expiration and return
+        await this.cache.put<RemoteCacheMetadata>(key, {
+          value: cachedValue.value,
+          expiration: newExpiration,
+          // Intentionally not updating storedAt here, future get()s should
+          // compare their cacheTtl against the original
+          metadata: cachedValue.metadata,
+        });
+
+        // If we recently deleted this key, we'll cache a tombstone instead,
+        // and want to return undefined in that case
+        if (cachedValue.metadata.tombstone) return undefined;
+        return {
+          value: cachedValue.value,
+          expiration: cachedValue.metadata.actualExpiration,
+          metadata: cachedValue.metadata.actualMetadata,
+        };
+      }
+      // Otherwise, revalidate...
+    }
+
+    // Otherwise, fetch the key...
+    const encodedKey = encodeURIComponent(key);
+    const valueResource = `storage/kv/namespaces/${this.namespace}/values/${encodedKey}`;
+    const metadataResource = `storage/kv/namespaces/${this.namespace}/metadata/${encodedKey}`;
+    const [valueResponse, metadataResponse] = await Promise.all([
+      this.cloudflareFetch(valueResource),
+      this.cloudflareFetch(metadataResource),
+    ]);
+    if (valueResponse.status === 404) {
+      // Don't cache not founds, so new keys always returned instantly
+      return undefined;
+    }
+    await assertSuccessfulResponse(valueResponse);
+    await assertSuccessfulResponse(metadataResponse);
+
+    const value = new Uint8Array(await valueResponse.arrayBuffer());
+    const metadataEnvelope = KVGetMetadataResponseSchema.parse(
+      await metadataResponse.json()
+    );
+    assert(metadataEnvelope.success);
+    // The API will return null if there's no metadata, but we treat this as
+    // undefined
+    const metadata = metadataEnvelope.result ?? undefined;
+
+    const expirationHeader = valueResponse.headers.get("Expiration");
+    let expiration: number | undefined;
+    if (expirationHeader !== null) {
+      const maybeExpiration = parseInt(expirationHeader);
+      if (!isNaN(maybeExpiration)) expiration = maybeExpiration;
+    }
+
+    // ...and cache it for the specified TTL, then return it
+    const result: StoredValueMeta = { value, expiration, metadata };
+    await this.cache.put<RemoteCacheMetadata>(key, {
+      value: result.value,
+      expiration: getCacheExpiration(this.clock, expiration, cacheTtl),
+      metadata: {
+        storedAt: millisToSeconds(this.clock()),
+        actualExpiration: result.expiration,
+        actualMetadata: result.metadata,
+      },
+    });
+    return result;
+  }
+
+  async put(key: string, value: StoredValueMeta): Promise<void> {
+    // Store new value, expiration and metadata in remote
+    const encodedKey = encodeURIComponent(key);
+    const resource = `storage/kv/namespaces/${this.namespace}/values/${encodedKey}`;
+
+    const searchParams = new URLSearchParams();
+    if (value.expiration !== undefined) {
+      // Send expiration as TTL to avoid "expiration times must be at least 60s
+      // in the future" issues from clock skew when setting `expirationTtl: 60`.
+      const desiredTtl = value.expiration - millisToSeconds(this.clock());
+      const ttl = Math.max(desiredTtl, 60);
+      searchParams.set("expiration_ttl", ttl.toString());
+    }
+
+    let body: BodyInit = value.value;
+    if (value.metadata !== undefined) {
+      body = new FormData();
+      body.set("value", new Blob([value.value]));
+      body.set("metadata", JSON.stringify(value.metadata));
+    }
+
+    const response = await this.cloudflareFetch(resource, searchParams, {
+      method: "PUT",
+      body,
+    });
+    await assertSuccessfulResponse(response);
+
+    // Store this value in the cache
+    await this.cache.put<RemoteCacheMetadata>(key, {
+      value: value.value,
+      expiration: getCacheExpiration(this.clock, value.expiration),
+      metadata: {
+        storedAt: millisToSeconds(this.clock()),
+        actualExpiration: value.expiration,
+        actualMetadata: value.metadata,
+      },
+    });
+  }
+
+  async delete(key: string): Promise<boolean> {
+    // Delete key from remote
+    const encodedKey = encodeURIComponent(key);
+    const resource = `storage/kv/namespaces/${this.namespace}/values/${encodedKey}`;
+
+    const response = await this.cloudflareFetch(resource, undefined, {
+      method: "DELETE",
+    });
+    await assertSuccessfulResponse(response);
+
+    // "Store" delete in cache as tombstone
+    await this.cache.put<RemoteCacheMetadata>(key, {
+      value: new Uint8Array(),
+      expiration: getCacheExpiration(this.clock),
+      metadata: { storedAt: millisToSeconds(this.clock()), tombstone: true },
+    });
+
+    // Technically, it's incorrect to always say we deleted the key by returning
+    // true here, as the value may not exist in the remote. However, `KVGateway`
+    // ignores this result anyway.
+    return true;
+  }
+
+  async list(options: StorageListOptions): Promise<StorageListResult> {
+    // Always list from remote, ignore cache
+    const resource = `storage/kv/namespaces/${this.namespace}/keys`;
+    const searchParams = new URLSearchParams();
+    if (options.limit !== undefined) {
+      searchParams.set("limit", options.limit.toString());
+    }
+    if (options.cursor !== undefined) {
+      searchParams.set("cursor", options.cursor.toString());
+    }
+    if (options.prefix !== undefined) {
+      searchParams.set("prefix", options.prefix.toString());
+    }
+
+    // Make sure unsupported options aren't specified
+    assert.strictEqual(options.start, undefined);
+    assert.strictEqual(options.end, undefined);
+    assert.strictEqual(options.reverse, undefined);
+    assert.strictEqual(options.delimiter, undefined);
+
+    const response = await this.cloudflareFetch(resource, searchParams);
+    await assertSuccessfulResponse(response);
+    const value = KVListResponseSchema.parse(await response.json());
+    assert(value.success);
+
+    return {
+      keys: value.result,
+      cursor: value.result_info?.cursor ?? "",
+    };
+  }
+
+  has(): never {
+    assert.fail("KVGateway should not call has()");
+  }
+  head(): never {
+    assert.fail("KVGateway should not call head()");
+  }
+  getRange(): never {
+    assert.fail("KVGateway should not call getRange()");
+  }
+}

--- a/packages/tre/src/plugins/shared/index.ts
+++ b/packages/tre/src/plugins/shared/index.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { Service, Worker_Binding, Worker_Module } from "../../runtime";
 import { Awaitable, OptionalZodTypeOf } from "../../shared";
-import { GatewayConstructor } from "./gateway";
+import { GatewayConstructor, RemoteStorageConstructor } from "./gateway";
 import { RouterConstructor } from "./router";
 
 export type DurableObjectClassNames = Map<string, string[]>;
@@ -40,10 +40,11 @@ export type Plugin<
     ? { sharedOptions?: undefined }
     : { sharedOptions: SharedOptions }) &
   (Gateway extends undefined
-    ? { gateway?: undefined; router?: undefined }
+    ? { gateway?: undefined; router?: undefined; remoteStorage?: undefined }
     : {
         gateway: GatewayConstructor<Gateway>;
         router: RouterConstructor<Gateway>;
+        remoteStorage?: RemoteStorageConstructor;
       });
 
 export * from "./constants";

--- a/packages/tre/src/shared/error.ts
+++ b/packages/tre/src/shared/error.ts
@@ -19,6 +19,8 @@ export type MiniflareCoreErrorCode =
   | "ERR_MODULE_DYNAMIC_SPEC" // Attempted to import/require a module without a literal spec
   | "ERR_MODULE_RULE" // No matching module rule for file
   | "ERR_PERSIST_UNSUPPORTED" // Unsupported storage persistence protocol
+  | "ERR_PERSIST_REMOTE_UNAUTHENTICATED" // cloudflareFetch implementation not provided
+  | "ERR_PERSIST_REMOTE_UNSUPPORTED" // Remote storage is not supported for this database
   | "ERR_FUTURE_COMPATIBILITY_DATE"; // Compatibility date in the future
 export class MiniflareCoreError extends MiniflareError<MiniflareCoreErrorCode> {}
 

--- a/packages/tre/src/shared/types.ts
+++ b/packages/tre/src/shared/types.ts
@@ -2,6 +2,12 @@ import { z } from "zod";
 
 export type Awaitable<T> = T | Promise<T>;
 
+export function zAwaitable<T extends z.ZodTypeAny>(
+  type: T
+): z.ZodUnion<[T, z.ZodPromise<T>]> {
+  return type.or(z.promise(type));
+}
+
 // { a: A, b: B, ... } => A | B | ...
 export type ValueOf<T> = T[keyof T];
 

--- a/packages/tre/src/storage/sqlite.ts
+++ b/packages/tre/src/storage/sqlite.ts
@@ -79,7 +79,6 @@ export class SqliteStorage extends LocalStorage {
   }
 
   private run(query: ReturnType<typeof sql>): { changes: number } {
-    console.log(query);
     const stmt = this.database.prepare(query.template);
     return stmt.run(...query.parameters);
   }

--- a/packages/tre/src/storage/storage.ts
+++ b/packages/tre/src/storage/storage.ts
@@ -1,7 +1,9 @@
+import { CloudflareFetch } from "../plugins";
 import {
   Awaitable,
   base64Decode,
   base64Encode,
+  defaultClock,
   lexicographicCompare,
   nonCircularClone,
 } from "../shared";
@@ -93,11 +95,13 @@ export abstract class Storage {
   ): Awaitable<StoredMeta<Meta> | undefined>;
   abstract get<Meta = unknown>(
     key: string,
-    skipMetadata?: false
+    skipMetadata?: false,
+    cacheTtl?: number
   ): Awaitable<StoredValueMeta<Meta> | undefined>;
   abstract get(
     key: string,
-    skipMetadata: true
+    skipMetadata: true,
+    cacheTtl?: number
   ): Awaitable<StoredValue | undefined>;
   abstract getRange<Meta = unknown>(
     key: string,
@@ -160,6 +164,17 @@ export abstract class Storage {
     let count = 0;
     for (const result of await Promise.all(results)) if (result) count++;
     return count;
+  }
+}
+
+export abstract class RemoteStorage extends Storage {
+  constructor(
+    protected readonly cache: Storage,
+    protected readonly cloudflareFetch: CloudflareFetch,
+    protected readonly namespace: string,
+    protected readonly clock = defaultClock
+  ) {
+    super();
   }
 }
 

--- a/packages/tre/test/plugins/shared/router.spec.ts
+++ b/packages/tre/test/plugins/shared/router.spec.ts
@@ -15,7 +15,7 @@ class TestGateway {
 
 class TestRouter extends Router<TestGateway> {
   constructor() {
-    super(new GatewayFactory("test", TestGateway));
+    super(new GatewayFactory(undefined, "test", TestGateway));
   }
 
   @GET("/params/:foo/:bar")


### PR DESCRIPTION
This PR adds experimental support for reading/writing from real KV namespaces. The user's computer is treated like another "colo", and values are cached there as they are in KV, respecting `cacheTtl`s passed to `get`.

> :warning: We're still exploring how this feature will work, so it's likely it'll change in the future.