### PR TITLE
Log uncaught source-mapped errors to the console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -432,6 +432,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/source-map-support": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==",
+      "dev": true,
+      "dependencies": {
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/@types/stoppable": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/stoppable/-/stoppable-1.1.1.tgz",
@@ -1135,6 +1144,11 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -4644,6 +4658,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -5846,7 +5869,7 @@
         "glob-to-regexp": "^0.4.1",
         "http-cache-semantics": "^4.1.0",
         "kleur": "^4.1.5",
-        "source-map": "^0.7.4",
+        "source-map-support": "0.5.21",
         "stoppable": "^1.1.0",
         "undici": "^5.12.0",
         "workerd": "^1.20221111.5",
@@ -5860,6 +5883,7 @@
         "@types/estree": "^1.0.0",
         "@types/glob-to-regexp": "^0.4.1",
         "@types/http-cache-semantics": "^4.0.1",
+        "@types/source-map-support": "^0.5.6",
         "@types/stoppable": "^1.1.1",
         "@types/ws": "^8.5.3"
       },
@@ -5876,14 +5900,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/tre/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "packages/watcher": {
@@ -6090,6 +6106,7 @@
         "@types/estree": "^1.0.0",
         "@types/glob-to-regexp": "^0.4.1",
         "@types/http-cache-semantics": "^4.0.1",
+        "@types/source-map-support": "^0.5.6",
         "@types/stoppable": "^1.1.1",
         "@types/ws": "^8.5.3",
         "acorn": "^8.8.0",
@@ -6101,7 +6118,7 @@
         "glob-to-regexp": "^0.4.1",
         "http-cache-semantics": "^4.1.0",
         "kleur": "^4.1.5",
-        "source-map": "^0.7.4",
+        "source-map-support": "0.5.21",
         "stoppable": "^1.1.0",
         "undici": "^5.12.0",
         "workerd": "^1.20221111.5",
@@ -6114,11 +6131,6 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
           "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
-        },
-        "source-map": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
         }
       }
     },
@@ -6285,6 +6297,15 @@
       "requires": {
         "@types/glob": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/source-map-support": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.0"
       }
     },
     "@types/stoppable": {
@@ -6751,6 +6772,11 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "busboy": {
       "version": "1.6.0",
@@ -9259,6 +9285,15 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/packages/tre/package.json
+++ b/packages/tre/package.json
@@ -35,7 +35,7 @@
     "glob-to-regexp": "^0.4.1",
     "http-cache-semantics": "^4.1.0",
     "kleur": "^4.1.5",
-    "source-map": "^0.7.4",
+    "source-map-support": "0.5.21",
     "stoppable": "^1.1.0",
     "undici": "^5.12.0",
     "workerd": "^1.20221111.5",
@@ -49,6 +49,7 @@
     "@types/estree": "^1.0.0",
     "@types/glob-to-regexp": "^0.4.1",
     "@types/http-cache-semantics": "^4.0.1",
+    "@types/source-map-support": "^0.5.6",
     "@types/stoppable": "^1.1.1",
     "@types/ws": "^8.5.3"
   },

--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -360,7 +360,11 @@ export class Miniflare {
       const workerSrcOpts = this.#workerOpts.map<SourceOptions>(
         ({ core }) => core
       );
-      response = await handlePrettyErrorRequest(workerSrcOpts, request);
+      response = await handlePrettyErrorRequest(
+        this.#log,
+        workerSrcOpts,
+        request
+      );
     } else {
       // TODO: check for proxying/outbound fetch header first (with plans for fetch mocking)
       response = await this.#handleLoopbackPlugins(request, url);

--- a/packages/tre/src/plugins/core/errors/callsite.ts
+++ b/packages/tre/src/plugins/core/errors/callsite.ts
@@ -1,0 +1,157 @@
+// Lifted from `node-stack-trace`:
+// https://github.com/felixge/node-stack-trace/blob/4c41a4526e74470179b3b6dd5d75191ca8c56c17/index.js
+// Ideally, we'd just use this package as-is, but it has a strict
+// `engines.node == 16` constraint in its `package.json`. There's a PR open to
+// fix this (https://github.com/felixge/node-stack-trace/pull/39), but it's been
+// open for a while. As soon as it's merged, we should just depend on it.
+
+/*!
+ * Copyright (c) 2011 Felix Geisendörfer (felix@debuggable.com)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+export function parseStack(stack: string): CallSite[] {
+  return stack
+    .split("\n")
+    .slice(1)
+    .map(parseCallSite)
+    .filter((site): site is CallSite => site !== undefined);
+}
+
+function parseCallSite(line: string): CallSite | undefined {
+  const lineMatch = line.match(
+    /at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/
+  );
+  if (!lineMatch) {
+    return;
+  }
+
+  let object = null;
+  let method = null;
+  let functionName = null;
+  let typeName = null;
+  let methodName = null;
+  const isNative = lineMatch[5] === "native";
+
+  if (lineMatch[1]) {
+    functionName = lineMatch[1];
+    let methodStart = functionName.lastIndexOf(".");
+    if (functionName[methodStart - 1] == ".") methodStart--;
+    if (methodStart > 0) {
+      object = functionName.substring(0, methodStart);
+      method = functionName.substring(methodStart + 1);
+      const objectEnd = object.indexOf(".Module");
+      if (objectEnd > 0) {
+        functionName = functionName.substring(objectEnd + 1);
+        object = object.substring(0, objectEnd);
+      }
+    }
+  }
+
+  if (method) {
+    typeName = object;
+    methodName = method;
+  }
+
+  if (method === "<anonymous>") {
+    methodName = null;
+    functionName = null;
+  }
+
+  return new CallSite({
+    typeName,
+    functionName,
+    methodName,
+    fileName: lineMatch[2] || null,
+    lineNumber: parseInt(lineMatch[3]) || null,
+    columnNumber: parseInt(lineMatch[4]) || null,
+    native: isNative,
+  });
+}
+
+export interface CallSiteOptions {
+  typeName: string | null;
+  functionName: string | null;
+  methodName: string | null;
+  fileName: string | null;
+  lineNumber: number | null;
+  columnNumber: number | null;
+  native: boolean;
+}
+
+// https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+// This class supports the subset of options implemented by `node-stack-trace`:
+// https://github.com/felixge/node-stack-trace/blob/4c41a4526e74470179b3b6dd5d75191ca8c56c17/index.js
+export class CallSite implements NodeJS.CallSite {
+  constructor(private readonly opts: CallSiteOptions) {}
+
+  getThis(): unknown {
+    return null;
+  }
+  getTypeName(): string | null {
+    return this.opts.typeName;
+  }
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  getFunction(): Function | undefined {
+    return undefined;
+  }
+  getFunctionName(): string | null {
+    return this.opts.functionName;
+  }
+  getMethodName(): string | null {
+    return this.opts.methodName;
+  }
+  getFileName(): string | null {
+    return this.opts.fileName;
+  }
+  getLineNumber(): number | null {
+    return this.opts.lineNumber;
+  }
+  getColumnNumber(): number | null {
+    return this.opts.columnNumber;
+  }
+  getEvalOrigin(): string | undefined {
+    return undefined;
+  }
+  isToplevel(): boolean {
+    return false;
+  }
+  isEval(): boolean {
+    return false;
+  }
+  isNative(): boolean {
+    return this.opts.native;
+  }
+  isConstructor(): boolean {
+    return false;
+  }
+  isAsync(): boolean {
+    return false;
+  }
+  isPromiseAll(): boolean {
+    return false;
+  }
+  isPromiseAny(): boolean {
+    return false;
+  }
+  getPromiseIndex(): number | null {
+    return null;
+  }
+}

--- a/packages/tre/src/plugins/core/errors/sourcemap.ts
+++ b/packages/tre/src/plugins/core/errors/sourcemap.ts
@@ -1,0 +1,66 @@
+import assert from "assert";
+import type { Options } from "source-map-support";
+import { parseStack } from "./callsite";
+
+const sourceMapInstallBaseOptions: Options = {
+  environment: "node",
+  // Don't add Node `uncaughtException` handler
+  handleUncaughtExceptions: false,
+  // Don't hook Node `require` function
+  hookRequire: false,
+
+  // Make sure we're using fresh copies of files (i.e. between `setOptions()`)
+  emptyCacheBetweenOperations: true,
+
+  // Always remove existing retrievers when calling `install()`, we should be
+  // specifying them each time we want to source map
+  overrideRetrieveFile: true,
+  overrideRetrieveSourceMap: true,
+};
+
+// Returns the source-mapped stack trace for the specified error, using the
+// specified function for retrieving source-maps.
+export type SourceMapper = (
+  retrieveSourceMap: Options["retrieveSourceMap"],
+  error: Error
+) => string;
+
+let sourceMapper: SourceMapper;
+export function getSourceMapper(): SourceMapper {
+  if (sourceMapper !== undefined) return sourceMapper;
+
+  // `source-map-support` will only modify `Error.prepareStackTrace` if this is
+  // the first time `install()` has been called. This is governed by a module
+  // level variable: `errorFormatterInstalled`. To ensure we're not affecting
+  // external user's use of this package, and so `Error.prepareStackTrace` is
+  // always updated, load a fresh copy, by resetting then restoring the
+  // `require` cache.
+
+  const originalSupport = require.cache["source-map-support"];
+  delete require.cache["source-map-support"];
+  const support: typeof import("source-map-support") = require("source-map-support");
+  require.cache["source-map-support"] = originalSupport;
+
+  const originalPrepareStackTrace = Error.prepareStackTrace;
+  support.install(sourceMapInstallBaseOptions);
+  const prepareStackTrace = Error.prepareStackTrace;
+  assert(prepareStackTrace !== undefined);
+  Error.prepareStackTrace = originalPrepareStackTrace;
+
+  sourceMapper = (retrieveSourceMap, error) => {
+    support.install({
+      ...sourceMapInstallBaseOptions,
+      retrieveFile(file: string): string | null {
+        // `retrieveFile` should only be called by the default implementation of
+        // `retrieveSourceMap`, so we shouldn't need to implement it
+        assert.fail(`Unexpected retrieveFile(${JSON.stringify(file)}) call`);
+      },
+      retrieveSourceMap,
+    });
+
+    // Parse the stack trace into structured call sites and source-map them
+    const callSites = parseStack(error.stack ?? "");
+    return prepareStackTrace(error, callSites);
+  };
+  return sourceMapper;
+}

--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -17,6 +17,7 @@ import {
   CloudflareFetchSchema,
   Plugin,
 } from "../shared";
+import { HEADER_ERROR_STACK } from "./errors";
 import {
   ModuleDefinitionSchema,
   ModuleLocator,
@@ -24,7 +25,6 @@ import {
   buildStringScriptPath,
   convertModuleDefinition,
 } from "./modules";
-import { HEADER_ERROR_STACK } from "./prettyerror";
 import { ServiceDesignatorSchema } from "./services";
 
 const encoder = new TextEncoder();
@@ -473,5 +473,5 @@ function getWorkerScript(
   }
 }
 
-export * from "./prettyerror";
+export * from "./errors";
 export * from "./services";


### PR DESCRIPTION
Previously, errors _thrown_ using the `MF-Experimental-Error-Stack` header were only shown in a pretty-error page. This PR logs those errors with source-maps applied to the console too, using the `source-map-support` package. This simplifies our code, and also means we don't need to touch internal Youch methods, as the errors we pass to Youch are already source-mapped.