### PR TITLE
Throw an error for KV expirations above the maximum 32-bit signed integer

### DIFF
--- a/packages/kv/src/namespace.ts
+++ b/packages/kv/src/namespace.ts
@@ -289,11 +289,11 @@ export class KVNamespace {
     let expiration = normaliseInt(options.expiration);
     const expirationTtl = normaliseInt(options.expirationTtl);
     if (expirationTtl !== undefined) {
-      if (isNaN(expirationTtl) || expirationTtl <= 0) {
+      if (isNaN(expirationTtl) || expirationTtl <= 0 || expirationTtl > 2147483647) {
         throwKVError(
           "PUT",
           400,
-          `Invalid expiration_ttl of ${options.expirationTtl}. Please specify integer greater than 0.`
+          `Invalid expiration_ttl of ${options.expirationTtl}. Please specify integer greater than 0 and less than or equal to 2147483647.`
         );
       }
       if (expirationTtl < MIN_CACHE_TTL) {
@@ -305,11 +305,11 @@ export class KVNamespace {
       }
       expiration = now + expirationTtl;
     } else if (expiration !== undefined) {
-      if (isNaN(expiration) || expiration <= now) {
+      if (isNaN(expiration) || expiration <= now || expiration > 2147483647) {
         throwKVError(
           "PUT",
           400,
-          `Invalid expiration of ${options.expiration}. Please specify integer greater than the current number of seconds since the UNIX epoch.`
+          `Invalid expiration of ${options.expiration}. Please specify integer greater than the current number of seconds since the UNIX epoch, and less than or equal to 2147483647.`
         );
       }
       if (expiration < now + MIN_CACHE_TTL) {

--- a/packages/kv/src/namespace.ts
+++ b/packages/kv/src/namespace.ts
@@ -16,6 +16,7 @@ import {
 } from "@miniflare/shared";
 
 const MIN_CACHE_TTL = 60; /* 60s */
+const MAX_EXPIRATION = 2147483647 /* Maximum signed 32-bit integer */
 const MAX_LIST_KEYS = 1000;
 const MAX_KEY_SIZE = 512; /* 512B */
 const MAX_VALUE_SIZE = 25 * 1024 * 1024; /* 25MiB */
@@ -289,11 +290,11 @@ export class KVNamespace {
     let expiration = normaliseInt(options.expiration);
     const expirationTtl = normaliseInt(options.expirationTtl);
     if (expirationTtl !== undefined) {
-      if (isNaN(expirationTtl) || expirationTtl <= 0 || expirationTtl > 2147483647) {
+      if (isNaN(expirationTtl) || expirationTtl <= 0 || expirationTtl > MAX_EXPIRATION) {
         throwKVError(
           "PUT",
           400,
-          `Invalid expiration_ttl of ${options.expirationTtl}. Please specify integer greater than 0 and less than or equal to 2147483647.`
+          `Invalid expiration_ttl of ${options.expirationTtl}. Please specify integer greater than 0 and less than or equal to ${MAX_EXPIRATION}.`
         );
       }
       if (expirationTtl < MIN_CACHE_TTL) {
@@ -305,11 +306,11 @@ export class KVNamespace {
       }
       expiration = now + expirationTtl;
     } else if (expiration !== undefined) {
-      if (isNaN(expiration) || expiration <= now || expiration > 2147483647) {
+      if (isNaN(expiration) || expiration <= now || expiration > MAX_EXPIRATION) {
         throwKVError(
           "PUT",
           400,
-          `Invalid expiration of ${options.expiration}. Please specify integer greater than the current number of seconds since the UNIX epoch, and less than or equal to 2147483647.`
+          `Invalid expiration of ${options.expiration}. Please specify integer greater than the current number of seconds since the UNIX epoch, and less than or equal to ${MAX_EXPIRATION}.`
         );
       }
       if (expiration < now + MIN_CACHE_TTL) {

--- a/packages/kv/src/namespace.ts
+++ b/packages/kv/src/namespace.ts
@@ -16,6 +16,7 @@ import {
 } from "@miniflare/shared";
 
 const MIN_CACHE_TTL = 60; /* 60s */
+const MIN_EXPIRATION = -2147483648; /* Minimum signed 32-bit integer */
 const MAX_EXPIRATION = 2147483647; /* Maximum signed 32-bit integer */
 const MAX_LIST_KEYS = 1000;
 const MAX_KEY_SIZE = 512; /* 512B */
@@ -290,15 +291,11 @@ export class KVNamespace {
     let expiration = normaliseInt(options.expiration);
     const expirationTtl = normaliseInt(options.expirationTtl);
     if (expirationTtl !== undefined) {
-      if (
-        isNaN(expirationTtl) ||
-        expirationTtl <= 0 ||
-        expirationTtl > MAX_EXPIRATION
-      ) {
+      if (isNaN(expirationTtl) || expirationTtl <= 0) {
         throwKVError(
           "PUT",
           400,
-          `Invalid expiration_ttl of ${options.expirationTtl}. Please specify integer greater than 0 and less than or equal to ${MAX_EXPIRATION}.`
+          `Invalid expiration_ttl of ${options.expirationTtl}. Please specify integer greater than 0.`
         );
       }
       if (expirationTtl < MIN_CACHE_TTL) {
@@ -308,17 +305,19 @@ export class KVNamespace {
           `Invalid expiration_ttl of ${options.expirationTtl}. Expiration TTL must be at least ${MIN_CACHE_TTL}.`
         );
       }
+      if (expirationTtl < MIN_EXPIRATION || expirationTtl > MAX_EXPIRATION) {
+        // Workers throws like this without the extra sugar when the value is out of bounds.
+        throw new TypeError(
+          `Value out of range. Must be between ${MIN_EXPIRATION} and ${MAX_EXPIRATION} (inclusive).`
+        );
+      }
       expiration = now + expirationTtl;
     } else if (expiration !== undefined) {
-      if (
-        isNaN(expiration) ||
-        expiration <= now ||
-        expiration > MAX_EXPIRATION
-      ) {
+      if (isNaN(expiration) || expiration <= now) {
         throwKVError(
           "PUT",
           400,
-          `Invalid expiration of ${options.expiration}. Please specify integer greater than the current number of seconds since the UNIX epoch, and less than or equal to ${MAX_EXPIRATION}.`
+          `Invalid expiration of ${options.expiration}. Please specify integer greater than the current number of seconds since the UNIX epoch.`
         );
       }
       if (expiration < now + MIN_CACHE_TTL) {
@@ -326,6 +325,12 @@ export class KVNamespace {
           "PUT",
           400,
           `Invalid expiration of ${options.expiration}. Expiration times must be at least ${MIN_CACHE_TTL} seconds in the future.`
+        );
+      }
+      if (expiration < MIN_EXPIRATION || expiration > MAX_EXPIRATION) {
+        // Workers throws like this without the extra sugar when the value is out of bounds.
+        throw new TypeError(
+          `Value out of range. Must be between ${MIN_EXPIRATION} and ${MAX_EXPIRATION} (inclusive).`
         );
       }
     }

--- a/packages/kv/src/namespace.ts
+++ b/packages/kv/src/namespace.ts
@@ -16,7 +16,7 @@ import {
 } from "@miniflare/shared";
 
 const MIN_CACHE_TTL = 60; /* 60s */
-const MAX_EXPIRATION = 2147483647 /* Maximum signed 32-bit integer */
+const MAX_EXPIRATION = 2147483647; /* Maximum signed 32-bit integer */
 const MAX_LIST_KEYS = 1000;
 const MAX_KEY_SIZE = 512; /* 512B */
 const MAX_VALUE_SIZE = 25 * 1024 * 1024; /* 25MiB */
@@ -290,7 +290,11 @@ export class KVNamespace {
     let expiration = normaliseInt(options.expiration);
     const expirationTtl = normaliseInt(options.expirationTtl);
     if (expirationTtl !== undefined) {
-      if (isNaN(expirationTtl) || expirationTtl <= 0 || expirationTtl > MAX_EXPIRATION) {
+      if (
+        isNaN(expirationTtl) ||
+        expirationTtl <= 0 ||
+        expirationTtl > MAX_EXPIRATION
+      ) {
         throwKVError(
           "PUT",
           400,
@@ -306,7 +310,11 @@ export class KVNamespace {
       }
       expiration = now + expirationTtl;
     } else if (expiration !== undefined) {
-      if (isNaN(expiration) || expiration <= now || expiration > MAX_EXPIRATION) {
+      if (
+        isNaN(expiration) ||
+        expiration <= now ||
+        expiration > MAX_EXPIRATION
+      ) {
         throwKVError(
           "PUT",
           400,

--- a/packages/kv/test/namespace.spec.ts
+++ b/packages/kv/test/namespace.spec.ts
@@ -455,12 +455,17 @@ test("put: validates expiration ttl", async (t) => {
   await t.throwsAsync(ns.put("key", "value", { expirationTtl: "nan" }), {
     instanceOf: Error,
     message:
-      "KV PUT failed: 400 Invalid expiration_ttl of nan. Please specify integer greater than 0.",
+      "KV PUT failed: 400 Invalid expiration_ttl of nan. Please specify integer greater than 0 and less than or equal to 2147483647.",
   });
   await t.throwsAsync(ns.put("key", "value", { expirationTtl: 0 }), {
     instanceOf: Error,
     message:
-      "KV PUT failed: 400 Invalid expiration_ttl of 0. Please specify integer greater than 0.",
+      "KV PUT failed: 400 Invalid expiration_ttl of 0. Please specify integer greater than 0 and less than or equal to 2147483647.",
+  });
+  await t.throwsAsync(ns.put("key", "value", { expirationTtl: 2147483648 }), {
+    instanceOf: Error,
+    message:
+      "KV PUT failed: 400 Invalid expiration_ttl of 2147483648. Please specify integer greater than 0 and less than or equal to 2147483647.",
   });
   await t.throwsAsync(ns.put("key", "value", { expirationTtl: 30 }), {
     instanceOf: Error,
@@ -473,13 +478,18 @@ test("put: validates expiration", async (t) => {
   await t.throwsAsync(ns.put("key", "value", { expiration: "nan" }), {
     instanceOf: Error,
     message:
-      "KV PUT failed: 400 Invalid expiration of nan. Please specify integer greater than the current number of seconds since the UNIX epoch.",
+      "KV PUT failed: 400 Invalid expiration of nan. Please specify integer greater than the current number of seconds since the UNIX epoch, and less than or equal to 2147483647.",
   });
   // testClock sets current time to 750s since UNIX epoch
   await t.throwsAsync(ns.put("key", "value", { expiration: 750 }), {
     instanceOf: Error,
     message:
-      "KV PUT failed: 400 Invalid expiration of 750. Please specify integer greater than the current number of seconds since the UNIX epoch.",
+      "KV PUT failed: 400 Invalid expiration of 750. Please specify integer greater than the current number of seconds since the UNIX epoch, and less than or equal to 2147483647.",
+  });
+  await t.throwsAsync(ns.put("key", "value", { expiration: 2147483648 }), {
+    instanceOf: Error,
+    message:
+      "KV PUT failed: 400 Invalid expiration of 2147483648. Please specify integer greater than the current number of seconds since the UNIX epoch, and less than or equal to 2147483647.",
   });
   await t.throwsAsync(ns.put("key", "value", { expiration: 780 }), {
     instanceOf: Error,

--- a/packages/kv/test/namespace.spec.ts
+++ b/packages/kv/test/namespace.spec.ts
@@ -455,22 +455,27 @@ test("put: validates expiration ttl", async (t) => {
   await t.throwsAsync(ns.put("key", "value", { expirationTtl: "nan" }), {
     instanceOf: Error,
     message:
-      "KV PUT failed: 400 Invalid expiration_ttl of nan. Please specify integer greater than 0 and less than or equal to 2147483647.",
+      "KV PUT failed: 400 Invalid expiration_ttl of nan. Please specify integer greater than 0.",
   });
   await t.throwsAsync(ns.put("key", "value", { expirationTtl: 0 }), {
     instanceOf: Error,
     message:
-      "KV PUT failed: 400 Invalid expiration_ttl of 0. Please specify integer greater than 0 and less than or equal to 2147483647.",
-  });
-  await t.throwsAsync(ns.put("key", "value", { expirationTtl: 2147483648 }), {
-    instanceOf: Error,
-    message:
-      "KV PUT failed: 400 Invalid expiration_ttl of 2147483648. Please specify integer greater than 0 and less than or equal to 2147483647.",
+      "KV PUT failed: 400 Invalid expiration_ttl of 0. Please specify integer greater than 0.",
   });
   await t.throwsAsync(ns.put("key", "value", { expirationTtl: 30 }), {
     instanceOf: Error,
     message:
       "KV PUT failed: 400 Invalid expiration_ttl of 30. Expiration TTL must be at least 60.",
+  });
+  await t.throwsAsync(ns.put("key", "value", { expirationTtl: 2147483648 }), {
+    instanceOf: TypeError,
+    message:
+      "Value out of range. Must be between -2147483648 and 2147483647 (inclusive).",
+  });
+  await t.throwsAsync(ns.put("key", "value", { expirationTtl: -2147483649 }), {
+    instanceOf: Error,
+    message:
+      "KV PUT failed: 400 Invalid expiration_ttl of -2147483649. Please specify integer greater than 0.",
   });
 });
 test("put: validates expiration", async (t) => {
@@ -478,23 +483,28 @@ test("put: validates expiration", async (t) => {
   await t.throwsAsync(ns.put("key", "value", { expiration: "nan" }), {
     instanceOf: Error,
     message:
-      "KV PUT failed: 400 Invalid expiration of nan. Please specify integer greater than the current number of seconds since the UNIX epoch, and less than or equal to 2147483647.",
+      "KV PUT failed: 400 Invalid expiration of nan. Please specify integer greater than the current number of seconds since the UNIX epoch.",
   });
   // testClock sets current time to 750s since UNIX epoch
   await t.throwsAsync(ns.put("key", "value", { expiration: 750 }), {
     instanceOf: Error,
     message:
-      "KV PUT failed: 400 Invalid expiration of 750. Please specify integer greater than the current number of seconds since the UNIX epoch, and less than or equal to 2147483647.",
-  });
-  await t.throwsAsync(ns.put("key", "value", { expiration: 2147483648 }), {
-    instanceOf: Error,
-    message:
-      "KV PUT failed: 400 Invalid expiration of 2147483648. Please specify integer greater than the current number of seconds since the UNIX epoch, and less than or equal to 2147483647.",
+      "KV PUT failed: 400 Invalid expiration of 750. Please specify integer greater than the current number of seconds since the UNIX epoch.",
   });
   await t.throwsAsync(ns.put("key", "value", { expiration: 780 }), {
     instanceOf: Error,
     message:
       "KV PUT failed: 400 Invalid expiration of 780. Expiration times must be at least 60 seconds in the future.",
+  });
+  await t.throwsAsync(ns.put("key", "value", { expiration: 2147483648 }), {
+    instanceOf: TypeError,
+    message:
+      "Value out of range. Must be between -2147483648 and 2147483647 (inclusive).",
+  });
+  await t.throwsAsync(ns.put("key", "value", { expiration: -2147483649 }), {
+    instanceOf: Error,
+    message:
+      "KV PUT failed: 400 Invalid expiration of -2147483649. Please specify integer greater than the current number of seconds since the UNIX epoch.",
   });
 });
 test("put: validates value size", async (t) => {

--- a/packages/kv/test/namespace.spec.ts
+++ b/packages/kv/test/namespace.spec.ts
@@ -473,9 +473,9 @@ test("put: validates expiration ttl", async (t) => {
       "Value out of range. Must be between -2147483648 and 2147483647 (inclusive).",
   });
   await t.throwsAsync(ns.put("key", "value", { expirationTtl: -2147483649 }), {
-    instanceOf: Error,
+    instanceOf: TypeError,
     message:
-      "KV PUT failed: 400 Invalid expiration_ttl of -2147483649. Please specify integer greater than 0.",
+      "Value out of range. Must be between -2147483648 and 2147483647 (inclusive).",
   });
 });
 test("put: validates expiration", async (t) => {
@@ -502,9 +502,9 @@ test("put: validates expiration", async (t) => {
       "Value out of range. Must be between -2147483648 and 2147483647 (inclusive).",
   });
   await t.throwsAsync(ns.put("key", "value", { expiration: -2147483649 }), {
-    instanceOf: Error,
+    instanceOf: TypeError,
     message:
-      "KV PUT failed: 400 Invalid expiration of -2147483649. Please specify integer greater than the current number of seconds since the UNIX epoch.",
+      "Value out of range. Must be between -2147483648 and 2147483647 (inclusive).",
   });
 });
 test("put: validates value size", async (t) => {


### PR DESCRIPTION
Mostly self-explanatory, but a couple of thoughts:

1. I didn’t check whether `cacheTtl` on `get` is also subject to this limit.
2. I didn’t match the error to Cloudflare’s one, which is `TypeError: Value out of range. Must be between -2147483648 and 2147483647 (inclusive).`. My assumption is that Cloudflare are directly throwing a database error and this could be subject to change in the future. But if you want the errors to match let me know ^_^
3. I didn’t split out the message from the existing range ones, but can also do this if you’d like

You have more important things to do than edit this PR, so just let me know what changes you’d like and I will implement them ❤️

Resolves #485