### PR TITLE
Copy known-length when `tee()` `ReadableStream`s, closes #506

### DIFF
--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -57,6 +57,7 @@ import {
 import {
   _isByteStream,
   convertToRegularStream,
+  kBodyStreamBrand,
   kContentLength,
 } from "./streams";
 
@@ -162,7 +163,6 @@ export function _headersFromIncomingRequest(
 export const _kInner = Symbol("kInner");
 
 const kBodyStream = Symbol("kBodyStream");
-const kBodyStreamBrand = Symbol("kBodyStreamBrand");
 const kInputGated = Symbol("kInputGated");
 const kFormDataFiles = Symbol("kFormDataFiles");
 const kCloned = Symbol("kCloned");

--- a/packages/r2/test/multipart.spec.ts
+++ b/packages/r2/test/multipart.spec.ts
@@ -177,8 +177,9 @@ test("R2MultipartUpload: uploadPart", async (t) => {
   const response = new Response("value7");
   assert(request.body !== null && response.body !== null);
   await upload.uploadPart(5, readable);
-  await upload.uploadPart(6, request.body);
-  await upload.uploadPart(7, response.body);
+  // Check `tee()`ing body inherits known length
+  await upload.uploadPart(6, request.body.tee()[0]);
+  await upload.uploadPart(7, response.body.tee()[1]);
   const unknownLengthReadable = new ReadableStream({
     type: "bytes",
     pull(controller) {


### PR DESCRIPTION
Previously calling `ReadableStream#tee()` would discard the fixed-length from `FixedLengthStream`s and the body-stream marker from `Request`/`Response` streams. This meant attempting to upload `tee()`ed streams as R2 multipart parts would fail. This change updates the `tee()` implementation to copy these across.