### PR TITLE
add comment about the family property no longer being numeric

### DIFF
--- a/packages/http-server/src/helpers.ts
+++ b/packages/http-server/src/helpers.ts
@@ -4,6 +4,8 @@ export function getAccessibleHosts(ipv4 = false): string[] {
   const hosts: string[] = [];
   Object.values(networkInterfaces()).forEach((net) => {
     net?.forEach(({ family, address }) => {
+      // The `family` property being numeric was reverted in Node 18.2
+      // https://github.com/nodejs/node/issues/43014
       // @ts-expect-error the `family` property is numeric as of Node.js 18.0.0
       if (!ipv4 || family === "IPv4" || family === 4) hosts.push(address);
     });


### PR DESCRIPTION
Not sure if we need to do anything with this info, but I thought it'd be useful to include as context for the existing comment, which isn't 100% accurate anymore.