### PR TITLE
Implement `export_commonjs_default`/`export_commonjs_namespace` flags

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -776,7 +776,8 @@ export class MiniflareCore<
         globalScope,
         script,
         rules,
-        additionalModules
+        additionalModules,
+        this.#compat
       );
 
       this.#scriptWatchPaths.clear();

--- a/packages/runner-vm/src/index.ts
+++ b/packages/runner-vm/src/index.ts
@@ -1,6 +1,7 @@
 import vm from "vm";
 import {
   AdditionalModules,
+  Compatibility,
   Context,
   ProcessedModuleRule,
   ScriptBlueprint,
@@ -44,7 +45,8 @@ export class VMScriptRunner implements ScriptRunner {
     globalScope: Context,
     blueprint: ScriptBlueprint,
     modulesRules?: ProcessedModuleRule[],
-    additionalModules?: AdditionalModules
+    additionalModules?: AdditionalModules,
+    compat?: Compatibility
   ): Promise<ScriptRunnerResult> {
     // If we're using modules, make sure --experimental-vm-modules is enabled
     if (modulesRules && !("SourceTextModule" in vm)) {
@@ -55,7 +57,8 @@ export class VMScriptRunner implements ScriptRunner {
     }
     // Also build a linker if we're using modules
     const linker =
-      modulesRules && new ModuleLinker(modulesRules, additionalModules ?? {});
+      modulesRules &&
+      new ModuleLinker(modulesRules, additionalModules ?? {}, compat);
 
     let context = this.context;
     if (context) {

--- a/packages/runner-vm/src/linker.ts
+++ b/packages/runner-vm/src/linker.ts
@@ -279,7 +279,7 @@ export class ModuleLinker {
       ) {
         return mod.exports;
       } else {
-        // Make sure we always return the same object for an indentifier
+        // Make sure we always return the same object for an identifier
         let ns = this.#namespaceCache.get(mod);
         if (ns !== undefined) return ns;
         ns = Object.defineProperty({}, "default", {

--- a/packages/runner-vm/test/fixtures/cjsadditional.cjs
+++ b/packages/runner-vm/test/fixtures/cjsadditional.cjs
@@ -1,2 +1,2 @@
 const additional = require("ADDITIONAL");
-module.exports = `CommonJS ${additional.default}`;
+module.exports = `CommonJS ${additional}`;

--- a/packages/runner-vm/test/fixtures/cjscompiledwasm.cjs
+++ b/packages/runner-vm/test/fixtures/cjscompiledwasm.cjs
@@ -1,3 +1,3 @@
 const addModule = require("./add.wasm");
-const instance = new WebAssembly.Instance(addModule.default);
+const instance = new WebAssembly.Instance(addModule);
 exports.add1 = (a) => instance.exports.add(a, 1);

--- a/packages/runner-vm/test/fixtures/cjsdata.cjs
+++ b/packages/runner-vm/test/fixtures/cjsdata.cjs
@@ -1,2 +1,2 @@
 const data = require("./data.bin");
-module.exports = `CommonJS ${new TextDecoder().decode(data.default).trimEnd()}`;
+module.exports = `CommonJS ${new TextDecoder().decode(data).trimEnd()}`;

--- a/packages/runner-vm/test/fixtures/cjsnamespace.cjs
+++ b/packages/runner-vm/test/fixtures/cjsnamespace.cjs
@@ -1,0 +1,6 @@
+const cjs = require("./cjs.cjs");
+const txt = require("./text.txt");
+const txt2 = require("./text.txt");
+module.exports = function () {
+  return { cjs, txt, txt2 };
+};

--- a/packages/runner-vm/test/fixtures/cjstext.cjs
+++ b/packages/runner-vm/test/fixtures/cjstext.cjs
@@ -1,2 +1,2 @@
 const text = require("./text.txt");
-module.exports = `CommonJS ${text.default.trimEnd()}`;
+module.exports = `CommonJS ${text.trimEnd()}`;

--- a/packages/shared/src/compat.ts
+++ b/packages/shared/src/compat.ts
@@ -13,6 +13,7 @@ export interface CompatibilityFeature {
 export type CompatibilityEnableFlag =
   | "streams_enable_constructors"
   | "transformstream_enable_standard_constructor"
+  | "export_commonjs_default"
   | "r2_list_honor_include"
   | "global_navigator"
   | "durable_object_fetch_requires_full_url"
@@ -22,6 +23,7 @@ export type CompatibilityEnableFlag =
 export type CompatibilityDisableFlag =
   | "streams_disable_constructors"
   | "transformstream_disable_standard_constructor"
+  | "export_commonjs_namespace"
   | "no_global_navigator"
   | "durable_object_fetch_allows_relative_url"
   | "fetch_treats_unknown_protocols_as_http"
@@ -40,6 +42,11 @@ const FEATURES: CompatibilityFeature[] = [
     defaultAsOf: "2022-11-30",
     enableFlag: "transformstream_enable_standard_constructor",
     disableFlag: "transformstream_disable_standard_constructor",
+  },
+  {
+    defaultAsOf: "2022-10-31",
+    enableFlag: "export_commonjs_default",
+    disableFlag: "export_commonjs_namespace",
   },
   {
     defaultAsOf: "2022-08-04",

--- a/packages/shared/src/runner.ts
+++ b/packages/shared/src/runner.ts
@@ -1,3 +1,4 @@
+import { Compatibility } from "./compat";
 import { Matcher } from "./data";
 import { AdditionalModules, Context } from "./plugin";
 
@@ -38,6 +39,7 @@ export interface ScriptRunner {
     globalScope: Context,
     blueprint: ScriptBlueprint,
     modulesRules?: ProcessedModuleRule[],
-    additionalModules?: AdditionalModules
+    additionalModules?: AdditionalModules,
+    compat?: Compatibility
   ): Promise<ScriptRunnerResult>;
 }


### PR DESCRIPTION
Previously, the Workers runtime would incorrectly return `{ default: module.exports }` from `require()`, as opposed to just `module.exports`. The `export_commonjs_default` compatibility flag enables the correct behaviour.

Miniflare previously implemented `export_commonjs_default` behaviour for `CommonJS` modules, but `export_commonjs_namespace` behaviour for all other types. (Ooops! 😅) This change switches everything to the correct `export_commonjs_default` by default, but allows old behaviour to be enabled by setting `export_commonjs_namespace`.

Note, importing `CommonJS` from an `ESModule` is not affected.

Ref: https://developers.cloudflare.com/workers/platform/compatibility-dates/#commonjs-modules-do-not-export-a-module-namespace