### PR TITLE
Add configurable logger

### DIFF
--- a/packages/tre/README.md
+++ b/packages/tre/README.md
@@ -132,6 +132,58 @@ Represents where data should be persisted, if anywhere.
 - Otherwise, if this is just a regular `string`, data will be stored on the
   file-system, using the value as the directory path.
 
+### `enum LogLevel`
+
+`NONE, ERROR, WARN, INFO, DEBUG, VERBOSE`
+
+Controls which messages Miniflare logs. All messages at or below the selected
+level will be logged.
+
+### `interface LogOptions`
+
+- `prefix?: string`
+
+  String to add before the level prefix when logging messages. Defaults to `mf`.
+
+- `suffix?: string`
+
+  String to add after the level prefix when logging messages.
+
+### `class Log`
+
+- `constructor(level?: LogLevel, opts?: LogOptions)`
+
+  Creates a new logger that logs all messages at or below the specified level to
+  the `console`.
+
+- `error(message: Error)`
+
+  Logs a message at the `ERROR` level. If the constructed log `level` is less
+  than `ERROR`, `throw`s the `message` instead.
+
+- `warn(message: string)`
+
+  Logs a message at the `WARN` level.
+
+- `info(message: string)`
+
+  Logs a message at the `INFO` level.
+
+- `debug(message: string)`
+
+  Logs a message at the `DEBUG` level.
+
+- `verbose(message: string)`
+
+  Logs a message at the `VERBOSE` level.
+
+### `class NoOpLog extends Log`
+
+- `constructor()`
+
+  Creates a new logger that logs nothing to the `console`, and always `throw`s
+  `message`s logged at the `ERROR` level.
+
 ### `interface WorkerOptions`
 
 Options for an individual Worker/"nanoservice". All bindings are accessible on
@@ -336,6 +388,11 @@ Options shared between all Workers/"nanoservices".
 
   Enable `workerd`'s `--verbose` flag for verbose logging. This can be used to
   see simplified `console.log`s.
+
+- `log?: Log`
+
+  Logger implementation for Miniflare's errors, warnings and informative
+  messages.
 
 - `cf?: boolean | string | Record<string, any>`
 

--- a/packages/tre/src/plugins/cache/gateway.ts
+++ b/packages/tre/src/plugins/cache/gateway.ts
@@ -3,7 +3,7 @@ import http from "http";
 import { AddressInfo } from "net";
 import CachePolicy from "http-cache-semantics";
 import { Headers, HeadersInit, Request, Response, fetch } from "undici";
-import { Clock, millisToSeconds } from "../../shared";
+import { Clock, Log, millisToSeconds } from "../../shared";
 import { Storage } from "../../storage";
 import { CacheMiss, PurgeFailure, StorageFailure } from "./errors";
 import { _getRangeResponse } from "./range";
@@ -201,6 +201,7 @@ class HttpParser {
 
 export class CacheGateway {
   constructor(
+    private readonly log: Log,
     private readonly storage: Storage,
     private readonly clock: Clock
   ) {}

--- a/packages/tre/src/plugins/do/gateway.ts
+++ b/packages/tre/src/plugins/do/gateway.ts
@@ -1,8 +1,9 @@
-import { Clock } from "../../shared";
+import { Clock, Log } from "../../shared";
 import { Storage } from "../../storage";
 
 export class DurableObjectsStorageGateway {
   constructor(
+    private readonly log: Log,
     private readonly storage: Storage,
     private readonly clock: Clock
   ) {}

--- a/packages/tre/src/plugins/kv/gateway.ts
+++ b/packages/tre/src/plugins/kv/gateway.ts
@@ -1,4 +1,4 @@
-import { Clock, HttpError, millisToSeconds } from "../../shared";
+import { Clock, HttpError, Log, millisToSeconds } from "../../shared";
 import { Storage, StoredKeyMeta, StoredValueMeta } from "../../storage";
 import {
   MAX_KEY_SIZE,
@@ -70,6 +70,7 @@ export interface KVGatewayListResult<Meta = unknown> {
 
 export class KVGateway {
   constructor(
+    private readonly log: Log,
     private readonly storage: Storage,
     private readonly clock: Clock
   ) {}

--- a/packages/tre/src/plugins/r2/gateway.ts
+++ b/packages/tre/src/plugins/r2/gateway.ts
@@ -1,3 +1,4 @@
+import { Log } from "../../shared";
 import { RangeStoredValueMeta, Storage } from "../../storage";
 import { InvalidRange, NoSuchKey } from "./errors";
 import {
@@ -90,7 +91,7 @@ const MAX_LIST_KEYS = 1_000;
 const validate = new Validator();
 
 export class R2Gateway {
-  constructor(private readonly storage: Storage) {}
+  constructor(private readonly log: Log, private readonly storage: Storage) {}
 
   async head(key: string): Promise<R2Object> {
     validate.key(key);

--- a/packages/tre/src/plugins/shared/gateway.ts
+++ b/packages/tre/src/plugins/shared/gateway.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import {
   Awaitable,
   Clock,
+  Log,
   MiniflareCoreError,
   defaultClock,
   sanitisePath,
@@ -34,7 +35,7 @@ export const CloudflareFetchSchema =
 export type CloudflareFetch = z.infer<typeof CloudflareFetchSchema>;
 
 export interface GatewayConstructor<Gateway> {
-  new (storage: Storage, clock: Clock): Gateway;
+  new (log: Log, storage: Storage, clock: Clock): Gateway;
 }
 
 export interface RemoteStorageConstructor {
@@ -60,6 +61,7 @@ export class GatewayFactory<Gateway> {
   readonly #gateways = new Map<string, [Persistence, Gateway]>();
 
   constructor(
+    private readonly log: Log,
     private readonly cloudflareFetch: CloudflareFetch | undefined,
     private readonly pluginName: string,
     private readonly gatewayClass: GatewayConstructor<Gateway>,
@@ -134,7 +136,7 @@ export class GatewayFactory<Gateway> {
     if (cached !== undefined && cached[0] === persist) return cached[1];
 
     const storage = this.getStorage(namespace, persist);
-    const gateway = new this.gatewayClass(storage, defaultClock);
+    const gateway = new this.gatewayClass(this.log, storage, defaultClock);
     this.#gateways.set(namespace, [persist, gateway]);
     return gateway;
   }

--- a/packages/tre/src/plugins/shared/index.ts
+++ b/packages/tre/src/plugins/shared/index.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { Service, Worker_Binding, Worker_Module } from "../../runtime";
-import { Awaitable, OptionalZodTypeOf } from "../../shared";
+import { Awaitable, Log, OptionalZodTypeOf } from "../../shared";
 import { GatewayConstructor, RemoteStorageConstructor } from "./gateway";
 import { RouterConstructor } from "./router";
 
@@ -10,6 +10,7 @@ export interface PluginServicesOptions<
   Options extends z.ZodType,
   SharedOptions extends z.ZodType | undefined
 > {
+  log: Log;
   options: z.infer<Options>;
   optionsVersion: number;
   sharedOptions: OptionalZodTypeOf<SharedOptions>;

--- a/packages/tre/src/plugins/shared/router.ts
+++ b/packages/tre/src/plugins/shared/router.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "undici";
-import { Awaitable } from "../../shared";
+import { Awaitable, Log } from "../../shared";
 import { GatewayFactory } from "./gateway";
 
 export type RouteHandler<Params = unknown> = (
@@ -12,7 +12,10 @@ export abstract class Router<Gateway> {
   // Routes added by @METHOD decorators
   routes?: Map<string, (readonly [RegExp, string | symbol])[]>;
 
-  constructor(protected readonly gatewayFactory: GatewayFactory<Gateway>) {
+  constructor(
+    protected readonly log: Log,
+    protected readonly gatewayFactory: GatewayFactory<Gateway>
+  ) {
     // Make sure this.routes isn't undefined and has the prototype's value
     this.routes = new.target.prototype.routes;
   }
@@ -34,7 +37,7 @@ export abstract class Router<Gateway> {
 }
 
 export interface RouterConstructor<Gateway> {
-  new (gatewayFactory: GatewayFactory<Gateway>): Router<Gateway>;
+  new (log: Log, gatewayFactory: GatewayFactory<Gateway>): Router<Gateway>;
 }
 
 function pathToRegexp(path: string): RegExp {

--- a/packages/tre/src/shared/index.ts
+++ b/packages/tre/src/shared/index.ts
@@ -2,6 +2,7 @@ export * from "./clock";
 export * from "./data";
 export * from "./deferred";
 export * from "./error";
+export * from "./log";
 export * from "./matcher";
 export * from "./mutex";
 export * from "./types";

--- a/packages/tre/src/shared/log.ts
+++ b/packages/tre/src/shared/log.ts
@@ -1,0 +1,123 @@
+import path from "path";
+import { Colorize, dim, green, grey, red, reset, yellow } from "kleur/colors";
+
+const cwd = process.cwd();
+const cwdNodeModules = path.join(cwd, "node_modules");
+
+export enum LogLevel {
+  NONE,
+  ERROR,
+  WARN,
+  INFO,
+  DEBUG,
+  VERBOSE,
+}
+
+const LEVEL_PREFIX: { [key in LogLevel]: string } = {
+  [LogLevel.NONE]: "",
+  [LogLevel.ERROR]: "err",
+  [LogLevel.WARN]: "wrn",
+  [LogLevel.INFO]: "inf",
+  [LogLevel.DEBUG]: "dbg",
+  [LogLevel.VERBOSE]: "vrb",
+};
+
+const LEVEL_COLOUR: { [key in LogLevel]: Colorize } = {
+  [LogLevel.NONE]: reset,
+  [LogLevel.ERROR]: red,
+  [LogLevel.WARN]: yellow,
+  [LogLevel.INFO]: green,
+  [LogLevel.DEBUG]: grey,
+  [LogLevel.VERBOSE]: (input) => dim(grey(input as any)) as any,
+};
+
+function prefixError(prefix: string, e: any): Error {
+  if (e.stack) {
+    return new Proxy(e, {
+      get(target, propertyKey, receiver) {
+        const value = Reflect.get(target, propertyKey, receiver);
+        return propertyKey === "stack" ? `${prefix}: ${value}` : value;
+      },
+    });
+  }
+  return e;
+}
+
+function dimInternalStackLine(line: string): string {
+  if (
+    line.startsWith("    at") &&
+    (!line.includes(cwd) || line.includes(cwdNodeModules))
+  ) {
+    return dim(line);
+  }
+  return line;
+}
+
+export interface LogOptions {
+  prefix?: string;
+  suffix?: string;
+}
+
+export class Log {
+  readonly #prefix: string;
+  readonly #suffix: string;
+
+  constructor(readonly level = LogLevel.INFO, opts: LogOptions = {}) {
+    const prefix = opts.prefix ?? "mf";
+    const suffix = opts.suffix ?? "";
+    // If prefix/suffix set, add colon at end/start
+    this.#prefix = prefix ? prefix + ":" : "";
+    this.#suffix = suffix ? ":" + suffix : "";
+  }
+
+  log(message: string): void {
+    console.log(message);
+  }
+
+  logWithLevel(level: LogLevel, message: string): void {
+    if (level <= this.level) {
+      const prefix = `[${this.#prefix}${LEVEL_PREFIX[level]}${this.#suffix}]`;
+      this.log(LEVEL_COLOUR[level](`${prefix} ${message}`));
+    }
+  }
+
+  error(message: Error): void {
+    if (this.level < LogLevel.ERROR) {
+      // Rethrow message if it won't get logged
+      throw message;
+    } else if (message.stack) {
+      // Dim internal stack trace lines to highlight user code
+      const lines = message.stack.split("\n").map(dimInternalStackLine);
+      this.logWithLevel(LogLevel.ERROR, lines.join("\n"));
+    } else {
+      this.logWithLevel(LogLevel.ERROR, message.toString());
+    }
+    if ((message as any).cause) {
+      this.error(prefixError("Cause", (message as any).cause));
+    }
+  }
+
+  warn(message: string): void {
+    this.logWithLevel(LogLevel.WARN, message);
+  }
+
+  info(message: string): void {
+    this.logWithLevel(LogLevel.INFO, message);
+  }
+
+  debug(message: string): void {
+    this.logWithLevel(LogLevel.DEBUG, message);
+  }
+
+  verbose(message: string): void {
+    this.logWithLevel(LogLevel.VERBOSE, message);
+  }
+}
+
+export class NoOpLog extends Log {
+  log(): void {}
+
+  error(message: Error): void {
+    throw message;
+  }
+}

--- a/packages/tre/test/plugins/kv/gateway.spec.ts
+++ b/packages/tre/test/plugins/kv/gateway.spec.ts
@@ -3,6 +3,7 @@ import {
   KVGateway,
   KVGatewayListOptions,
   MemoryStorage,
+  NoOpLog,
   Storage,
   StoredKeyMeta,
   StoredValueMeta,
@@ -26,7 +27,7 @@ const test = anyTest as TestFn<Context>;
 
 test.beforeEach((t) => {
   const storage = new MemoryStorage(undefined, testClock);
-  const gateway = new KVGateway(storage, testClock);
+  const gateway = new KVGateway(new NoOpLog(), storage, testClock);
   t.context = { storage, gateway };
 });
 

--- a/packages/tre/test/plugins/shared/router.spec.ts
+++ b/packages/tre/test/plugins/shared/router.spec.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import {
   GET,
   GatewayFactory,
+  NoOpLog,
   POST,
   RouteHandler,
   Router,
@@ -15,7 +16,8 @@ class TestGateway {
 
 class TestRouter extends Router<TestGateway> {
   constructor() {
-    super(new GatewayFactory(undefined, "test", TestGateway));
+    const log = new NoOpLog();
+    super(log, new GatewayFactory(log, undefined, "test", TestGateway));
   }
 
   @GET("/params/:foo/:bar")


### PR DESCRIPTION
This PR copies the `Log` implementation from Miniflare 2, and allows logging to be configured via the `log` shared option. Even though none of our gateways need a logger at the moment, I've added it in case we need it later.