### PR TITLE
Cache API tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20221111.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20221111.1.tgz",
+      "integrity": "sha512-BNV2wN8V6Zduvo7UzxcdjBbLQ906D2KhS804PDufLgx/sanGJCHVJMOIaLvS/b61JKtot1U7P/l1fjrjZ7/E3A==",
+      "dev": true
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
@@ -5079,17 +5085,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
-      "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=12.18"
-      }
-    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -5871,13 +5866,14 @@
         "kleur": "^4.1.5",
         "source-map-support": "0.5.21",
         "stoppable": "^1.1.0",
-        "undici": "^5.12.0",
+        "undici": "^5.13.0",
         "workerd": "^1.20221111.5",
         "ws": "^8.11.0",
         "youch": "^3.2.2",
         "zod": "^3.18.0"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20221111.1",
         "@types/better-sqlite3": "^7.6.2",
         "@types/debug": "^4.1.7",
         "@types/estree": "^1.0.0",
@@ -5900,6 +5896,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/tre/node_modules/undici": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.13.0.tgz",
+      "integrity": "sha512-UDZKtwb2k7KRsK4SdXWG7ErXiL7yTGgLWvk2AXO1JMjgjh404nFo6tWSCM2xMpJwMPx3J8i/vfqEh1zOqvj82Q==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "packages/watcher": {
@@ -5979,6 +5986,12 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20221111.5.tgz",
       "integrity": "sha512-21IZ44ZnW6PvE6oT/UWstHazAF0nZOiprsbxu0NHnrLgsdSjSsKt7nWfLr/R/6DzKcYYdnQs8btgvKIvI8kChQ==",
       "optional": true
+    },
+    "@cloudflare/workers-types": {
+      "version": "4.20221111.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20221111.1.tgz",
+      "integrity": "sha512-BNV2wN8V6Zduvo7UzxcdjBbLQ906D2KhS804PDufLgx/sanGJCHVJMOIaLvS/b61JKtot1U7P/l1fjrjZ7/E3A==",
+      "dev": true
     },
     "@eslint/eslintrc": {
       "version": "1.0.5",
@@ -6101,6 +6114,7 @@
     "@miniflare/tre": {
       "version": "file:packages/tre",
       "requires": {
+        "@cloudflare/workers-types": "^4.20221111.1",
         "@types/better-sqlite3": "^7.6.2",
         "@types/debug": "^4.1.7",
         "@types/estree": "^1.0.0",
@@ -6120,7 +6134,7 @@
         "kleur": "^4.1.5",
         "source-map-support": "0.5.21",
         "stoppable": "^1.1.0",
-        "undici": "^5.12.0",
+        "undici": "^5.13.0",
         "workerd": "^1.20221111.5",
         "ws": "^8.11.0",
         "youch": "^3.2.2",
@@ -6131,6 +6145,14 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
           "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
+        },
+        "undici": {
+          "version": "5.13.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.13.0.tgz",
+          "integrity": "sha512-UDZKtwb2k7KRsK4SdXWG7ErXiL7yTGgLWvk2AXO1JMjgjh404nFo6tWSCM2xMpJwMPx3J8i/vfqEh1zOqvj82Q==",
+          "requires": {
+            "busboy": "^1.6.0"
+          }
         }
       }
     },
@@ -9595,14 +9617,6 @@
         "has-bigints": "^1.0.1",
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
-      }
-    },
-    "undici": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
-      "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
-      "requires": {
-        "busboy": "^1.6.0"
       }
     },
     "universalify": {

--- a/packages/tre/package.json
+++ b/packages/tre/package.json
@@ -37,13 +37,14 @@
     "kleur": "^4.1.5",
     "source-map-support": "0.5.21",
     "stoppable": "^1.1.0",
-    "undici": "^5.12.0",
+    "undici": "^5.13.0",
     "workerd": "^1.20221111.5",
     "ws": "^8.11.0",
     "youch": "^3.2.2",
     "zod": "^3.18.0"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20221111.1",
     "@types/better-sqlite3": "^7.6.2",
     "@types/debug": "^4.1.7",
     "@types/estree": "^1.0.0",

--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -46,6 +46,7 @@ import {
   serializeConfig,
 } from "./runtime";
 import {
+  Clock,
   HttpError,
   Log,
   MiniflareCoreError,
@@ -54,6 +55,7 @@ import {
   OptionalZodTypeOf,
   UnionToIntersection,
   ValueOf,
+  defaultClock,
 } from "./shared";
 import { anyAbortSignal } from "./shared/signal";
 import { waitForRequest } from "./wait";
@@ -157,6 +159,7 @@ export class Miniflare {
   #sharedOpts: PluginSharedOptions;
   #workerOpts: PluginWorkerOptions[];
   #log: Log;
+  readonly #clock: Clock;
 
   readonly #runtimeConstructor: RuntimeConstructor;
   #runtime?: Runtime;
@@ -201,6 +204,7 @@ export class Miniflare {
     this.#sharedOpts = sharedOpts;
     this.#workerOpts = workerOpts;
     this.#log = this.#sharedOpts.core.log ?? new NoOpLog();
+    this.#clock = this.#sharedOpts.core.clock ?? defaultClock;
     this.#initPlugins();
 
     // Get supported shell for executing runtime binary
@@ -220,6 +224,7 @@ export class Miniflare {
       if (plugin.gateway !== undefined && plugin.router !== undefined) {
         const gatewayFactory = new GatewayFactory<any>(
           this.#log,
+          this.#clock,
           this.#sharedOpts.core.cloudflareFetch,
           key,
           plugin.gateway,

--- a/packages/tre/src/plugins/cache/gateway.ts
+++ b/packages/tre/src/plugins/cache/gateway.ts
@@ -207,11 +207,12 @@ export class CacheGateway {
     private readonly clock: Clock
   ) {}
 
-  async match(request: Request): Promise<Response> {
+  async match(request: Request, cacheKey?: string): Promise<Response> {
     // Never cache Workers Sites requests, so we always return on-disk files
     if (isSitesRequest(request)) throw new CacheMiss();
 
-    const cached = await this.storage.get<CacheMetadata>(request.url);
+    cacheKey ??= request.url;
+    const cached = await this.storage.get<CacheMetadata>(cacheKey);
     if (cached?.metadata === undefined) throw new CacheMiss();
 
     const response = new CacheResponse(
@@ -228,7 +229,11 @@ export class CacheGateway {
     );
   }
 
-  async put(request: Request, value: ArrayBuffer): Promise<Response> {
+  async put(
+    request: Request,
+    value: ArrayBuffer,
+    cacheKey?: string
+  ): Promise<Response> {
     // Never cache Workers Sites requests, so we always return on-disk files
     if (isSitesRequest(request)) return new Response(null, { status: 204 });
 
@@ -246,7 +251,8 @@ export class CacheGateway {
       throw new StorageFailure();
     }
 
-    await this.storage.put<CacheMetadata>(request.url, {
+    cacheKey ??= request.url;
+    await this.storage.put<CacheMetadata>(cacheKey, {
       value: response.body,
       expiration: millisToSeconds(this.clock() + expiration),
       metadata: {
@@ -257,8 +263,9 @@ export class CacheGateway {
     return new Response(null, { status: 204 });
   }
 
-  async delete(request: Request): Promise<Response> {
-    const deleted = await this.storage.delete(request.url);
+  async delete(request: Request, cacheKey?: string): Promise<Response> {
+    cacheKey ??= request.url;
+    const deleted = await this.storage.delete(cacheKey);
     // This is an extremely vague error, but it fits with what the cache API in workerd expects
     if (!deleted) throw new PurgeFailure();
     return new Response(null);

--- a/packages/tre/src/plugins/cache/index.ts
+++ b/packages/tre/src/plugins/cache/index.ts
@@ -97,3 +97,4 @@ export const CACHE_PLUGIN: Plugin<
 };
 
 export * from "./gateway";
+export * from "./range";

--- a/packages/tre/src/plugins/cache/router.ts
+++ b/packages/tre/src/plugins/cache/router.ts
@@ -24,6 +24,98 @@ function decodeNamespace(headers: Headers) {
   return namespace === null ? `default` : `named:${namespace}`;
 }
 
+const CR = "\r".charCodeAt(0);
+const LF = "\n".charCodeAt(0);
+
+// Remove `Transfer-Encoding: chunked` header from the HTTP `message` if it
+// exists. Why do we need to do this?
+//
+// With the following code:
+//
+// ```js
+// const { readable, writable } = new IdentityTransformStream();
+// const encoder = new TextEncoder();
+// const writer = writable.getWriter();
+// void writer.write(encoder.encode("hello"));
+// void writer.write(encoder.encode("world"));
+// void writer.close();
+// const response = new Response(readable, {
+//   headers: { "Cache-Control": "max-age=3600" },
+// });
+// await caches.default.put(key, response);
+// ```
+//
+// ...the Miniflare loopback server will receive the following HTTP request:
+//
+// ```http
+// PUT / HTTP/1.1
+// Transfer-Encoding: chunked
+// Host: localhost
+//
+// 4c
+// HTTP/1.1 200 OK
+// Transfer-Encoding: chunked
+// Cache-Control: max-age=3600
+//
+//
+// 5
+// hello
+// 5
+// world
+// 0
+// ```
+//
+// The body of this request (what the `body` variable here stores) will be:
+//
+// ```http
+// HTTP/1.1 200 OK
+// Transfer-Encoding: chunked
+// Cache-Control: max-age=3600
+//
+//
+// helloworld
+// ```
+//
+// ...which is invalid `chunked` `Transfer-Encoding`
+// (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding#directives)
+// as there aren't any chunk lengths. This is working as intended, as the
+// internal version of the cache gateway API wants responses in this format.
+// However, the `llhttp` (https://github.com/nodejs/llhttp) parser used by
+// `undici` will throw on receiving this.
+//
+// Therefore, we just remove the `Transfer-Encoding: chunked` header. We never
+// reuse sockets when parsing HTTP requests, so we don't need to worry about
+// delimiting HTTP messages.
+function removeTransferEncodingChunked(message: Buffer): Buffer {
+  // Split headers from the body by looking for the first instance of
+  // "\r\n\r\n" signifying end-of-headers
+  const endOfHeadersIndex = message.findIndex(
+    (_value, index) =>
+      message[index] === CR &&
+      message[index + 1] === LF &&
+      message[index + 2] === CR &&
+      message[index + 3] === LF
+  );
+  if (endOfHeadersIndex !== -1) {
+    // `subarray` returns a new `Buffer` that references the original memory
+    const headers = message.subarray(0, endOfHeadersIndex).toString();
+    // Try to remove case-insensitive `Transfer-Encoding: chunked` header.
+    // Might be last header so may not have trailing "\r\n" (only `subarray`ing)
+    // up to "\r\n\r\n", so match "\r\n" at the start.
+    const replaced = headers.replace(/\r\nTransfer-Encoding: chunked/i, "");
+    if (headers.length !== replaced.length) {
+      // If we removed something, replace the message with a concatenation of
+      // the new headers and the body
+      message = Buffer.concat([
+        Buffer.from(replaced),
+        message.subarray(endOfHeadersIndex),
+      ]);
+    }
+  }
+  return message;
+}
+
+// noinspection DuplicatedCode
 export class CacheRouter extends Router<CacheGateway> {
   #warnedUsage = false;
   #maybeWarnUsage(headers: Headers) {
@@ -55,8 +147,10 @@ export class CacheRouter extends Router<CacheGateway> {
     const persist = decodePersist(req.headers);
     const cf = decodeCfBlob(req.headers);
     const gateway = this.gatewayFactory.get(namespace, persist);
+    const bodyBuffer = Buffer.from(await req.arrayBuffer());
+    const bodyArray = new Uint8Array(removeTransferEncodingChunked(bodyBuffer));
     const key = new Request(uri, { ...(req as RequestInit), body: undefined });
-    return fallible(gateway.put(key, await req.arrayBuffer(), cf.cacheKey));
+    return fallible(gateway.put(key, bodyArray, cf.cacheKey));
   };
 
   @PURGE("/:uri")

--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -15,6 +15,7 @@ import { getCacheServiceName } from "../cache";
 import {
   BINDING_SERVICE_LOOPBACK,
   CloudflareFetchSchema,
+  HEADER_CF_BLOB,
   Plugin,
 } from "../shared";
 import { HEADER_ERROR_STACK } from "./errors";
@@ -338,7 +339,10 @@ export const CORE_PLUGIN: Plugin<
       });
     }
     const services: Service[] = [
-      { name: SERVICE_LOOPBACK, external: { http: {} } },
+      {
+        name: SERVICE_LOOPBACK,
+        external: { http: { cfBlobHeader: HEADER_CF_BLOB } },
+      },
       {
         name: SERVICE_ENTRY,
         worker: {

--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -65,6 +65,7 @@ export const CoreSharedOptionsSchema = z.object({
   verbose: z.boolean().optional(),
 
   log: z.instanceof(Log).optional(),
+  clock: z.function().returns(z.number()).optional(),
   cloudflareFetch: CloudflareFetchSchema.optional(),
 
   // TODO: add back validation of cf object

--- a/packages/tre/src/plugins/shared/constants.ts
+++ b/packages/tre/src/plugins/shared/constants.ts
@@ -1,3 +1,4 @@
+import type { RequestInitCfProperties } from "@cloudflare/workers-types";
 import { Headers } from "undici";
 import { Worker_Binding } from "../../runtime";
 import { Persistence, PersistenceSchema } from "./gateway";
@@ -5,6 +6,10 @@ import { Persistence, PersistenceSchema } from "./gateway";
 export const SOCKET_ENTRY = "entry";
 
 export const HEADER_PERSIST = "MF-Persist";
+// Even though we inject the `cf` blob in the entry script, we still need to
+// specify a header, so we receive things like `cf.cacheKey` in loopback
+// requests.
+export const HEADER_CF_BLOB = "MF-CF-Blob";
 
 export const BINDING_SERVICE_LOOPBACK = "MINIFLARE_LOOPBACK";
 export const BINDING_TEXT_PLUGIN = "MINIFLARE_PLUGIN";
@@ -33,6 +38,11 @@ export function decodePersist(headers: Headers): Persistence {
   return header === null
     ? undefined
     : PersistenceSchema.parse(JSON.parse(header));
+}
+
+export function decodeCfBlob(headers: Headers): RequestInitCfProperties {
+  const header = headers.get(HEADER_CF_BLOB);
+  return header === null ? {} : JSON.parse(header);
 }
 
 export enum CfHeader {

--- a/packages/tre/src/shared/log.ts
+++ b/packages/tre/src/shared/log.ts
@@ -31,7 +31,7 @@ const LEVEL_COLOUR: { [key in LogLevel]: Colorize } = {
   [LogLevel.VERBOSE]: (input) => dim(grey(input as any)) as any,
 };
 
-function prefixError(prefix: string, e: any): Error {
+export function prefixError(prefix: string, e: any): Error {
   if (e.stack) {
     return new Proxy(e, {
       get(target, propertyKey, receiver) {

--- a/packages/tre/test/index.ts
+++ b/packages/tre/test/index.ts
@@ -1,0 +1,114 @@
+import {
+  ExecutionContext,
+  ServiceWorkerGlobalScope,
+  Request as WorkerRequest,
+  Response as WorkerResponse,
+} from "@cloudflare/workers-types";
+import {
+  Awaitable,
+  Log,
+  LogLevel,
+  Miniflare,
+  MiniflareOptions,
+} from "@miniflare/tre";
+import anyTest, { TestFn } from "ava";
+import { ModuleDefinition } from "../src/plugins/core/modules";
+
+export type LogEntry = [level: LogLevel, message: string];
+export class TestLog extends Log {
+  logs: LogEntry[] = [];
+
+  constructor() {
+    super(LogLevel.VERBOSE);
+  }
+
+  log(message: string): void {
+    this.logs.push([LogLevel.NONE, message]);
+  }
+
+  logWithLevel(level: LogLevel, message: string): void {
+    this.logs.push([level, message]);
+  }
+
+  error(message: Error): void {
+    throw message;
+  }
+
+  logsAtLevel(level: LogLevel): string[] {
+    return this.logs
+      .filter(([logLevel]) => logLevel === level)
+      .map(([, message]) => message);
+  }
+}
+
+export type TestMiniflareHandler<Env> = (
+  global: ServiceWorkerGlobalScope,
+  request: WorkerRequest,
+  env: Env,
+  ctx: ExecutionContext
+) => Awaitable<WorkerResponse>;
+
+export interface TestClock {
+  timestamp: number;
+}
+
+type MiniflareOptionsWithoutScripts = Exclude<
+  MiniflareOptions,
+  "script" | "scriptPath" | "modules" | "modulesRoot"
+>;
+
+interface MiniflareTestContext {
+  mf: Miniflare;
+  url: URL;
+
+  // Warning: if mutating or calling any of the following, `test.serial` must be
+  // used to prevent races.
+  log: TestLog;
+  clock: TestClock;
+  setOptions(opts: MiniflareOptionsWithoutScripts): Promise<void>;
+}
+const test = anyTest as TestFn<MiniflareTestContext>;
+
+export function miniflareTest<Env>(
+  handler: TestMiniflareHandler<Env>,
+  userOpts?: MiniflareOptionsWithoutScripts
+): TestFn<MiniflareTestContext> {
+  const script = `
+    const handler = (${handler.toString()});
+    export default {
+      async fetch(request, env, ctx) {
+        try {
+          return handler(globalThis, request, env, ctx);
+        } catch (e) {
+          return new Response(e?.stack ?? String(e), { status: 500 });
+        } 
+      }
+    }
+  `;
+
+  test.before(async (t) => {
+    const log = new TestLog();
+    const clock: TestClock = { timestamp: 1_000_000 }; // 1000s
+    const clockFunction = () => clock.timestamp;
+
+    const modules: ModuleDefinition[] = [
+      { type: "ESModule", path: "index.mjs", contents: script },
+    ];
+
+    const opts: MiniflareOptions = {
+      log,
+      clock: clockFunction,
+      verbose: true,
+      modules,
+    };
+
+    t.context.mf = new Miniflare({ ...userOpts, ...opts });
+    t.context.log = log;
+    t.context.clock = clock;
+    t.context.setOptions = (userOpts) =>
+      t.context.mf.setOptions({ ...userOpts, ...opts });
+    t.context.url = await t.context.mf.ready;
+  });
+  test.after((t) => t.context.mf.dispose());
+  return test;
+}

--- a/packages/tre/test/plugins/cache/index.spec.ts
+++ b/packages/tre/test/plugins/cache/index.spec.ts
@@ -1,0 +1,476 @@
+import crypto from "crypto";
+import path from "path";
+import { FileStorage, HeadersInit, LogLevel } from "@miniflare/tre";
+import { miniflareTest } from "../../index";
+import { useTmp, utf8Encode } from "../../storage/helpers";
+
+const test = miniflareTest(async (global, req) => {
+  // Sort headers
+  let name: string | undefined;
+  let cfCacheKey: string | undefined;
+  let bufferPut = false;
+  const reqHeaders = new global.Headers();
+  const resHeaders = new global.Headers();
+  for (const [key, value] of req.headers) {
+    const lowerKey = key.toLowerCase();
+    if (lowerKey === "test-cache-name") {
+      name = value;
+    } else if (lowerKey === "test-cf-cache-key") {
+      cfCacheKey = value;
+    } else if (lowerKey === "test-buffer") {
+      bufferPut = true;
+    } else if (lowerKey.startsWith("test-response-")) {
+      resHeaders.set(lowerKey.substring("test-response-".length), value);
+    } else {
+      reqHeaders.set(lowerKey, value);
+    }
+  }
+
+  // Get cache and cache key
+  const cache =
+    name === undefined ? global.caches.default : await global.caches.open(name);
+  const key = new global.Request(req.url, {
+    headers: reqHeaders,
+    cf: cfCacheKey === undefined ? undefined : { cacheKey: cfCacheKey },
+  });
+
+  // Perform cache operation
+  if (req.method === "GET") {
+    const cachedRes = await cache.match(key);
+    return cachedRes ?? new global.Response("<miss>", { status: 404 });
+  } else if (req.method === "PUT") {
+    const body = bufferPut ? await req.arrayBuffer() : req.body;
+    const res = new global.Response(body, { headers: resHeaders });
+    await cache.put(key, res);
+    return new global.Response(null, { status: 204 });
+  } else if (req.method === "DELETE") {
+    const deleted = await cache.delete(key);
+    return new global.Response(null, { status: deleted ? 204 : 404 });
+  } else {
+    return new global.Response(null, { status: 405 });
+  }
+});
+
+test("match returns cached responses", async (t) => {
+  const key = "http://localhost/cache-hit";
+
+  // Check caching stream body
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: {
+      "Test-Response-Cache-Control": "max-age=3600",
+      "Test-Response-X-Key": "value",
+    },
+    body: "body",
+  });
+  let res = await t.context.mf.dispatchFetch(key);
+  t.is(res.status, 200);
+  t.is(res.headers.get("Cache-Control"), "max-age=3600");
+  t.is(res.headers.get("CF-Cache-Status"), "HIT");
+  t.is(res.headers.get("X-Key"), "value"); // Check custom headers stored
+  t.is(await res.text(), "body");
+
+  // Check caching binary streamed body
+  const array = new Uint8Array([1, 2, 3]);
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: { "Test-Response-Cache-Control": "max-age=3600" },
+    body: array,
+  });
+  res = await t.context.mf.dispatchFetch(key);
+  t.is(res.status, 200);
+  t.deepEqual(new Uint8Array(await res.arrayBuffer()), array);
+
+  // Check caching buffered body
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: {
+      "Test-Buffer": "1",
+      "Test-Response-Cache-Control": "max-age=3600",
+    },
+    body: "body",
+  });
+  res = await t.context.mf.dispatchFetch(key);
+  t.is(res.status, 200);
+  t.is(await res.text(), "body");
+});
+test("match returns nothing on cache miss", async (t) => {
+  const key = "http://localhost/cache-miss";
+  const res = await t.context.mf.dispatchFetch(key);
+  t.is(res.status, 404);
+  t.is(await res.text(), "<miss>");
+});
+test("match respects If-None-Match header", async (t) => {
+  const key = "http://localhost/cache-if-none-match";
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: {
+      "Test-Response-ETag": '"thing"',
+      "Test-Response-Cache-Control": "max-age=3600",
+    },
+    body: "body",
+  });
+
+  const ifNoneMatch = (value: string) =>
+    t.context.mf.dispatchFetch(key, { headers: { "If-None-Match": value } });
+
+  // Check returns 304 only if an ETag in `If-Modified-Since` matches
+  let res = await ifNoneMatch('"thing"');
+  t.is(res.status, 304);
+  res = await ifNoneMatch('   W/"thing"      ');
+  t.is(res.status, 304);
+  res = await ifNoneMatch('"not the thing"');
+  t.is(res.status, 200);
+  res = await ifNoneMatch(
+    '"not the thing",    "thing"    , W/"still not the thing"'
+  );
+  t.is(res.status, 304);
+  res = await ifNoneMatch("*");
+  t.is(res.status, 304);
+  res = await ifNoneMatch("    *   ");
+  t.is(res.status, 304);
+});
+test("match respects If-Modified-Since header", async (t) => {
+  const key = "http://localhost/cache-if-modified-since";
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: {
+      "Test-Response-Last-Modified": "Tue, 13 Sep 2022 12:00:00 GMT",
+      "Test-Response-Cache-Control": "max-age=3600",
+    },
+    body: "body",
+  });
+
+  const ifModifiedSince = (value: string) =>
+    t.context.mf.dispatchFetch(key, {
+      headers: { "If-Modified-Since": value },
+    });
+
+  // Check returns 200 if modified after `If-Modified-Since`
+  let res = await ifModifiedSince("Tue, 13 Sep 2022 11:00:00 GMT");
+  t.is(res.status, 200);
+  // Check returns 304 if modified on `If-Modified-Since`
+  res = await ifModifiedSince("Tue, 13 Sep 2022 12:00:00 GMT");
+  t.is(res.status, 304);
+  // Check returns 304 if modified before `If-Modified-Since`
+  res = await ifModifiedSince("Tue, 13 Sep 2022 13:00:00 GMT");
+  t.is(res.status, 304);
+  // Check returns 200 if `If-Modified-Since` is not a "valid" UTC date
+  res = await ifModifiedSince("13 Sep 2022 13:00:00 GMT");
+  t.is(res.status, 200);
+});
+test("match respects Range header", async (t) => {
+  const key = "http://localhost/cache-range";
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: {
+      "Test-Response-Content-Length": "10",
+      "Test-Response-Cache-Control": "max-age=3600",
+    },
+    body: "0123456789",
+  });
+  const res = await t.context.mf.dispatchFetch(key, {
+    headers: { Range: "bytes=2-4" },
+  });
+  t.is(res.status, 206);
+  t.is(res.headers.get("Content-Length"), "3");
+  t.is(res.headers.get("Cache-Control"), "max-age=3600");
+  t.is(res.headers.get("CF-Cache-Status"), "HIT");
+  t.is(await res.text(), "234");
+});
+
+const expireMacro = test.macro({
+  title(providedTitle) {
+    return `expires after ${providedTitle}`;
+  },
+  async exec(t, opts: { headers: HeadersInit; expectedTtl: number }) {
+    // Reset clock to known time, restoring afterwards.
+    // Note this macro must be used with `test.serial` to avoid races.
+    const originalTimestamp = t.context.clock.timestamp;
+    t.teardown(() => (t.context.clock.timestamp = originalTimestamp));
+    t.context.clock.timestamp = 1_000_000; // 1000s
+
+    const key = "http://localhost/cache-expire";
+    await t.context.mf.dispatchFetch(key, {
+      method: "PUT",
+      headers: opts.headers,
+      body: "body",
+    });
+
+    let res = await t.context.mf.dispatchFetch(key);
+    t.is(res.status, 200);
+
+    t.context.clock.timestamp += opts.expectedTtl / 2;
+    res = await t.context.mf.dispatchFetch(key);
+    t.is(res.status, 200);
+
+    t.context.clock.timestamp += opts.expectedTtl / 2;
+    res = await t.context.mf.dispatchFetch(key);
+    t.is(res.status, 404);
+  },
+});
+test.serial("Expires", expireMacro, {
+  headers: {
+    "Test-Response-Expires": new Date(1000000 + 2000).toUTCString(),
+  },
+  expectedTtl: 2000,
+});
+test.serial("Cache-Control's max-age", expireMacro, {
+  headers: { "Test-Response-Cache-Control": "max-age=1" },
+  expectedTtl: 1000,
+});
+test.serial("Cache-Control's s-maxage", expireMacro, {
+  headers: { "Test-Response-Cache-Control": "s-maxage=1, max-age=10" },
+  expectedTtl: 1000,
+});
+
+const isCachedMacro = test.macro({
+  title(providedTitle) {
+    return `put ${providedTitle}`;
+  },
+  async exec(t, opts: { headers: Record<string, string>; cached: boolean }) {
+    // Use different key for each invocation of this macro
+    const headersHash = crypto
+      .createHash("sha1")
+      .update(JSON.stringify(opts.headers))
+      .digest("hex");
+    const key = `http://localhost/cache-is-cached-${headersHash}`;
+
+    const expires = new Date(t.context.clock.timestamp + 2000).toUTCString();
+    await t.context.mf.dispatchFetch(key, {
+      method: "PUT",
+      headers: {
+        ...opts.headers,
+        "Test-Response-Expires": expires,
+      },
+      body: "body",
+    });
+    const res = await t.context.mf.dispatchFetch(key);
+    t.is(res.status, opts.cached ? 200 : 404);
+  },
+});
+test("does not cache with private Cache-Control", isCachedMacro, {
+  headers: { "Test-Response-Cache-Control": "private" },
+  cached: false,
+});
+test("does not cache with no-store Cache-Control", isCachedMacro, {
+  headers: { "Test-Response-Cache-Control": "no-store" },
+  cached: false,
+});
+test("does not cache with no-cache Cache-Control", isCachedMacro, {
+  headers: { "Test-Response-Cache-Control": "no-cache" },
+  cached: false,
+});
+test("does not cache with Set-Cookie", isCachedMacro, {
+  headers: { "Test-Response-Set-Cookie": "key=value" },
+  cached: false,
+});
+test(
+  "caches with Set-Cookie if Cache-Control private=set-cookie",
+  isCachedMacro,
+  {
+    headers: {
+      "Test-Response-Cache-Control": "private=set-cookie",
+      "Test-Response-Set-Cookie": "key=value",
+    },
+    cached: true,
+  }
+);
+
+test("delete returns if deleted", async (t) => {
+  const key = "http://localhost/cache-delete";
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: { "Test-Response-Cache-Control": "max-age=3600" },
+    body: "body",
+  });
+
+  // Check first delete deletes
+  let res = await t.context.mf.dispatchFetch(key, { method: "DELETE" });
+  t.is(res.status, 204);
+
+  // Check subsequent deletes don't match
+  res = await t.context.mf.dispatchFetch(key, { method: "DELETE" });
+  t.is(res.status, 404);
+});
+
+test("operations respect cf.cacheKey", async (t) => {
+  const key = "http://localhost/cache-cf-key-unused";
+
+  // Check put respects `cf.cacheKey`
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: {
+      "Test-CF-Cache-Key": "1",
+      "Test-Response-Cache-Control": "max-age=3600",
+    },
+    body: "body1",
+  });
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: {
+      "Test-CF-Cache-Key": "2",
+      "Test-Response-Cache-Control": "max-age=3600",
+    },
+    body: "body2",
+  });
+
+  // Check match respects `cf.cacheKey`
+  let res1 = await t.context.mf.dispatchFetch(key, {
+    headers: { "Test-CF-Cache-Key": "1" },
+  });
+  let res2 = await t.context.mf.dispatchFetch(key, {
+    headers: { "Test-CF-Cache-Key": "2" },
+  });
+  t.is(await res1.text(), "body1");
+  t.is(await res2.text(), "body2");
+
+  // Check delete respects `cf.cacheKey`
+  res1 = await t.context.mf.dispatchFetch(key, {
+    method: "DELETE",
+    headers: { "Test-CF-Cache-Key": "1" },
+  });
+  res2 = await t.context.mf.dispatchFetch(key, {
+    method: "DELETE",
+    headers: { "Test-CF-Cache-Key": "2" },
+  });
+  t.is(res1.status, 204);
+  t.is(res2.status, 204);
+});
+test.serial("operations log warning on workers.dev subdomain", async (t) => {
+  // Set option, then reset after test
+  await t.context.setOptions({ cacheWarnUsage: true });
+  t.teardown(() => t.context.setOptions({}));
+
+  const key = "http://localhost/cache-workers-dev-warning";
+
+  t.context.log.logs = [];
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: { "Test-Response-Cache-Control": "max-age=3600" },
+    body: "body",
+  });
+  t.deepEqual(t.context.log.logsAtLevel(LogLevel.WARN), [
+    "Cache operations will have no impact if you deploy to a workers.dev subdomain!",
+  ]);
+
+  // Check only warns once
+  t.context.log.logs = [];
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: { "Test-Response-Cache-Control": "max-age=3600" },
+    body: "body",
+  });
+  t.deepEqual(t.context.log.logsAtLevel(LogLevel.WARN), []);
+});
+test.serial("operations persist cached data", async (t) => {
+  // Create new temporary file-system persistence directory
+  const tmp = await useTmp(t);
+  const clock = () => t.context.clock.timestamp;
+  const storage = new FileStorage(path.join(tmp, "default"), undefined, clock);
+
+  // Set option, then reset after test
+  await t.context.setOptions({ cachePersist: tmp });
+  t.teardown(() => t.context.setOptions({}));
+
+  const key = "http://localhost/cache-persist";
+  const storedKey = new URL("/cache-persist", t.context.url).toString();
+
+  // Check put respects persist
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: { "Test-Response-Cache-Control": "max-age=3600" },
+    body: "body",
+  });
+  let stored = await storage.get(storedKey);
+  t.deepEqual(stored?.value, utf8Encode("body"));
+
+  // Check match respects persist
+  let res = await t.context.mf.dispatchFetch(key);
+  t.is(res.status, 200);
+  t.is(await res.text(), "body");
+
+  // Check delete respects persist
+  res = await t.context.mf.dispatchFetch(key, { method: "DELETE" });
+  t.is(res.status, 204);
+  stored = await storage.get(storedKey);
+  t.is(stored, undefined);
+});
+test.serial("operations are no-ops when caching disabled", async (t) => {
+  // Set option, then reset after test
+  await t.context.setOptions({ cache: false });
+  t.teardown(() => t.context.setOptions({}));
+
+  const key = "http://localhost/cache-disabled";
+
+  // Check match never matches
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: { "Test-Response-Cache-Control": "max-age=3600" },
+    body: "body",
+  });
+  let res = await t.context.mf.dispatchFetch(key);
+  t.is(res.status, 404);
+
+  // Check delete never deletes
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: { "Test-Response-Cache-Control": "max-age=3600" },
+    body: "body",
+  });
+  res = await t.context.mf.dispatchFetch(key, { method: "DELETE" });
+  t.is(res.status, 404);
+});
+
+test("default and named caches are disjoint", async (t) => {
+  const key = "http://localhost/cache-disjoint";
+
+  // Check put respects cache name
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: { "Test-Response-Cache-Control": "max-age=3600" },
+    body: "bodyDefault",
+  });
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: {
+      "Test-Cache-Name": "1",
+      "Test-Response-Cache-Control": "max-age=3600",
+    },
+    body: "body1",
+  });
+  await t.context.mf.dispatchFetch(key, {
+    method: "PUT",
+    headers: {
+      "Test-Cache-Name": "2",
+      "Test-Response-Cache-Control": "max-age=3600",
+    },
+    body: "body2",
+  });
+
+  // Check match respects cache name
+  let resDefault = await t.context.mf.dispatchFetch(key);
+  let res1 = await t.context.mf.dispatchFetch(key, {
+    headers: { "Test-Cache-Name": "1" },
+  });
+  let res2 = await t.context.mf.dispatchFetch(key, {
+    headers: { "Test-Cache-Name": "2" },
+  });
+  t.is(await resDefault.text(), "bodyDefault");
+  t.is(await res1.text(), "body1");
+  t.is(await res2.text(), "body2");
+
+  // Check delete respects cache name
+  resDefault = await t.context.mf.dispatchFetch(key, { method: "DELETE" });
+  res1 = await t.context.mf.dispatchFetch(key, {
+    method: "DELETE",
+    headers: { "Test-Cache-Name": "1" },
+  });
+  res2 = await t.context.mf.dispatchFetch(key, {
+    method: "DELETE",
+    headers: { "Test-Cache-Name": "2" },
+  });
+  t.is(resDefault.status, 204);
+  t.is(res1.status, 204);
+  t.is(res2.status, 204);
+});

--- a/packages/tre/test/plugins/cache/range.spec.ts
+++ b/packages/tre/test/plugins/cache/range.spec.ts
@@ -1,0 +1,140 @@
+import assert from "assert";
+import { _getRangeResponse, _parseRanges } from "@miniflare/tre";
+import test from "ava";
+import { Headers } from "undici";
+import { utf8Encode } from "../../storage/helpers";
+
+test('_parseRanges: case-insensitive unit must be "bytes"', (t) => {
+  // Check case-insensitive and ignores whitespace
+  t.not(_parseRanges("bytes=0-1", 2), undefined);
+  t.not(_parseRanges("BYTES    =0-1", 2), undefined);
+  t.not(_parseRanges("     bYtEs=0-1", 4), undefined);
+  t.not(_parseRanges("    Bytes        =0-1", 2), undefined);
+  // Check fails with other units
+  t.is(_parseRanges("nibbles=0-1", 2), undefined);
+});
+
+test("_parseRanges: matches range with start and end", (t) => {
+  // Check valid ranges accepted
+  t.deepEqual(_parseRanges("bytes=0-1", 8), [[0, 1]]);
+  t.deepEqual(_parseRanges("bytes=2-7", 8), [[2, 7]]);
+  t.deepEqual(_parseRanges("bytes=5-5", 8), [[5, 5]]);
+  // Check start after end rejected
+  t.deepEqual(_parseRanges("bytes=1-0", 2), undefined);
+  // Check start after content rejected
+  t.deepEqual(_parseRanges("bytes=2-3", 2), undefined);
+  t.deepEqual(_parseRanges("bytes=5-7", 2), undefined);
+  // Check end after content truncated
+  t.deepEqual(_parseRanges("bytes=0-2", 2), [[0, 1]]);
+  t.deepEqual(_parseRanges("bytes=1-5", 3), [[1, 2]]);
+  // Check multiple valid ranges accepted
+  t.deepEqual(_parseRanges("bytes=  1-3  , 6-7,10-11", 12), [
+    [1, 3],
+    [6, 7],
+    [10, 11],
+  ]);
+  // Check overlapping ranges accepted
+  t.deepEqual(_parseRanges("bytes=0-2,1-3", 5), [
+    [0, 2],
+    [1, 3],
+  ]);
+});
+
+test("_parseRanges: matches range with just start", (t) => {
+  // Check valid ranges accepted
+  t.deepEqual(_parseRanges("bytes=2-", 8), [[2, 7]]);
+  t.deepEqual(_parseRanges("bytes=5-", 6), [[5, 5]]);
+  // Check start after content rejected
+  t.deepEqual(_parseRanges("bytes=2-", 2), undefined);
+  t.deepEqual(_parseRanges("bytes=5-", 2), undefined);
+  // Check multiple valid ranges accepted
+  t.deepEqual(_parseRanges("bytes=  1-  ,6- ,  10-11   ", 12), [
+    [1, 11],
+    [6, 11],
+    [10, 11],
+  ]);
+});
+
+test("_parseRanges: matches range with just end", (t) => {
+  // Check valid ranges accepted
+  t.deepEqual(_parseRanges("bytes=-2", 8), [[6, 7]]);
+  t.deepEqual(_parseRanges("bytes=-6", 7), [[1, 6]]);
+  // Check start before content truncated and entire response returned
+  t.deepEqual(_parseRanges("bytes=-7", 7), []);
+  t.deepEqual(_parseRanges("bytes=-10", 5), []);
+  // Check if any range returns entire response, other ranges ignored
+  t.deepEqual(_parseRanges("bytes=0-1,-5,2-3", 5), []);
+  // Check empty range ignored
+  t.deepEqual(_parseRanges("bytes=-0", 2), []);
+  t.deepEqual(_parseRanges("bytes=0-1,-0,2-3", 4), [
+    [0, 1],
+    [2, 3],
+  ]);
+});
+
+test("_parseRanges: range requires at least start or end", (t) => {
+  // Check range with no start or end rejected
+  t.is(_parseRanges("bytes=-", 2), undefined);
+  // Check range with no dash rejected
+  t.is(_parseRanges("bytes=0", 2), undefined);
+  // Check empty range rejected
+  t.is(_parseRanges("bytes=0-1,", 2), undefined);
+  // Check no ranges accepted
+  t.deepEqual(_parseRanges("bytes=", 2), []);
+});
+
+test("_getRangeResponse: returns 416 response if range unsatisfiable", (t) => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  const res = _getRangeResponse("bytes=-", 200, headers, utf8Encode("abc"));
+  t.is(res.status, 416);
+  t.is(res.headers.get("Content-Range"), "bytes */3");
+});
+test("_getRangeResponse: returns 200 response if entire response returned", async (t) => {
+  const headers = new Headers({ "Content-Type": "text/html", "X-Key": "key" });
+  const res = _getRangeResponse("bytes=-10", 200, headers, utf8Encode("abc"));
+  t.is(res.status, 200);
+  t.is(res.headers.get("Content-Type"), "text/html");
+  t.is(res.headers.get("Content-Range"), null);
+  t.is(res.headers.get("X-Key"), "key");
+  t.is(await res.text(), "abc");
+});
+test("_getRangeResponse: returns 206 response with single range", async (t) => {
+  const headers = new Headers({ "Content-Type": "text/html", "X-Key": "key" });
+  const res = _getRangeResponse("bytes=1-3", 200, headers, utf8Encode("abcde"));
+  t.is(res.status, 206);
+  t.is(res.headers.get("Content-Type"), "text/html");
+  t.is(res.headers.get("Content-Range"), "bytes 1-3/5");
+  t.is(res.headers.get("X-Key"), "key");
+  t.is(await res.text(), "bcd");
+});
+test("_getRangeResponse: returns 206 response with multiple ranges", async (t) => {
+  const headers = new Headers({ "Content-Type": "text/html", "X-Key": "key" });
+  const body = utf8Encode("abcdefghijklmnopqrstuvwxyz");
+  const res = _getRangeResponse("bytes=5-7,10-14,20-", 200, headers, body);
+  t.is(res.status, 206);
+  const contentType = res.headers.get("Content-Type")?.split("=");
+  assert(contentType?.length === 2);
+  t.is(contentType[0], "multipart/byteranges; boundary");
+  t.is(res.headers.get("Content-Range"), null);
+  t.is(res.headers.get("X-Key"), "key");
+
+  const expectedText = [
+    `--${contentType[1]}`,
+    "Content-Type: text/html",
+    "Content-Range: bytes 5-7/26",
+    "",
+    "fgh",
+    `--${contentType[1]}`,
+    "Content-Type: text/html",
+    "Content-Range: bytes 10-14/26",
+    "",
+    "klmno",
+    `--${contentType[1]}`,
+    "Content-Type: text/html",
+    "Content-Range: bytes 20-25/26",
+    "",
+    "uvwxyz",
+    `--${contentType[1]}--`,
+  ].join("\r\n");
+  t.is(await res.text(), expectedText);
+});

--- a/packages/tre/test/storage/helpers.ts
+++ b/packages/tre/test/storage/helpers.ts
@@ -1,5 +1,9 @@
+import crypto from "crypto";
+import fs from "fs/promises";
+import path from "path";
 import { TextDecoder, TextEncoder } from "util";
-import { Clock } from "@miniflare/tre";
+import { Clock, sanitisePath } from "@miniflare/tre";
+import { ExecutionContext } from "ava";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -23,3 +27,14 @@ export const TIME_NOW = 750;
 export const TIME_EXPIRING = 1000;
 
 export const testClock: Clock = () => TIME_NOW * 1000;
+
+const tmpRoot = path.resolve(".tmp");
+export async function useTmp(t: ExecutionContext): Promise<string> {
+  const filePath = path.join(
+    tmpRoot,
+    sanitisePath(t.title),
+    crypto.randomBytes(4).toString("hex")
+  );
+  await fs.mkdir(filePath, { recursive: true });
+  return filePath;
+}


### PR DESCRIPTION
This PR adds testing for Miniflare 3's Cache API. I've written these as integration tests. Along the way, I fixed some bugs with caching streamed responses, and using `cf.cacheKey`.

This PR is pretty big, because it also adds lots of the required integration testing infrastructure. Hopefully, it should be easier to add tests for other features after this.