### PR TITLE
`nodejs_compat` flag

### DIFF
--- a/packages/core/src/plugins/node/async_hooks.ts
+++ b/packages/core/src/plugins/node/async_hooks.ts
@@ -1,0 +1,6 @@
+import async_hooks from "node:async_hooks";
+
+export class AsyncHooksModule {
+  AsyncLocalStorage = async_hooks.AsyncLocalStorage;
+  AsyncResource = async_hooks.AsyncResource;
+}

--- a/packages/core/src/plugins/node/index.ts
+++ b/packages/core/src/plugins/node/index.ts
@@ -1,0 +1,5 @@
+import { AsyncHooksModule } from "./async_hooks";
+
+export const additionalModules = {
+  "node:async_hooks": { default: new AsyncHooksModule() },
+};

--- a/packages/core/test/plugins/core.spec.ts
+++ b/packages/core/test/plugins/core.spec.ts
@@ -654,6 +654,20 @@ test("CorePlugin: setup: uses actual time if option enabled", async (t) => {
   });
 });
 
+test("CorePlugin: nodejs_compat compatibiltiy flag includes Node.js modules", async (t) => {
+  const compat = new Compatibility(undefined, ["nodejs_compat"]);
+
+  const plugin = new CorePlugin(
+    { ...ctx, compat },
+    { compatibilityFlags: ["nodejs_compat"] }
+  );
+  const additionalModules = (await plugin.setup()).additionalModules;
+  t.deepEqual(
+    Object.keys(additionalModules?.["node:async_hooks"].default ?? {}),
+    ["AsyncLocalStorage", "AsyncResource"]
+  );
+});
+
 // Test stream constructors
 test("CorePlugin: setup: ReadableStream/WriteableStream constructors only enabled if compatibility flag enabled", async (t) => {
   // Check without "streams_enable_constructors" compatibility flag (should throw)

--- a/packages/shared/src/compat.ts
+++ b/packages/shared/src/compat.ts
@@ -11,6 +11,7 @@ export interface CompatibilityFeature {
 // will get a type error if they try to use an unsupported flag via the API,
 // and they won't be logged in the "Enabled Compatibility Flags" section.
 export type CompatibilityEnableFlag =
+  | "nodejs_compat"
   | "streams_enable_constructors"
   | "transformstream_enable_standard_constructor"
   | "global_navigator"
@@ -30,6 +31,9 @@ export type CompatibilityFlag =
   | CompatibilityDisableFlag;
 
 const FEATURES: CompatibilityFeature[] = [
+  {
+    enableFlag: "nodejs_compat",
+  },
   {
     defaultAsOf: "2022-11-30",
     enableFlag: "streams_enable_constructors",


### PR DESCRIPTION
Adds the `nodejs_compat` flag and attaches the `node:async_hooks` partial implementation that is now in `workerd`.