### PR TITLE
fix(response): reset bodyStream when body is cloned

### DIFF
--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -191,6 +191,10 @@ export class Body<Inner extends BaseRequest | BaseResponse> {
     return this[_kInner].headers;
   }
 
+  set bodyStream(value: ReadableStream | undefined) {
+    this.#bodyStream = value;
+  }
+
   get body(): ReadableStream<Uint8Array> | null {
     const body = this[_kInner].body;
 
@@ -584,6 +588,7 @@ export class Response<
       throw new TypeError("Cannot clone a response to a WebSocket handshake.");
     }
     const innerClone = this[_kInner].clone();
+    this.bodyStream = undefined;
     const clone = new Response(innerClone.body, innerClone);
     clone[kInputGated] = this[kInputGated];
     clone[kFormDataFiles] = this[kFormDataFiles];

--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -409,6 +409,7 @@ export class Request extends Body<BaseRequest> {
 
   clone(): Request {
     const innerClone = this[_kInner].clone();
+    this[kBodyStream] = undefined;
     const clone = new Request(innerClone);
     clone[kInputGated] = this[kInputGated];
     clone[kFormDataFiles] = this[kFormDataFiles];

--- a/packages/core/test/standards/http.spec.ts
+++ b/packages/core/test/standards/http.spec.ts
@@ -616,9 +616,9 @@ test("Request: should reset bodyStream when body is cloned", async (t) => {
   t.true(req instanceof Body);
   const bodyStream = req.body;
   assert(bodyStream instanceof ReadableStream);
-  // Clone the response. undici will change the `body.stream` to a new clone.
-  const cloneRes = req.clone();
-  t.deepEqual(await cloneRes.arrayBuffer(), reqBody);
+  // Clone the request. undici will change the `body.stream` to a new clone.
+  const cloneReq = req.clone();
+  t.deepEqual(await cloneReq.arrayBuffer(), reqBody);
   // We can loop over body. This is what http-server writeResponse() does.
   if (req.body) {
     for await (const chunk of req.body) {

--- a/packages/core/test/standards/http.spec.ts
+++ b/packages/core/test/standards/http.spec.ts
@@ -168,13 +168,15 @@ test("Body: should be locked when attaching a reader", async (t) => {
   t.true(res.body.locked);
 });
 test("Body: should reset bodyStream when body is cloned", async (t) => {
-  const res = new Response(new ArrayBuffer(10));
+  const resBody = new ArrayBuffer(10);
+  const res = new Response(resBody);
   // noinspection SuspiciousTypeOfGuard
   t.true(res instanceof Body);
   const bodyStream = res.body;
   assert(bodyStream instanceof ReadableStream);
   // Clone the response. undici will change the `body.stream` to a new clone.
-  res.clone();
+  const cloneRes = res.clone();
+  t.deepEqual(await cloneRes.arrayBuffer(), resBody);
   // We can loop over body. This is what http-server writeResponse() does.
   if (res.body) {
     for await (const chunk of res.body) {


### PR DESCRIPTION
## What
`Response.clone()` behaves differently than in the actual Workers or in Browser.

## Why
When response body gets cloned, the original `body.stream` is set to one of the cloned streams.
Miniflare's `Response` keeps an internal `bodyStream` reference which is not reset whenever the original `body.stream` is reset.

Thus, whenever you get a reference of the `body` before cloning it and attempting to loop over the body after cloning it, you get this error message: `TypeError: Invalid state: ReadableStream is locked` . 

[See code example that reproduces the issue here](https://github.com/cloudflare/miniflare/pull/449/files#diff-963ba9d1eeb501b4be74716fd399a23eaf366c36fd0af770154b6adf8c389e8cR167-R179).

```js
const res = new Response(new ArrayBuffer(10));
const bodyStream = res.body;
// Clone the response. undici will change the `body.stream` to a new clone.
res.clone();
// We should be able to loop over body. This is what http-server writeResponse() does.
for await (const chunk of res.body) { // Since `body` points to old/locked/used `bodyStream`, attempting to `stream.getReader()` would fail
  assert(chunk instanceof Uint8Array);
}
```

See undici code [here](https://github.com/nodejs/undici/blob/671e05fb90d4e047a3b219d802a8afeeb35ad883/lib/fetch/body.js#L291-L298).

```js
function cloneBody (body) {
  // To clone a body body, run these steps:

  // https://fetch.spec.whatwg.org/#concept-body-clone

  // 1. Let « out1, out2 » be the result of teeing body’s stream.
  const [out1, out2] = body.stream.tee()
  const out2Clone = structuredClone(out2, { transfer: [out2] })
  // This, for whatever reasons, unrefs out2Clone which allows
  // the process to exit by itself.
  const [, finalClone] = out2Clone.tee()

  // 2. Set body’s stream to out1.
  body.stream = out1

  // 3. Return a body whose stream is out2 and other members are copied from body.
  return {
    stream: finalClone,
    length: body.length,
    source: body.source
  }
}
```

## How

Reset internal `bodyStream` when `Response.clone()`.
