### PR TITLE
Disable `shell: true` when using `NativeRuntime`

### DIFF
--- a/packages/tre/src/runtime/index.ts
+++ b/packages/tre/src/runtime/index.ts
@@ -119,7 +119,6 @@ class NativeRuntime extends Runtime {
     // 2. Start new process
     const runtimeProcess = childProcess.spawn(this.#command, this.#args, {
       stdio: "pipe",
-      shell: true,
     });
     this.#process = runtimeProcess;
     this.#processExitPromise = waitForExit(runtimeProcess);


### PR DESCRIPTION
When `dispose()`ing a `NativeRuntime`, I've observed the `workerd` process not being terminated properly with this option enabled. We don't actually need it, since we're specifying an absolute path to the `workerd` binary anyway.

From a user-perspective, this will help fix issues in Wrangler where reloading crashes with a port-in-use error, or where pressing 'x' doesn't actually exit.