### PR TITLE
fix: rename queue binding to match runtime

### DIFF
--- a/packages/queues/src/broker.ts
+++ b/packages/queues/src/broker.ts
@@ -89,7 +89,7 @@ enum FlushType {
 
 export const kSetFlushCallback = Symbol("kSetFlushCallback");
 
-export class Queue<Body = unknown> implements QueueInterface<Body> {
+export class WorkerQueue<Body = unknown> implements QueueInterface<Body> {
   readonly #broker: QueueBroker;
   readonly #queueName: string;
   readonly #log?: Log;
@@ -263,23 +263,23 @@ export class Queue<Body = unknown> implements QueueInterface<Body> {
 }
 
 export class QueueBroker implements QueueBrokerInterface {
-  readonly #queues: Map<string, Queue>;
+  readonly #queues: Map<string, WorkerQueue>;
   readonly #log?: Log;
 
   constructor(log?: Log) {
-    this.#queues = new Map<string, Queue>();
+    this.#queues = new Map<string, WorkerQueue>();
     this.#log = log;
   }
 
-  getOrCreateQueue(name: string): Queue {
+  getOrCreateQueue(name: string): WorkerQueue {
     let queue = this.#queues.get(name);
     if (queue === undefined) {
-      this.#queues.set(name, (queue = new Queue(this, name, this.#log)));
+      this.#queues.set(name, (queue = new WorkerQueue(this, name, this.#log)));
     }
     return queue;
   }
 
-  setConsumer(queue: Queue, consumer: Consumer) {
+  setConsumer(queue: WorkerQueue, consumer: Consumer) {
     queue[kSetConsumer](consumer);
   }
 }

--- a/packages/queues/test/plugin.spec.ts
+++ b/packages/queues/test/plugin.spec.ts
@@ -1,9 +1,9 @@
 import {
   DEFAULT_BATCH_SIZE,
   DEFAULT_WAIT_MS,
-  Queue,
   QueueBroker,
   QueuesPlugin,
+  WorkerQueue,
 } from "@miniflare/queues";
 import {
   Compatibility,
@@ -157,6 +157,6 @@ test("QueuesPlugin: setup: includes queues in bindings", async (t) => {
   });
 
   const result = await plugin.setup(factory);
-  t.true(result.bindings?.QUEUE1 instanceof Queue);
-  t.true(result.bindings?.QUEUE2 instanceof Queue);
+  t.true(result.bindings?.QUEUE1 instanceof WorkerQueue);
+  t.true(result.bindings?.QUEUE2 instanceof WorkerQueue);
 });


### PR DESCRIPTION
Renames the queue binding in the miniflare plugin to `WorkerQueue` to match the name in the Cloudflare runtime. This small discrepancy is particularly important for the [workers-rs](https://github.com/cloudflare/workers-rs) framework which [validates the types of bindings at runtime based on their constructor name](https://github.com/cloudflare/workers-rs/blob/7a78ac9cd6be4d27d6fc435fa8dc60d59d55405d/worker/src/env.rs#L66), making it impossible to use queues with miniflare.