### PR TITLE
Disable automatic handling of `Sec-WebSocket-Protocol` header

### DIFF
--- a/packages/tre/src/http/websocket.ts
+++ b/packages/tre/src/http/websocket.ts
@@ -267,6 +267,8 @@ export async function coupleWebSocket(
   pair.addEventListener("close", (e) => {
     if (e.code === 1005 /* No Status Received */) {
       ws.close();
+    } else if (e.code === 1006 /* Abnormal Closure */) {
+      ws.terminate();
     } else {
       ws.close(e.code, e.reason);
     }

--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -240,7 +240,13 @@ export class Miniflare {
     this.#log.debug(`Running workerd ${desc}...`);
 
     this.#liveReloadServer = new WebSocketServer({ noServer: true });
-    this.#webSocketServer = new WebSocketServer({ noServer: true });
+    this.#webSocketServer = new WebSocketServer({
+      noServer: true,
+      // Disable automatic handling of `Sec-WebSocket-Protocol` header,
+      // Cloudflare Workers require users to include this header themselves in
+      // `Response`s: https://github.com/cloudflare/miniflare/issues/179
+      handleProtocols: () => false,
+    });
     // Add custom headers included in response to WebSocket upgrade requests
     this.#webSocketExtraHeaders = new WeakMap();
     this.#webSocketServer.on("headers", (headers, req) => {


### PR DESCRIPTION
See #490 for a detailed description of the problem this solves.

Previously, we had `ws`'s automatic `Sec-WebSocket-Protocol` handling enabled, in addition to adding the header ourselves. This lead to duplicate sub-protocols in the WebSocket handshake response which is a protocol error.

Workers require users to include this header themselves in WebSocket `Response`s, so ignoring this key outright when copying headers would be incorrect. Instead, we just disable `ws`'s automatic handling. Funnily enough, we had exactly the same issue in Miniflare 2 too (#179), and fixed it in 34cc73a. Looks like the fix didn't make it into Miniflare 3 though. :(

This PR also fixes an issue where `1006` closures were not propagated correctly. This is an issue in Miniflare 2 too (#465), so we should back-port this.

Supersedes #490