### PR TITLE
Fix accidental destructure of string binding names

### DIFF
--- a/packages/tre/src/plugins/shared/index.ts
+++ b/packages/tre/src/plugins/shared/index.ts
@@ -55,7 +55,7 @@ export function namespaceEntries(
   namespaces?: Record<string, string> | string[]
 ): [bindingName: string, id: string][] {
   if (Array.isArray(namespaces)) {
-    return namespaces.map(([bindingName]) => [bindingName, bindingName]);
+    return namespaces.map((bindingName) => [bindingName, bindingName]);
   } else if (namespaces !== undefined) {
     return Object.entries(namespaces);
   } else {


### PR DESCRIPTION
Hi!

Was just having a play around and I found a lil bug in the handling of simple `string[]`-style bindings in namespaceEntries. 

An extra pair of square brackets snuck in there, causing bindings like `r2Buckets: ['hello']` to bind as 'h' because the string is destructured like an array:
```js
> ['hello'].map(([x]) => [x, x])
[ [ 'h', 'h' ] ] 
```

Types didn't catch it 'cause technically that's a super chill and valid thing to do with your string arguments 🤷‍♂️