### PR TITLE
Run API extractor on PRs and fix `@internal` WebSocket methods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
           node-version: lts/*
       - run: npm ci
       - run: npm run lint
-      - run: npm run types:build
+      - run: npm run types:bundle

--- a/packages/web-sockets/src/websocket.ts
+++ b/packages/web-sockets/src/websocket.ts
@@ -254,6 +254,7 @@ export class WebSocket extends InputGatedEventTarget<WebSocketEventMap> {
     this[kSend](message);
   }
 
+  /** @internal */
   [kSend](message: ArrayBuffer | string): void {
     // Split from send() so we can queue messages before accept() is called when
     // forwarding message events from the client
@@ -290,6 +291,7 @@ export class WebSocket extends InputGatedEventTarget<WebSocketEventMap> {
     this[_kClose](code, reason);
   }
 
+  /** @internal */
   [_kClose](code?: number, reason?: string): void {
     // Split from close() so we can queue closes before accept() is called, and
     // skip close code checks when forwarding close events from the client.
@@ -321,6 +323,7 @@ export class WebSocket extends InputGatedEventTarget<WebSocketEventMap> {
     void this.#queuingDispatchToPair(event);
   }
 
+  /** @internal */
   [kError](error?: Error): void {
     const event = new ErrorEvent("error", { error });
     void this.#queuingDispatchToPair(event);

--- a/scripts/types.mjs
+++ b/scripts/types.mjs
@@ -71,14 +71,7 @@ async function buildTypes() {
       showVerboseMessages: true,
     });
     errorCount += extractorRes.errorCount;
-    if (name !== "jest-environment-miniflare") {
-      // Ignore `jest-environment-miniflare` warnings. This package will never
-      // be used directly so correct type definitions aren't critical. We have
-      // integration tests for this package anyways, so if something breaks,
-      // we'll know.
-      // TODO: work out why these warnings are being thrown
-      warningCount += extractorRes.warningCount;
-    }
+    warningCount += extractorRes.warningCount;
   }
   const failed = errorCount + warningCount > 0;
   const colour = failed ? 31 : 32;


### PR DESCRIPTION
API extractor was failing as `[_kClose]()` wasn't marked as `@internal`, but `_kClose` was. We should be running `types:bundle` in PR CI to catch these types of issues.