### PR TITLE
Fix WSL support, closes cloudflare/wrangler2#2243

### DIFF
--- a/packages/tre/lib/docker-restart.sh
+++ b/packages/tre/lib/docker-restart.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Restarts a process on receiving SIGUSR1.
 # Usage: ./restart.sh <command> <...args>
+set -eo pipefail
 
 # Start process and record its PID
 "$@" &

--- a/packages/tre/lib/wsl-restart.sh
+++ b/packages/tre/lib/wsl-restart.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Wraps a process with commands for restarting/stopping.
+# We can't use signals here as this script will be started by wsl.exe
+# which doesn't pass them through correctly.
+# Usage: ./wsl-restart.sh <command> <...args>
+set -eo pipefail
+
+# Start process and log its PID
+"$@" &
+PID=$!
+echo "[*] Started $PID"
+
+while read LINE
+do
+  if [[ $LINE = "restart" ]]; then
+    # Kill existing process...
+    kill -TERM $PID
+    # ...and start a new one
+    "$@" &
+    PID=$!
+    echo "[*] Restarted $PID"
+  elif [[ $LINE = "exit" ]]; then
+    # Kill existing process
+    kill -TERM $PID
+    exit 0
+  fi
+done

--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -265,7 +265,13 @@ export class Miniflare {
     };
     this.#runtime = new this.#runtimeConstructor(opts);
     this.#removeRuntimeExitHook = exitHook(() => void this.#runtime?.dispose());
-    this.#runtimeEntryURL = new URL(`http://127.0.0.1:${opts.entryPort}`);
+
+    const accessibleHost =
+      this.#runtime.accessibleHostOverride ??
+      (host === "*" || host === "0.0.0.0" ? "127.0.0.1" : host);
+    this.#runtimeEntryURL = new URL(
+      `http://${accessibleHost}:${opts.entryPort}`
+    );
 
     const config = await this.#assembleConfig();
     assert(config !== undefined);
@@ -604,7 +610,7 @@ export class Miniflare {
     } finally {
       // Cleanup as much as possible even if `#init()` threw
       this.#removeRuntimeExitHook?.();
-      this.#runtime?.dispose();
+      await this.#runtime?.dispose();
       await this.#stopLoopbackServer();
     }
   }


### PR DESCRIPTION
Previously, Miniflare passed Windows paths to WSL, without first converting them to WSL-friendly `/mnt/...` paths. This PR fixes that, WSL detection, and also adds a new restart script similar to the Docker runtime to massively reduce script-reload time.