### PR TITLE
Move `Range` header handling to `@miniflare/core`

### DIFF
--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -3,6 +3,7 @@ import {
   Request,
   RequestInfo,
   Response,
+  getRangeResponse,
   withImmutableHeaders,
   withStringFormDataFiles,
 } from "@miniflare/core";
@@ -12,7 +13,6 @@ import {
   Storage,
   assertInRequest,
   defaultClock,
-  getRangeResponse,
   getRequestContext,
   millisToSeconds,
   waitForOpenInputGate,

--- a/packages/core/src/standards/index.ts
+++ b/packages/core/src/standards/index.ts
@@ -51,4 +51,5 @@ export {
 } from "./streams";
 export type { ArrayBufferViewConstructor } from "./streams";
 export * from "./navigator";
+export * from "./range";
 export * from "./timers";

--- a/packages/core/src/standards/range.ts
+++ b/packages/core/src/standards/range.ts
@@ -1,7 +1,7 @@
 import { ReadableStream } from "stream/web";
 import { TextEncoder } from "util";
-import { Response } from "@miniflare/core";
 import { Headers } from "undici";
+import { Response } from "./http";
 
 const encoder = new TextEncoder();
 

--- a/packages/core/test/standards/range.spec.ts
+++ b/packages/core/test/standards/range.spec.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { getRangeResponse, parseRanges } from "@miniflare/shared";
+import { getRangeResponse, parseRanges } from "@miniflare/core";
 import { utf8Encode } from "@miniflare/shared-test";
 import test from "ava";
 import { Headers } from "undici";

--- a/packages/r2/src/bucket.ts
+++ b/packages/r2/src/bucket.ts
@@ -5,13 +5,13 @@ import crypto from "crypto";
 import { arrayBuffer } from "stream/consumers";
 import { ReadableStream } from "stream/web";
 import { TextEncoder } from "util";
+import { parseRanges } from "@miniflare/core";
 import {
   RangeStoredValueMeta,
   RequestContext,
   Storage,
   assertInRequest,
   getRequestContext,
-  parseRanges,
   viewToArray,
   waitForOpenInputGate,
   waitForOpenOutputGate,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,7 +6,6 @@ export * from "./event";
 export * from "./log";
 export * from "./plugin";
 export * from "./queues";
-export * from "./range";
 export * from "./runner";
 export * from "./storage";
 export * from "./sync/";


### PR DESCRIPTION
`range.ts` was previously located in `@miniflare/shared`, but had a dependency on `Response` from `@miniflare/core`. `@miniflare/shared` isn't meant to have any `@miniflare/*` dependencies, so this change moves the implementation to `@miniflare/core`.