### PR TITLE
Shared Durable Object instances across mounts

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -217,6 +217,7 @@ function throwNoScriptError(modules?: boolean) {
   throw new MiniflareCoreError("ERR_NO_SCRIPT", lines.join("\n"));
 }
 
+const kParentSharedCache = Symbol("kParentSharedCache");
 export interface MiniflareCoreContext {
   log: Log;
   storageFactory: StorageFactory;
@@ -224,7 +225,10 @@ export interface MiniflareCoreContext {
   scriptRunner?: ScriptRunner;
   scriptRequired?: boolean;
   scriptRunForModuleExports?: boolean;
-  isMount?: boolean;
+  // `kParentSharedCache` is used to determine if an instance is a mount, so we
+  // restrict setting it to internal users via a Symbol
+  /** @internal */
+  [kParentSharedCache]?: Map<string, unknown>;
 }
 
 export class ReloadEvent<Plugins extends PluginSignatures> extends Event {
@@ -253,6 +257,7 @@ export class MiniflareCore<
   #previousSetOptions: MiniflareCoreOptions<Plugins>;
   #overrides: PluginOptions<Plugins>;
   #previousOptions?: PluginOptions<Plugins>;
+  readonly #sharedCache: Map<string, unknown>; // See `PluginContext`
 
   readonly #ctx: MiniflareCoreContext;
   readonly #pluginStorages: PluginData<Plugins, PluginStorageFactory>;
@@ -291,11 +296,16 @@ export class MiniflareCore<
     this.#plugins = getPluginEntries(plugins);
     this.#previousSetOptions = options;
     this.#overrides = splitPluginOptions(this.#plugins, options);
+    this.#sharedCache = ctx[kParentSharedCache] ?? new Map();
 
     this.#ctx = ctx;
     this.#pluginStorages = new Map<keyof Plugins, PluginStorageFactory>();
 
     this.#initPromise = this.#init().then(() => this.#reload());
+  }
+
+  get #isMount() {
+    return this.#ctx[kParentSharedCache] !== undefined;
   }
 
   #updateWatch(
@@ -425,6 +435,7 @@ export class MiniflareCore<
       fetchMock,
       queueEventDispatcher,
       queueBroker,
+      sharedCache: this.#sharedCache,
     };
 
     // Log options and compatibility flags every time they might've changed
@@ -545,9 +556,9 @@ export class MiniflareCore<
                 ...rawOptions,
               };
         // - `"mounts" in mountOptions` detects nested mount options,
-        // - `this.#ctx.isMount` detects if `setOptions()` has been called on a
+        // - `this.#isMount` detects if `setOptions()` has been called on a
         //   mount with an object containing mount options
-        if ("mounts" in mountOptions || this.#ctx.isMount) {
+        if ("mounts" in mountOptions || this.#isMount) {
           throw new MiniflareCoreError(
             "ERR_MOUNT_NESTED",
             "Nested mounts are unsupported"
@@ -577,7 +588,7 @@ export class MiniflareCore<
             scriptRunForModuleExports: false,
             // Mark this as a mount, so we defer calling reload() hooks,
             // see #reload()
-            isMount: true,
+            [kParentSharedCache]: this.#sharedCache,
           };
           mount = new MiniflareCore(this.#originalPlugins, ctx, mountOptions);
           mount.addEventListener("reload", async (event) => {
@@ -707,11 +718,15 @@ export class MiniflareCore<
 
     // Run all before reload hooks, including mounts if we have any
     await this.#runAllBeforeReloads();
-    if (!this.#ctx.isMount) {
+    if (!this.#isMount) {
       // this.#mounts is set in #init() which is always called before this
       for (const mount of this.#mounts!.values()) {
         await mount.#runAllBeforeReloads();
       }
+      // Clear shared cache in parent after we've executed all `beforeReload()`s
+      // (i.e. clear references Durable Object instances which should cause them
+      // to get GCed)
+      this.#sharedCache.clear();
     }
 
     let script: ScriptBlueprint | undefined = undefined;
@@ -813,7 +828,7 @@ export class MiniflareCore<
     // called by the parent (us) once the root and all mounts have reloaded.
     // This ensures that if some mounts depend on other mounts, they'll
     // be ready when reload() hooks are called.
-    if (!this.#ctx.isMount) {
+    if (!this.#isMount) {
       // Run reload hooks, getting module exports for each mount (we await
       // getPlugins() for each mount before running #reload() so their scripts
       // must've been run)
@@ -1154,10 +1169,7 @@ export class MiniflareCore<
     // Start a new pipeline too.
     return new RequestContext({
       externalSubrequestLimit: usageModelExternalSubrequestLimit(usageModel),
-    }).runWith(() => {
-      const result = globalScope![kDispatchQueue]<WaitUntil>(batch);
-      return result;
-    });
+    }).runWith(() => globalScope![kDispatchQueue]<WaitUntil>(batch));
   }
 
   async dispose(): Promise<void> {
@@ -1183,5 +1195,6 @@ export class MiniflareCore<
       }
       this.#mounts.clear();
     }
+    if (!this.#isMount) this.#sharedCache.clear();
   }
 }

--- a/packages/core/test/plugins/bindings.spec.ts
+++ b/packages/core/test/plugins/bindings.spec.ts
@@ -21,7 +21,7 @@ import {
   getRequestContext,
   viewToBuffer,
 } from "@miniflare/shared";
-import { TestLog } from "@miniflare/shared-test";
+import { TestLog, unusable } from "@miniflare/shared-test";
 import {
   getObjectProperties,
   logPluginOptions,
@@ -44,6 +44,7 @@ const ctx: PluginContext = {
   rootPath,
   queueBroker,
   queueEventDispatcher,
+  sharedCache: unusable(),
 };
 
 const fixturesPath = path.join(__dirname, "..", "..", "..", "test", "fixtures");
@@ -340,10 +341,7 @@ test("BindingsPlugin: setup: loads .env bindings from default location", async (
   const tmp = await useTmp(t);
   const defaultEnvPath = path.join(tmp, ".env");
 
-  let plugin = new BindingsPlugin(
-    { log, compat, rootPath: tmp, queueBroker, queueEventDispatcher },
-    { envPath: true }
-  );
+  let plugin = new BindingsPlugin({ ...ctx, rootPath: tmp }, { envPath: true });
   // Shouldn't throw if file doesn't exist...
   let result = await plugin.setup();
   // ...but should still watch file
@@ -363,10 +361,7 @@ test("BindingsPlugin: setup: loads .env bindings from default location", async (
   });
 
   // Check default .env only loaded when envPath set to true
-  plugin = new BindingsPlugin(
-    { log, compat, rootPath: tmp, queueBroker, queueEventDispatcher },
-    {}
-  );
+  plugin = new BindingsPlugin({ ...ctx, rootPath: tmp }, {});
   result = await plugin.setup();
   t.deepEqual(result, { globals: undefined, bindings: {}, watch: [] });
 });
@@ -377,7 +372,7 @@ test("BindingsPlugin: setup: loads .env bindings from custom location", async (t
   await fs.writeFile(defaultEnvPath, "KEY=default");
 
   const plugin = new BindingsPlugin(
-    { log, compat, rootPath: tmp, queueBroker, queueEventDispatcher },
+    { ...ctx, rootPath: tmp },
     // Should resolve envPath relative to rootPath
     { envPath: ".env.custom" }
   );
@@ -416,13 +411,7 @@ test("BindingsPlugin: setup: loads WebAssembly bindings", async (t) => {
 
   // Check resolves wasmBindings path relative to rootPath
   plugin = new BindingsPlugin(
-    {
-      log,
-      compat,
-      rootPath: path.dirname(addModulePath),
-      queueBroker,
-      queueEventDispatcher,
-    },
+    { ...ctx, rootPath: path.dirname(addModulePath) },
     { wasmBindings: { ADD: path.basename(addModulePath) } }
   );
   result = await plugin.setup();
@@ -438,13 +427,7 @@ test("BindingsPlugin: setup: loads text blob bindings", async (t) => {
 
   // Check resolves text blob bindings path relative to rootPath
   plugin = new BindingsPlugin(
-    {
-      log,
-      compat,
-      rootPath: path.dirname(loremIpsumPath),
-      queueBroker,
-      queueEventDispatcher,
-    },
+    { ...ctx, rootPath: path.dirname(loremIpsumPath) },
     { textBlobBindings: { LOREM_IPSUM: "lorem-ipsum.txt" } }
   );
   result = await plugin.setup();
@@ -460,13 +443,7 @@ test("BindingsPlugin: setup: loads data blob bindings", async (t) => {
 
   // Check resolves data blob bindings path relative to rootPath
   plugin = new BindingsPlugin(
-    {
-      log,
-      compat,
-      rootPath: path.dirname(loremIpsumPath),
-      queueBroker,
-      queueEventDispatcher,
-    },
+    { ...ctx, rootPath: path.dirname(loremIpsumPath) },
     { dataBlobBindings: { BINARY_DATA: "lorem-ipsum.txt" } }
   );
   result = await plugin.setup();

--- a/packages/core/test/plugins/build.spec.ts
+++ b/packages/core/test/plugins/build.spec.ts
@@ -16,6 +16,7 @@ import {
   logPluginOptions,
   parsePluginArgv,
   parsePluginWranglerConfig,
+  unusable,
   useMiniflare,
   useTmp,
 } from "@miniflare/shared-test";
@@ -34,6 +35,7 @@ const ctx: PluginContext = {
   rootPath,
   queueBroker,
   queueEventDispatcher,
+  sharedCache: unusable(),
 };
 
 const rimrafPromise = promisify(rimraf);
@@ -118,7 +120,7 @@ test("BuildPlugin: beforeSetup: runs build successfully", async (t) => {
   const tmp = await useTmp(t);
   const log = new TestLog();
   const plugin = new BuildPlugin(
-    { log, compat, rootPath, queueBroker, queueEventDispatcher },
+    { ...ctx, log },
     {
       buildCommand: "echo test > test.txt",
       buildBasePath: tmp,
@@ -137,7 +139,7 @@ test("BuildPlugin: beforeSetup: builds in plugin context's rootPath", async (t) 
   const tmp = await useTmp(t);
   let plugin = new BuildPlugin(
     // This will be set to the mounted directory when mounting workers
-    { log, compat, rootPath: tmp, queueBroker, queueEventDispatcher },
+    { ...ctx, rootPath: tmp },
     { buildCommand: "echo test > test.txt" }
   );
   await plugin.beforeSetup();
@@ -148,7 +150,7 @@ test("BuildPlugin: beforeSetup: builds in plugin context's rootPath", async (t) 
   const dir = path.join(tmp, "dir");
   await fs.mkdir(dir);
   plugin = new BuildPlugin(
-    { log, compat, rootPath: tmp, queueBroker, queueEventDispatcher },
+    { ...ctx, rootPath: tmp },
     { buildCommand: "echo test > test.txt", buildBasePath: "dir" }
   );
   await plugin.beforeSetup();

--- a/packages/html-rewriter/test/plugin.spec.ts
+++ b/packages/html-rewriter/test/plugin.spec.ts
@@ -7,6 +7,7 @@ import {
   PluginContext,
   QueueEventDispatcher,
 } from "@miniflare/shared";
+import { unusable } from "@miniflare/shared-test";
 import test from "ava";
 import type { ElementHandlers } from "html-rewriter-wasm";
 
@@ -21,6 +22,7 @@ const ctx: PluginContext = {
   rootPath,
   queueBroker,
   queueEventDispatcher,
+  sharedCache: unusable(),
 };
 
 test("HTMLRewriterPlugin: setup: includes HTMLRewriter in globals", (t) => {

--- a/packages/http-server/test/plugin.spec.ts
+++ b/packages/http-server/test/plugin.spec.ts
@@ -17,6 +17,7 @@ import {
   logPluginOptions,
   parsePluginArgv,
   parsePluginWranglerConfig,
+  unusable,
   useServer,
   useTmp,
 } from "@miniflare/shared-test";
@@ -33,6 +34,7 @@ const ctx: PluginContext = {
   rootPath,
   queueBroker,
   queueEventDispatcher,
+  sharedCache: unusable(),
 };
 
 test("HTTPPlugin: parses options from argv", (t) => {
@@ -236,7 +238,7 @@ test("HTTPPlugin: setupCf: cf fetch caches cf.json at default location", async (
   );
   const log = new TestLog();
   const plugin = new HTTPPlugin(
-    { log, compat, rootPath, queueBroker, queueEventDispatcher },
+    { ...ctx, log },
     {},
     { cfPath, cfFetch: true, cfFetchEndpoint: upstream }
   );
@@ -257,7 +259,7 @@ test("HTTPPlugin: setupCf: cf fetch caches cf.json at custom location", async (t
   );
   const log = new TestLog();
   const plugin = new HTTPPlugin(
-    { log, compat, rootPath, queueBroker, queueEventDispatcher },
+    { ...ctx, log },
     { cfFetch: customCfPath },
     { cfPath: defaultCfPath, cfFetch: true, cfFetchEndpoint: upstream }
   );
@@ -300,7 +302,7 @@ test("HTTPPlugin: setupCf: cf fetch refetches cf.json if stale", async (t) => {
   );
   const log = new TestLog();
   const plugin = new HTTPPlugin(
-    { log, compat, rootPath, queueBroker, queueEventDispatcher },
+    { ...ctx, log },
     {},
     { cfPath, cfFetch: true, cfFetchEndpoint: upstream, clock }
   );
@@ -392,7 +394,7 @@ test("HTTPPlugin: setupHttps: generates self-signed certificate at default locat
   const log = new TestLog();
   const tmp = await useTmp(t);
   const plugin = new HTTPPlugin(
-    { log, compat, rootPath, queueBroker, queueEventDispatcher },
+    { ...ctx, log },
     { https: true },
     { certRoot: tmp }
   );
@@ -417,7 +419,7 @@ test("HTTPPlugin: setupHttps: generates self-signed certificate at custom locati
   const tmpDefault = await useTmp(t);
   const tmpCustom = await useTmp(t);
   const plugin = new HTTPPlugin(
-    { log, compat, rootPath, queueBroker, queueEventDispatcher },
+    { ...ctx, log },
     { https: tmpCustom },
     { certRoot: tmpDefault }
   );
@@ -445,7 +447,7 @@ test("HTTPPlugin: setupHttps: reuses existing non-expired certificates", async (
   await fs.writeFile(path.join(tmp, "key.pem"), "existing_key", "utf8");
   await fs.writeFile(path.join(tmp, "cert.pem"), "existing_cert", "utf8");
   const plugin = new HTTPPlugin(
-    { log, compat, rootPath, queueBroker, queueEventDispatcher },
+    { ...ctx, log },
     { https: true },
     { certRoot: tmp }
   );
@@ -467,7 +469,7 @@ test("HTTPPlugin: setupHttps: regenerates self-signed certificate if expired", a
   await fs.writeFile(path.join(tmp, "cert.pem"), "expired_cert", "utf8");
   const clock: Clock = () => Date.now() + 86400000 * 30; // now + 30 days
   const plugin = new HTTPPlugin(
-    { log, compat, rootPath, queueBroker, queueEventDispatcher },
+    { ...ctx, log },
     { https: true },
     { certRoot: tmp, clock }
   );

--- a/packages/scheduler/test/plugin.spec.ts
+++ b/packages/scheduler/test/plugin.spec.ts
@@ -10,6 +10,7 @@ import {
   logPluginOptions,
   parsePluginArgv,
   parsePluginWranglerConfig,
+  unusable,
 } from "@miniflare/shared-test";
 import test from "ava";
 
@@ -24,6 +25,7 @@ const ctx: PluginContext = {
   rootPath,
   queueBroker,
   queueEventDispatcher,
+  sharedCache: unusable(),
 };
 
 test("SchedulerPlugin: parses options from argv", (t) => {

--- a/packages/shared-test/src/asserts.ts
+++ b/packages/shared-test/src/asserts.ts
@@ -66,3 +66,29 @@ export async function advancesTime<T>(
   t.not(ctx.currentTime, previous);
   return result;
 }
+
+export function unusable<T extends object>(): T {
+  return new Proxy({} as T, {
+    apply() {
+      throw new TypeError("Attempted to call unusable object");
+    },
+    construct() {
+      throw new TypeError("Attempted to construct unusable object");
+    },
+    deleteProperty(target, prop) {
+      throw new TypeError(
+        `Attempted to delete \"${String(prop)}\" on unusable object`
+      );
+    },
+    get(target, prop) {
+      throw new TypeError(
+        `Attempted to get \"${String(prop)}\" on unusable object`
+      );
+    },
+    set(target, prop) {
+      throw new TypeError(
+        `Attempted to set \"${String(prop)}\" on unusable object`
+      );
+    },
+  });
+}

--- a/packages/shared/src/plugin.ts
+++ b/packages/shared/src/plugin.ts
@@ -99,6 +99,31 @@ export interface PluginContext {
   fetchMock?: MockAgent;
   queueEventDispatcher: QueueEventDispatcher;
   queueBroker: QueueBroker;
+  // Cache shared between all mounted instances of this plugin within a
+  // Miniflare instance. Cleared after all `beforeReload()` hooks have executed.
+  // Used by the Durable Objects plugin to ensure single instances of objects
+  // across mounts.
+  sharedCache: Map<string, unknown>;
+}
+
+export interface TypedMap<ValueMap extends Record<string, unknown>> {
+  clear(): void;
+  delete(key: keyof ValueMap): boolean;
+  forEach(
+    callback: (
+      value: ValueOf<ValueMap>,
+      key: keyof ValueMap,
+      map: this
+    ) => void,
+    thisArg?: any
+  ): void;
+  get<Key extends keyof ValueMap>(key: Key): ValueMap[Key] | undefined;
+  has(key: keyof ValueMap): boolean;
+  set<Key extends keyof ValueMap>(key: Key, value: ValueMap[Key]): void;
+  keys(): IterableIterator<keyof ValueMap>;
+  values(): IterableIterator<ValueOf<ValueMap>>;
+  entries(): IterableIterator<[keyof ValueMap, ValueOf<ValueMap>]>;
+  [Symbol.iterator](): IterableIterator<[keyof ValueMap, ValueOf<ValueMap>]>;
 }
 
 export abstract class Plugin<Options extends Context = never> {

--- a/packages/sites/test/plugin.spec.ts
+++ b/packages/sites/test/plugin.spec.ts
@@ -14,6 +14,7 @@ import {
   logPluginOptions,
   parsePluginArgv,
   parsePluginWranglerConfig,
+  unusable,
   useMiniflare,
   useTmp,
 } from "@miniflare/shared-test";
@@ -31,6 +32,7 @@ const ctx: PluginContext = {
   rootPath,
   queueBroker,
   queueEventDispatcher,
+  sharedCache: unusable(),
 };
 
 test("SitesPlugin: parses options from argv", (t) => {
@@ -86,7 +88,7 @@ test("SitesPlugin: setup: returns empty result if no site", async (t) => {
 test("SitesPlugin: setup: includes read-only content namespace and watches files", async (t) => {
   const tmp = await useTmp(t);
   const plugin = new SitesPlugin(
-    { log, compat, rootPath: tmp, queueBroker, queueEventDispatcher },
+    { ...ctx, rootPath: tmp },
     { sitePath: "site" }
   );
   const result = await plugin.setup();
@@ -116,7 +118,7 @@ test("SitesPlugin: setup: includes populated manifest", async (t) => {
   await fs.writeFile(path.join(tmp, "4.jsx"), "test4", "utf8");
 
   const plugin = new SitesPlugin(
-    { log, compat, rootPath: tmp, queueBroker, queueEventDispatcher },
+    { ...ctx, rootPath: tmp },
     { sitePath: tmp, siteInclude: ["*.txt"], siteExclude: ["3.txt"] }
   );
   let result = await plugin.setup();


### PR DESCRIPTION
A core guarantee of Durable Objects is global uniqueness: there will only ever be a single instance of a Durable Object class with a given ID running at once. Miniflare stores instances of Durable Objects in instances of `DurableObjectsPlugin`. These object instances get reset on every script change. If a stub attempts to fetch the object again, a new instance will be created with the new code. Unfortunately, each mount has its own `DurableObjectsPlugin`, meaning stubs in each mount were unable to see instances created by other mounts, and hence created their own. This broke global uniqueness.

This change introduces the concept of a `sharedCache` between all mounts in a `Miniflare` instance. This is created when `new Miniflare()` is called, then passed to all mounts and all their plugins via context. The parent `Miniflare` instance will clear this after all `beforeReload()`/`dispose()` hooks have run. `DurableObjectsPlugin`s now use this to store active instances and their corresponding storages.

Closes #461