### PR TITLE
Add support for D1 `meta.{last_row_id,changes}`

### DIFF
--- a/packages/d1/src/api.ts
+++ b/packages/d1/src/api.ts
@@ -34,8 +34,8 @@ interface SuccessResponse {
   served_by: string;
   meta: ResponseMeta | null;
   // These are deprecated in place of `meta`
-  lastRowId: number | null;
-  changes: number | null;
+  lastRowId: null;
+  changes: null;
 }
 
 const served_by = "miniflare.db";

--- a/packages/d1/test/d1js.spec.ts
+++ b/packages/d1/test/d1js.spec.ts
@@ -253,8 +253,8 @@ test("D1PreparedStatement: run", async (t) => {
     meta: {
       // Don't know duration, so just match on returned value asserted > 0
       duration: result.meta.duration,
-      last_row_id: null,
-      changes: null,
+      last_row_id: 4,
+      changes: 1,
       served_by: "miniflare.db",
       internal_stats: null,
     },
@@ -276,8 +276,8 @@ test("D1PreparedStatement: all", async (t) => {
     meta: {
       // Don't know duration, so just match on returned value asserted > 0
       duration: result.meta.duration,
-      last_row_id: null,
-      changes: null,
+      last_row_id: 0,
+      changes: 0,
       served_by: "miniflare.db",
       internal_stats: null,
     },
@@ -297,6 +297,8 @@ test("D1PreparedStatement: all", async (t) => {
     .bind(4, "yellow", 0xffff00)
     .all();
   t.deepEqual(result.results, []);
+  t.is(result.meta.last_row_id, 4);
+  t.is(result.meta.changes, 1);
   const id = await db
     .prepare("SELECT id FROM colours WHERE name = ?")
     .bind("yellow")


### PR DESCRIPTION
This PR adds support for `meta.last_row_id` and `meta.changes`. These appear to default to 0 in case of read-only statements. See https://discord.com/channels/595317990191398933/992060581832032316/1073479458952065094.

/cc @geelen (can't add you as a reviewer 😢)