### PR TITLE
chore: bump undici and other packages to resolve audit warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,9 +113,10 @@
       }
     },
     "node_modules/@babel/core/node_modules/json5": {
-      "version": "2.2.1",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -5083,8 +5084,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "license": "BSD-2-Clause"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/human-id": {
       "version": "1.0.2",
@@ -6543,9 +6545,10 @@
       "license": "MIT"
     },
     "node_modules/json5": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -6982,9 +6985,10 @@
       "link": true
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -9611,9 +9615,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.11.0.tgz",
-      "integrity": "sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -10190,7 +10194,7 @@
         "@miniflare/core": "2.12.0",
         "@miniflare/shared": "2.12.0",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.11.0"
+        "undici": "5.20.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.12.0",
@@ -10232,7 +10236,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.11.0",
+        "undici": "5.20.0",
         "urlpattern-polyfill": "^4.0.3"
       },
       "devDependencies": {
@@ -10271,7 +10275,7 @@
         "@miniflare/core": "2.12.0",
         "@miniflare/shared": "2.12.0",
         "@miniflare/storage-memory": "2.12.0",
-        "undici": "5.11.0"
+        "undici": "5.20.0"
       },
       "devDependencies": {
         "@miniflare/cache": "2.12.0",
@@ -10290,7 +10294,7 @@
         "@miniflare/core": "2.12.0",
         "@miniflare/shared": "2.12.0",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.11.0"
+        "undici": "5.20.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.12.0"
@@ -10309,7 +10313,7 @@
         "@miniflare/web-sockets": "2.12.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.11.0",
+        "undici": "5.20.0",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
@@ -10391,7 +10395,7 @@
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.11.0"
+        "undici": "5.20.0"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -10441,7 +10445,7 @@
       "license": "MIT",
       "dependencies": {
         "@miniflare/shared": "2.12.0",
-        "undici": "5.11.0"
+        "undici": "5.20.0"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.12.0"
@@ -10645,7 +10649,7 @@
       "dependencies": {
         "@miniflare/core": "2.12.0",
         "@miniflare/shared": "2.12.0",
-        "undici": "5.11.0",
+        "undici": "5.20.0",
         "ws": "^8.2.2"
       },
       "devDependencies": {
@@ -10707,7 +10711,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "2.2.1",
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
           "dev": true
         },
         "semver": {
@@ -11931,7 +11937,7 @@
         "@miniflare/web-sockets": "2.12.0",
         "@types/http-cache-semantics": "^4.0.1",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.11.0"
+        "undici": "5.20.0"
       }
     },
     "@miniflare/cli-parser": {
@@ -11962,7 +11968,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.11.0",
+        "undici": "5.20.0",
         "urlpattern-polyfill": "^4.0.3"
       }
     },
@@ -11983,7 +11989,7 @@
         "@miniflare/shared": "2.12.0",
         "@miniflare/shared-test": "2.12.0",
         "@miniflare/storage-memory": "2.12.0",
-        "undici": "5.11.0"
+        "undici": "5.20.0"
       }
     },
     "@miniflare/html-rewriter": {
@@ -11993,7 +11999,7 @@
         "@miniflare/shared": "2.12.0",
         "@miniflare/shared-test": "2.12.0",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.11.0"
+        "undici": "5.20.0"
       }
     },
     "@miniflare/http-server": {
@@ -12006,7 +12012,7 @@
         "@types/node-forge": "^0.10.4",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.11.0",
+        "undici": "5.20.0",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
@@ -12030,7 +12036,7 @@
       "requires": {
         "@miniflare/shared": "2.12.0",
         "@miniflare/shared-test": "2.12.0",
-        "undici": "5.11.0"
+        "undici": "5.20.0"
       }
     },
     "@miniflare/runner-vm": {
@@ -12140,7 +12146,7 @@
         "@miniflare/shared": "2.12.0",
         "@miniflare/shared-test": "2.12.0",
         "@types/ws": "^8.2.0",
-        "undici": "5.11.0",
+        "undici": "5.20.0",
         "ws": "^8.2.2"
       }
     },
@@ -14205,7 +14211,9 @@
       "version": "0.4.1"
     },
     "http-cache-semantics": {
-      "version": "4.1.0"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "human-id": {
       "version": "1.0.2",
@@ -15144,7 +15152,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -15443,11 +15453,13 @@
         "open": "^8.4.0",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.11.0"
+        "undici": "5.20.0"
       }
     },
     "minimatch": {
-      "version": "3.0.4",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -17065,9 +17077,9 @@
       }
     },
     "undici": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.11.0.tgz",
-      "integrity": "sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "requires": {
         "busboy": "^1.6.0"
       }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.12.0",
     "@miniflare/shared": "2.12.0",
     "http-cache-semantics": "^4.1.0",
-    "undici": "5.11.0"
+    "undici": "5.20.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.12.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "dotenv": "^10.0.0",
     "kleur": "^4.1.4",
     "set-cookie-parser": "^2.4.8",
-    "undici": "5.11.0",
+    "undici": "5.20.0",
     "urlpattern-polyfill": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/durable-objects/package.json
+++ b/packages/durable-objects/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.12.0",
     "@miniflare/shared": "2.12.0",
     "@miniflare/storage-memory": "2.12.0",
-    "undici": "5.11.0"
+    "undici": "5.20.0"
   },
   "devDependencies": {
     "@miniflare/cache": "2.12.0",

--- a/packages/html-rewriter/package.json
+++ b/packages/html-rewriter/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.12.0",
     "@miniflare/shared": "2.12.0",
     "html-rewriter-wasm": "^0.4.1",
-    "undici": "5.11.0"
+    "undici": "5.20.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.12.0"

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -40,7 +40,7 @@
     "@miniflare/web-sockets": "2.12.0",
     "kleur": "^4.1.4",
     "selfsigned": "^2.0.0",
-    "undici": "5.11.0",
+    "undici": "5.20.0",
     "ws": "^8.2.2",
     "youch": "^2.2.2"
   },

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -66,7 +66,7 @@
     "kleur": "^4.1.4",
     "semiver": "^1.1.0",
     "source-map-support": "^0.5.20",
-    "undici": "5.11.0"
+    "undici": "5.20.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.12.0",

--- a/packages/r2/package.json
+++ b/packages/r2/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@miniflare/shared": "2.12.0",
-    "undici": "5.11.0"
+    "undici": "5.20.0"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.12.0"

--- a/packages/web-sockets/package.json
+++ b/packages/web-sockets/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@miniflare/core": "2.12.0",
     "@miniflare/shared": "2.12.0",
-    "undici": "5.11.0",
+    "undici": "5.20.0",
     "ws": "^8.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR bumps undici to 5.20.0 which resolves https://github.com/advisories/GHSA-5r9g-qh6m-jxff and https://github.com/advisories/GHSA-r6ch-mqf9-qc9w. This removes the scary `npm audit` warnings when installing wrangler.