### PR TITLE
Add support for built-in `workerd` services

### DIFF
--- a/packages/tre/README.md
+++ b/packages/tre/README.md
@@ -275,7 +275,7 @@ parameter in module format Workers.
   Record mapping binding name to paths containing arbitrary binary data to
   inject as `ArrayBuffer` bindings into this Worker.
 
-- `serviceBindings?: Record<string, string | (request: Request) => Awaitable<Response>>`
+- `serviceBindings?: Record<string, string | { network: Network } | { external: ExternalServer } | { disk: DiskDirectory } | (request: Request) => Awaitable<Response>>`
 
   Record mapping binding name to service designators to inject as
   `{ fetch: typeof fetch }`
@@ -284,10 +284,22 @@ parameter in module format Workers.
 
   - If the designator is a `string`, requests will be dispatched to the Worker
     with that `name`.
+  - If the designator is an object of the form `{ network: { ... } }`, where
+    `network` is a
+    [`workerd` `Network` struct](https://github.com/cloudflare/workerd/blob/bdbd6075c7c53948050c52d22f2dfa37bf376253/src/workerd/server/workerd.capnp#L555-L598),
+    requests will be dispatched according to the `fetch`ed URL.
+  - If the designator is an object of the form `{ external: { ... } }` where
+    `external` is a
+    [`workerd` `ExternalServer` struct](https://github.com/cloudflare/workerd/blob/bdbd6075c7c53948050c52d22f2dfa37bf376253/src/workerd/server/workerd.capnp#L504-L553),
+    requests will be dispatched to the specified remote server.
+  - If the designator is an object of the form `{ disk: { ... } }` where `disk`
+    is a
+    [`workerd` `DiskDirectory` struct](https://github.com/cloudflare/workerd/blob/bdbd6075c7c53948050c52d22f2dfa37bf376253/src/workerd/server/workerd.capnp#L600-L643),
+    requests will be dispatched to an HTTP service backed by an on-disk
+    directory.
   - If the designator is a function, requests will be dispatched to your custom
     handler. This allows you to access data and functions defined in Node.js
     from your Worker.
-    <!--TODO: other service types, disk, network, external, etc-->
 
 #### Cache
 

--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -478,7 +478,7 @@ export class Miniflare {
       const workerBindings: Worker_Binding[] = [];
       const additionalModules: Worker_Module[] = [];
       for (const [key, plugin] of PLUGIN_ENTRIES) {
-        const pluginBindings = await plugin.getBindings(workerOpts[key]);
+        const pluginBindings = await plugin.getBindings(workerOpts[key], i);
         if (pluginBindings !== undefined) {
           workerBindings.push(...pluginBindings);
 

--- a/packages/tre/src/plugins/core/services.ts
+++ b/packages/tre/src/plugins/core/services.ts
@@ -1,0 +1,83 @@
+import { Request, Response } from "undici";
+import { z } from "zod";
+import {
+  ExternalServer,
+  HttpOptions_Style,
+  TlsOptions_Version,
+} from "../../runtime";
+import { zAwaitable } from "../../shared";
+
+// Zod validators for types in runtime/config/workerd.ts.
+// All options should be optional except where specifically stated.
+// TODO: autogenerate these with runtime/config/workerd.ts from capnp
+
+export const HttpOptionsHeaderSchema = z.object({
+  name: z.string(), // name should be required
+  value: z.ostring(), // If omitted, the header will be removed
+});
+const HttpOptionsSchema = z.object({
+  style: z.nativeEnum(HttpOptions_Style).optional(),
+  forwardedProtoHeader: z.ostring(),
+  cfBlobHeader: z.ostring(),
+  injectRequestHeaders: HttpOptionsHeaderSchema.array().optional(),
+  injectResponseHeaders: HttpOptionsHeaderSchema.array().optional(),
+});
+
+const TlsOptionsKeypairSchema = z.object({
+  privateKey: z.ostring(),
+  certificateChain: z.ostring(),
+});
+
+const TlsOptionsSchema = z.object({
+  keypair: TlsOptionsKeypairSchema.optional(),
+  requireClientCerts: z.oboolean(),
+  trustBrowserCas: z.oboolean(),
+  trustedCertificates: z.string().array().optional(),
+  minVersion: z.nativeEnum(TlsOptions_Version).optional(),
+  cipherList: z.ostring(),
+});
+
+const NetworkSchema = z.object({
+  allow: z.string().array().optional(),
+  deny: z.string().array().optional(),
+  tlsOptions: TlsOptionsSchema.optional(),
+});
+
+export const ExternalServerSchema = z.intersection(
+  z.object({ address: z.string() }), // address should be required
+  z.union([
+    z.object({ http: z.optional(HttpOptionsSchema) }),
+    z.object({
+      https: z.optional(
+        z.object({
+          options: HttpOptionsSchema.optional(),
+          tlsOptions: TlsOptionsSchema.optional(),
+          certificateHost: z.ostring(),
+        })
+      ),
+    }),
+  ])
+) as z.ZodType<ExternalServer>;
+// This type cast is required for `api-extractor` to produce a `.d.ts` rollup.
+// Rather than outputting a `z.ZodIntersection<...>` for this type, it will
+// just use `z.ZodType<ExternalServer>`. Without this, the extractor process
+// just ends up pinned at 100% CPU. Probably unbounded recursion? I guess this
+// type is too complex? Something to investigate... :thinking_face:
+
+const DiskDirectorySchema = z.object({
+  path: z.string(), // path should be required
+  writable: z.oboolean(),
+});
+
+export const ServiceFetchSchema = z
+  .function()
+  .args(z.instanceof(Request))
+  .returns(zAwaitable(z.instanceof(Response)));
+
+export const ServiceDesignatorSchema = z.union([
+  z.string(),
+  z.object({ network: NetworkSchema }),
+  z.object({ external: ExternalServerSchema }),
+  z.object({ disk: DiskDirectorySchema }),
+  ServiceFetchSchema,
+]);

--- a/packages/tre/src/plugins/shared/index.ts
+++ b/packages/tre/src/plugins/shared/index.ts
@@ -26,7 +26,10 @@ export interface PluginBase<
   SharedOptions extends z.ZodType | undefined
 > {
   options: Options;
-  getBindings(options: z.infer<Options>): Awaitable<Worker_Binding[] | void>;
+  getBindings(
+    options: z.infer<Options>,
+    workerIndex: number
+  ): Awaitable<Worker_Binding[] | void>;
   getServices(
     options: PluginServicesOptions<Options, SharedOptions>
   ): Awaitable<Service[] | void>;

--- a/packages/tre/src/runtime/config/workerd.ts
+++ b/packages/tre/src/runtime/config/workerd.ts
@@ -132,9 +132,10 @@ export type Worker_DurableObjectNamespace = { className?: string } & (
   | { ephemeralLocal?: Void }
 );
 
-export type ExternalServer =
+export type ExternalServer = { address?: string } & (
   | { http: HttpOptions }
-  | { https: ExternalServer_Https };
+  | { https: ExternalServer_Https }
+);
 
 export interface ExternalServer_Https {
   options?: HttpOptions;


### PR DESCRIPTION
Specifically, this allows custom `network`, `external` and `disk` services to be specified as service bindings. Requests to `network` services are dispatched according to URL. Requests to `external` services are dispatched to the specified remote server. Requests to `disk` services are dispatched to an HTTP service backed by an on-disk directory.

This PR also fixes a bug where custom function service bindings with the same name in different Workers would dispatch all requests to the first Workers' function.