### PR TITLE
Pass through WebSocket abnormal closure code

### DIFF
--- a/packages/web-sockets/src/index.ts
+++ b/packages/web-sockets/src/index.ts
@@ -7,5 +7,6 @@ export {
   WebSocket,
   WebSocketPair,
   coupleWebSocket,
+  _kClose,
 } from "./websocket";
 export type { WebSocketEventMap } from "./websocket";

--- a/packages/web-sockets/test/fetch.spec.ts
+++ b/packages/web-sockets/test/fetch.spec.ts
@@ -279,7 +279,7 @@ test("upgradingFetch: requires GET for web socket upgrade", async (t) => {
 });
 test("upgradeFetch: throws catchable error on connection failure", async (t) => {
   await t.throwsAsync(
-    upgradingFetch("http://[100::]", { headers: { upgrade: "websocket" } })
+    upgradingFetch("http://127.0.0.1:0", { headers: { upgrade: "websocket" } })
   );
 });
 test("upgradingFetch: increments subrequest count", async (t) => {


### PR DESCRIPTION
Previously, the abnormal closure close code `1006` was passed directly to `StandardWebSocket#close()`. This is forbidden, throwing an uncatchable validation error. With this change, the WebSocket is `terminate()`ed instead, propagating the `1006` code correctly to the other side of the connection.

Closes #465
Ref #493