### PR TITLE
Assorted Cache API fixes

### DIFF
--- a/packages/tre/README.md
+++ b/packages/tre/README.md
@@ -289,6 +289,18 @@ parameter in module format Workers.
     from your Worker.
     <!--TODO: other service types, disk, network, external, etc-->
 
+#### Cache
+
+- `cache?: boolean`
+
+  If `false`, default and named caches will be disabled. The Cache API will
+  still be available, it just won't cache anything.
+
+- `cacheWarnUsage?: boolean`
+
+  If `true`, the first use of the Cache API will log a warning stating that the
+  Cache API is unsupported on `workers.dev` subdomains.
+
 #### Durable Objects
 
 - `durableObjects?: Record<string, string | { className: string, scriptName?: string }>`
@@ -404,24 +416,12 @@ Options shared between all Workers/"nanoservices".
 
 <!--TODO: implement custom logger-->
 
-#### Cache
+#### Cache, Durable Objects, KV and R2
 
 - `cachePersist?: Persistence`
 
   Where to persist data cached in default or named caches. See docs for
   `Persistence`.
-
-- `cache?: boolean`
-
-  If `false`, default and named caches will be disabled. The Cache API will
-  still be available, it just won't cache anything.
-
-- `cacheWarnUsage?: boolean`
-
-  If `true`, the first use of the Cache API will log a warning stating that the
-  Cache API is unsupported on `workers.dev` subdomains.
-
-#### Durable Objects, KV and R2
 
 - `durableObjectsPersist?: Persistence`
 

--- a/packages/tre/README.md
+++ b/packages/tre/README.md
@@ -418,10 +418,8 @@ Options shared between all Workers/"nanoservices".
 
 - `cacheWarnUsage?: boolean`
 
-  _Not yet supported_
-
-  <!--If `true`, the first use of the Cache API will log a warning stating that the
-  Cache API is unsupported on `workers.dev` subdomains.-->
+  If `true`, the first use of the Cache API will log a warning stating that the
+  Cache API is unsupported on `workers.dev` subdomains.
 
 #### Durable Objects, KV and R2
 

--- a/packages/tre/README.md
+++ b/packages/tre/README.md
@@ -289,24 +289,6 @@ parameter in module format Workers.
     from your Worker.
     <!--TODO: other service types, disk, network, external, etc-->
 
-#### Cache
-
-<!--TODO: implement these options-->
-
-- `cache?: boolean`
-
-  _Not yet supported_, the Cache API is always enabled.
-
-  <!--If `true`, default and named caches will be disabled. The Cache API will still
-  be available, it just won't cache anything.-->
-
-- `cacheWarnUsage?: boolean`
-
-  _Not yet supported_
-
-  <!--If `true`, the first use of the Cache API will log a warning stating that the
-  Cache API is unsupported on `workers.dev` subdomains.-->
-
 #### Durable Objects
 
 - `durableObjects?: Record<string, string | { className: string, scriptName?: string }>`
@@ -422,12 +404,26 @@ Options shared between all Workers/"nanoservices".
 
 <!--TODO: implement custom logger-->
 
-#### Cache, Durable Objects, KV and R2
+#### Cache
 
 - `cachePersist?: Persistence`
 
   Where to persist data cached in default or named caches. See docs for
   `Persistence`.
+
+- `cache?: boolean`
+
+  If `false`, default and named caches will be disabled. The Cache API will
+  still be available, it just won't cache anything.
+
+- `cacheWarnUsage?: boolean`
+
+  _Not yet supported_
+
+  <!--If `true`, the first use of the Cache API will log a warning stating that the
+  Cache API is unsupported on `workers.dev` subdomains.-->
+
+#### Durable Objects, KV and R2
 
 - `durableObjectsPersist?: Persistence`
 

--- a/packages/tre/src/plugins/cache/constants.ts
+++ b/packages/tre/src/plugins/cache/constants.ts
@@ -1,0 +1,1 @@
+export const HEADER_CACHE_WARN_USAGE = "MF-Cache-Warn";

--- a/packages/tre/src/plugins/cache/index.ts
+++ b/packages/tre/src/plugins/cache/index.ts
@@ -11,6 +11,7 @@ import {
   Plugin,
   encodePersist,
 } from "../shared";
+import { HEADER_CACHE_WARN_USAGE } from "./constants";
 import { CacheGateway } from "./gateway";
 import { CacheRouter } from "./router";
 
@@ -23,17 +24,15 @@ export const CacheSharedOptionsSchema = z.object({
   cache: z.boolean().optional(),
   cacheWarnUsage: z.boolean().optional(),
 });
-export const CacheSharedOptionsSchema = z.object({
-  cachePersist: PersistenceSchema,
-});
+
+const BINDING_JSON_CACHE_WARN_USAGE = "MINIFLARE_CACHE_WARN_USAGE";
+
 export const CACHE_LOOPBACK_SCRIPT = `addEventListener("fetch", (event) => {
-  let request = event.request;
+  const request = new Request(event.request);
   const url = new URL(request.url);
   url.pathname = \`/\${${BINDING_TEXT_PLUGIN}}/\${encodeURIComponent(request.url)}\`;
-  if (globalThis.${BINDING_TEXT_PERSIST} !== undefined) {
-    request = new Request(request);
-    request.headers.set("${HEADER_PERSIST}", ${BINDING_TEXT_PERSIST});
-  }
+  if (globalThis.${BINDING_TEXT_PERSIST} !== undefined) request.headers.set("${HEADER_PERSIST}", ${BINDING_TEXT_PERSIST});
+  if (globalThis.${BINDING_JSON_CACHE_WARN_USAGE}) request.headers.set("${HEADER_CACHE_WARN_USAGE}", "true");
   event.respondWith(${BINDING_SERVICE_LOOPBACK}.fetch(url, request));
 });`;
 // Cache service script that doesn't do any caching
@@ -83,6 +82,10 @@ export const CACHE_PLUGIN: Plugin<
           bindings: [
             ...persistBinding,
             { name: BINDING_TEXT_PLUGIN, text: CACHE_PLUGIN_NAME },
+            {
+              name: BINDING_JSON_CACHE_WARN_USAGE,
+              json: JSON.stringify(sharedOptions.cacheWarnUsage ?? false),
+            },
             loopbackBinding,
           ],
           compatibilityDate: "2022-09-01",

--- a/packages/tre/src/plugins/cache/index.ts
+++ b/packages/tre/src/plugins/cache/index.ts
@@ -8,6 +8,7 @@ import {
   HEADER_PERSIST,
   PersistenceSchema,
   Plugin,
+  encodePersist,
 } from "../shared";
 import { CacheGateway } from "./gateway";
 import { CacheRouter } from "./router";
@@ -42,7 +43,8 @@ export const CACHE_PLUGIN: Plugin<
   getBindings() {
     return [];
   },
-  getServices() {
+  getServices({ options, sharedOptions }) {
+    const persistBinding = encodePersist(sharedOptions.cachePersist);
     const loopbackBinding: Worker_Binding = {
       name: BINDING_SERVICE_LOOPBACK,
       service: { name: SERVICE_LOOPBACK },
@@ -53,6 +55,7 @@ export const CACHE_PLUGIN: Plugin<
         worker: {
           serviceWorkerScript: CACHE_LOOPBACK_SCRIPT,
           bindings: [
+            ...persistBinding,
             { name: BINDING_TEXT_PLUGIN, text: CACHE_PLUGIN_NAME },
             loopbackBinding,
           ],

--- a/packages/tre/src/plugins/cache/router.ts
+++ b/packages/tre/src/plugins/cache/router.ts
@@ -1,4 +1,4 @@
-import { Request, RequestInit } from "undici";
+import { Headers, Request, RequestInit } from "undici";
 import {
   CfHeader,
   GET,
@@ -12,32 +12,32 @@ import { fallible } from "./errors";
 import { CacheGateway } from "./gateway";
 
 export interface CacheParams {
-  namespace: string;
   uri: string;
+}
+
+function decodeNamespace(headers: Headers) {
+  const namespace = headers.get(CfHeader.CacheNamespace);
+  // Namespace separator `:` will become a new directory when using file-system
+  // backed persistent storage
+  return namespace === null ? `default` : `named:${namespace}`;
 }
 
 export class CacheRouter extends Router<CacheGateway> {
   @GET("/:uri")
   match: RouteHandler<CacheParams> = async (req, params) => {
     const uri = decodeURIComponent(params.uri);
+    const namespace = decodeNamespace(req.headers);
     const persist = decodePersist(req.headers);
-    const ns = req.headers.get(CfHeader.CacheNamespace);
-    const gateway = this.gatewayFactory.get(
-      params.namespace + ns ? `:ns:${ns}` : `:default`,
-      persist
-    );
+    const gateway = this.gatewayFactory.get(namespace, persist);
     return fallible(gateway.match(new Request(uri, req as RequestInit)));
   };
 
   @PUT("/:uri")
   put: RouteHandler<CacheParams> = async (req, params) => {
     const uri = decodeURIComponent(params.uri);
+    const namespace = decodeNamespace(req.headers);
     const persist = decodePersist(req.headers);
-    const ns = req.headers.get(CfHeader.CacheNamespace);
-    const gateway = this.gatewayFactory.get(
-      params.namespace + ns ? `:ns:${ns}` : `:default`,
-      persist
-    );
+    const gateway = this.gatewayFactory.get(namespace, persist);
     return fallible(
       gateway.put(new Request(uri, req as RequestInit), await req.arrayBuffer())
     );
@@ -46,12 +46,9 @@ export class CacheRouter extends Router<CacheGateway> {
   @PURGE("/:uri")
   delete: RouteHandler<CacheParams> = async (req, params) => {
     const uri = decodeURIComponent(params.uri);
+    const namespace = decodeNamespace(req.headers);
     const persist = decodePersist(req.headers);
-    const ns = req.headers.get(CfHeader.CacheNamespace);
-    const gateway = this.gatewayFactory.get(
-      params.namespace + ns ? `:ns:${ns}` : `:default`,
-      persist
-    );
+    const gateway = this.gatewayFactory.get(namespace, persist);
     return fallible(gateway.delete(new Request(uri, req as RequestInit)));
   };
 }

--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -18,6 +18,7 @@ import {
   MiniflareCoreError,
   zAwaitable,
 } from "../../shared";
+import { getCacheServiceName } from "../cache";
 import {
   BINDING_SERVICE_LOOPBACK,
   CloudflareFetchSchema,
@@ -358,7 +359,7 @@ export const CORE_PLUGIN: Plugin<
             uniqueKey: className,
           })),
           durableObjectStorage: { inMemory: kVoid },
-          cacheApiOutbound: { name: "cache" },
+          cacheApiOutbound: { name: getCacheServiceName(workerIndex) },
         },
       });
       serviceEntryBindings.push({

--- a/packages/tre/src/plugins/kv/index.ts
+++ b/packages/tre/src/plugins/kv/index.ts
@@ -89,5 +89,5 @@ export const KV_PLUGIN: Plugin<
 };
 
 export * from "./gateway";
-export { maybeGetSitesManifestModule } from "./sites";
+export { maybeGetSitesManifestModule, isSitesRequest } from "./sites";
 export { KV_PLUGIN_NAME };


### PR DESCRIPTION
Each of these fixes is split into a separate commit for easier reviewing. 🙂 
- **Enable persistence:** previously the `cachePersist` option was being ignored, so cached data couldn't be persisted
- **Disable Workers Sites asset caching:** we always want to serve the latest on-disk Workers Sites files so changes are reflected. However, `@cloudlfare/kv-asset-handler` automatically caches files, so we need to disable the Cache API for these URIs.
- **Allow cache to be disabled:** Miniflare 2 had a `cache: false` option for disabling the cache. The Cache API was still available, it just didn't do anything.
- **Facilitate cache usage warning on `workers.dev` subdomains:** Cache API operations are no-ops on `workers.dev` subdomains. This is a common cause of confusion, so this PR also brings over Miniflare 2's `cacheWarnUsage: true` option. We can set this in Wrangler if we detect the user will be publishing to a `workers.dev` zone.