### PR TITLE
[Miniflare 3] Add support for routing to multiple Workers

### DIFF
--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -168,7 +168,9 @@ function getWorkerRoutes(
   const allRoutes = new Map<string, string[]>();
   for (const workerOpts of allWorkerOpts) {
     if (workerOpts.core.routes !== undefined) {
-      allRoutes.set(workerOpts.core.name ?? "", workerOpts.core.routes);
+      const name = workerOpts.core.name ?? "";
+      assert(!allRoutes.has(name));
+      allRoutes.set(name, workerOpts.core.routes);
     }
   }
   return allRoutes;

--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -124,7 +124,9 @@ function validateOptions(
     if (names.has(name)) {
       throw new MiniflareCoreError(
         "ERR_DUPLICATE_NAME",
-        `Multiple workers defined with the same name: "${name}"`
+        name === ""
+          ? "Multiple workers defined without a `name`"
+          : `Multiple workers defined with the same \`name\`: "${name}"`
       );
     }
     names.add(name);

--- a/packages/tre/src/plugins/cache/index.ts
+++ b/packages/tre/src/plugins/cache/index.ts
@@ -1,6 +1,4 @@
 import { z } from "zod";
-import { Worker_Binding } from "../../runtime";
-import { SERVICE_LOOPBACK } from "../core";
 import {
   BINDING_SERVICE_LOOPBACK,
   BINDING_TEXT_PERSIST,
@@ -9,6 +7,7 @@ import {
   HEADER_PERSIST,
   PersistenceSchema,
   Plugin,
+  WORKER_BINDING_SERVICE_LOOPBACK,
   encodePersist,
 } from "../shared";
 import { HEADER_CACHE_WARN_USAGE } from "./constants";
@@ -69,10 +68,6 @@ export const CACHE_PLUGIN: Plugin<
   },
   getServices({ sharedOptions, options, workerIndex }) {
     const persistBinding = encodePersist(sharedOptions.cachePersist);
-    const loopbackBinding: Worker_Binding = {
-      name: BINDING_SERVICE_LOOPBACK,
-      service: { name: SERVICE_LOOPBACK },
-    };
     return [
       {
         name: getCacheServiceName(workerIndex),
@@ -87,7 +82,7 @@ export const CACHE_PLUGIN: Plugin<
               name: BINDING_JSON_CACHE_WARN_USAGE,
               json: JSON.stringify(options.cacheWarnUsage ?? false),
             },
-            loopbackBinding,
+            WORKER_BINDING_SERVICE_LOOPBACK,
           ],
           compatibilityDate: "2022-09-01",
         },

--- a/packages/tre/src/plugins/cache/index.ts
+++ b/packages/tre/src/plugins/cache/index.ts
@@ -24,6 +24,7 @@ export const CacheSharedOptionsSchema = z.object({
 
 const BINDING_JSON_CACHE_WARN_USAGE = "MINIFLARE_CACHE_WARN_USAGE";
 
+const CACHE_SCRIPT_COMPAT_DATE = "2022-09-01";
 export const CACHE_LOOPBACK_SCRIPT = `addEventListener("fetch", (event) => {
   const request = new Request(event.request);
   const url = new URL(request.url);
@@ -84,7 +85,7 @@ export const CACHE_PLUGIN: Plugin<
             },
             WORKER_BINDING_SERVICE_LOOPBACK,
           ],
-          compatibilityDate: "2022-09-01",
+          compatibilityDate: CACHE_SCRIPT_COMPAT_DATE,
         },
       },
     ];

--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -15,7 +15,6 @@ import { getCacheServiceName } from "../cache";
 import { DURABLE_OBJECTS_STORAGE_SERVICE_NAME } from "../do";
 import {
   BINDING_SERVICE_LOOPBACK,
-  CORE_PLUGIN_NAME,
   CloudflareFetchSchema,
   HEADER_CF_BLOB,
   Plugin,
@@ -71,6 +70,8 @@ export const CoreSharedOptionsSchema = z.object({
 
   liveReload: z.boolean().optional(),
 });
+
+export const CORE_PLUGIN_NAME = "core";
 
 // Service for HTTP socket entrypoint (for checking runtime ready, routing, etc)
 export const SERVICE_ENTRY = `${CORE_PLUGIN_NAME}:entry`;

--- a/packages/tre/src/plugins/core/modules.ts
+++ b/packages/tre/src/plugins/core/modules.ts
@@ -61,6 +61,36 @@ export const ModuleDefinitionSchema = z.object({
 });
 export type ModuleDefinition = z.infer<typeof ModuleDefinitionSchema>;
 
+export const SourceOptionsSchema = z.union([
+  z.object({
+    // Manually defined modules
+    // (used by Wrangler which has its own module collection code)
+    modules: z.array(ModuleDefinitionSchema),
+    // `modules` "name"s will be their paths relative to this value.
+    // This ensures file paths in stack traces are correct.
+    modulesRoot: z.string().optional(),
+  }),
+  z.object({
+    script: z.string(),
+    // Optional script path for resolving modules, and stack traces file names
+    scriptPath: z.string().optional(),
+    // Automatically collect modules by parsing `script` if `true`, or treat as
+    // service-worker if `false`
+    modules: z.boolean().optional(),
+    // How to interpret automatically collected modules
+    modulesRules: z.array(ModuleRuleSchema).optional(),
+  }),
+  z.object({
+    scriptPath: z.string(),
+    // Automatically collect modules by parsing `scriptPath` if `true`, or treat
+    // as service-worker if `false`
+    modules: z.boolean().optional(),
+    // How to interpret automatically collected modules
+    modulesRules: z.array(ModuleRuleSchema).optional(),
+  }),
+]);
+export type SourceOptions = z.infer<typeof SourceOptionsSchema>;
+
 const DEFAULT_MODULE_RULES: ModuleRule[] = [
   { type: "ESModule", include: ["**/*.mjs"] },
   { type: "CommonJS", include: ["**/*.js", "**/*.cjs"] },

--- a/packages/tre/src/plugins/d1/index.ts
+++ b/packages/tre/src/plugins/d1/index.ts
@@ -1,14 +1,10 @@
 import { z } from "zod";
 import { Service, Worker_Binding } from "../../runtime";
 import {
-  BINDING_TEXT_NAMESPACE,
-  BINDING_TEXT_PLUGIN,
   PersistenceSchema,
   Plugin,
-  SCRIPT_PLUGIN_NAMESPACE_PERSIST,
-  WORKER_BINDING_SERVICE_LOOPBACK,
-  encodePersist,
   namespaceEntries,
+  pluginNamespacePersistWorker,
 } from "../shared";
 import { D1Gateway } from "./gateway";
 import { D1Router } from "./router";
@@ -40,20 +36,11 @@ export const D1_PLUGIN: Plugin<
     }));
   },
   getServices({ options, sharedOptions }) {
-    const persistBinding = encodePersist(sharedOptions.d1Persist);
+    const persist = sharedOptions.d1Persist;
     const databases = namespaceEntries(options.d1Databases);
     return databases.map<Service>(([_, id]) => ({
       name: `${SERVICE_DATABASE_PREFIX}:${id}`,
-      worker: {
-        serviceWorkerScript: SCRIPT_PLUGIN_NAMESPACE_PERSIST,
-        compatibilityDate: "2022-09-01",
-        bindings: [
-          ...persistBinding,
-          { name: BINDING_TEXT_PLUGIN, text: D1_PLUGIN_NAME },
-          { name: BINDING_TEXT_NAMESPACE, text: id },
-          WORKER_BINDING_SERVICE_LOOPBACK,
-        ],
-      },
+      worker: pluginNamespacePersistWorker(D1_PLUGIN_NAME, id, persist),
     }));
   },
 };

--- a/packages/tre/src/plugins/d1/index.ts
+++ b/packages/tre/src/plugins/d1/index.ts
@@ -1,13 +1,12 @@
 import { z } from "zod";
 import { Service, Worker_Binding } from "../../runtime";
-import { SERVICE_LOOPBACK } from "../core";
 import {
-  BINDING_SERVICE_LOOPBACK,
   BINDING_TEXT_NAMESPACE,
   BINDING_TEXT_PLUGIN,
   PersistenceSchema,
   Plugin,
   SCRIPT_PLUGIN_NAMESPACE_PERSIST,
+  WORKER_BINDING_SERVICE_LOOPBACK,
   encodePersist,
   namespaceEntries,
 } from "../shared";
@@ -52,10 +51,7 @@ export const D1_PLUGIN: Plugin<
           ...persistBinding,
           { name: BINDING_TEXT_PLUGIN, text: D1_PLUGIN_NAME },
           { name: BINDING_TEXT_NAMESPACE, text: id },
-          {
-            name: BINDING_SERVICE_LOOPBACK,
-            service: { name: SERVICE_LOOPBACK },
-          },
+          WORKER_BINDING_SERVICE_LOOPBACK,
         ],
       },
     }));

--- a/packages/tre/src/plugins/index.ts
+++ b/packages/tre/src/plugins/index.ts
@@ -1,10 +1,11 @@
 import { ValueOf } from "../shared";
 import { CACHE_PLUGIN, CACHE_PLUGIN_NAME } from "./cache";
-import { CORE_PLUGIN, CORE_PLUGIN_NAME } from "./core";
+import { CORE_PLUGIN } from "./core";
 import { D1_PLUGIN, D1_PLUGIN_NAME } from "./d1";
 import { DURABLE_OBJECTS_PLUGIN, DURABLE_OBJECTS_PLUGIN_NAME } from "./do";
 import { KV_PLUGIN, KV_PLUGIN_NAME } from "./kv";
 import { R2_PLUGIN, R2_PLUGIN_NAME } from "./r2";
+import { CORE_PLUGIN_NAME } from "./shared";
 
 export const PLUGINS = {
   [CORE_PLUGIN_NAME]: CORE_PLUGIN,
@@ -22,7 +23,7 @@ export const PLUGIN_ENTRIES = Object.entries(PLUGINS) as [
 ][];
 
 export * from "./shared";
-export { SERVICE_LOOPBACK, SERVICE_ENTRY, HEADER_PROBE } from "./core";
+export { SERVICE_ENTRY, HEADER_PROBE, getGlobalServices } from "./core";
 
 // TODO: be more liberal on exports?
 export * from "./cache";
@@ -31,7 +32,12 @@ export {
   ModuleRuleSchema,
   ModuleDefinitionSchema,
 } from "./core";
-export type { ModuleRuleType, ModuleRule, ModuleDefinition } from "./core";
+export type {
+  ModuleRuleType,
+  ModuleRule,
+  ModuleDefinition,
+  GlobalServicesOptions,
+} from "./core";
 export * from "./d1";
 export * from "./do";
 export * from "./kv";

--- a/packages/tre/src/plugins/index.ts
+++ b/packages/tre/src/plugins/index.ts
@@ -1,12 +1,11 @@
 import { z } from "zod";
 import { ValueOf } from "../shared";
 import { CACHE_PLUGIN, CACHE_PLUGIN_NAME } from "./cache";
-import { CORE_PLUGIN } from "./core";
+import { CORE_PLUGIN, CORE_PLUGIN_NAME } from "./core";
 import { D1_PLUGIN, D1_PLUGIN_NAME } from "./d1";
 import { DURABLE_OBJECTS_PLUGIN, DURABLE_OBJECTS_PLUGIN_NAME } from "./do";
 import { KV_PLUGIN, KV_PLUGIN_NAME } from "./kv";
 import { R2_PLUGIN, R2_PLUGIN_NAME } from "./r2";
-import { CORE_PLUGIN_NAME } from "./shared";
 
 export const PLUGINS = {
   [CORE_PLUGIN_NAME]: CORE_PLUGIN,

--- a/packages/tre/src/plugins/index.ts
+++ b/packages/tre/src/plugins/index.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { ValueOf } from "../shared";
 import { CACHE_PLUGIN, CACHE_PLUGIN_NAME } from "./cache";
 import { CORE_PLUGIN } from "./core";
@@ -14,8 +15,56 @@ export const PLUGINS = {
   [DURABLE_OBJECTS_PLUGIN_NAME]: DURABLE_OBJECTS_PLUGIN,
   [KV_PLUGIN_NAME]: KV_PLUGIN,
   [R2_PLUGIN_NAME]: R2_PLUGIN,
-} as const;
+};
 export type Plugins = typeof PLUGINS;
+
+// Note, we used to define these as...
+//
+// ```ts
+// // A | B | ... => A & B & ... (https://stackoverflow.com/a/50375286)
+// export type UnionToIntersection<U> = (
+//   U extends any ? (k: U) => void : never
+// ) extends (k: infer I) => void
+//   ? I
+//   : never;
+// export type WorkerOptions = UnionToIntersection<
+//   z.infer<ValueOf<Plugins>["options"]>
+// >;
+// export type SharedOptions = UnionToIntersection<
+//   z.infer<Exclude<ValueOf<Plugins>["sharedOptions"], undefined>>
+// >;
+// ```
+//
+// This caused issues when we tried to make `CORE_PLUGIN.options` an
+// intersection of a union type (source options) and a regular object type.
+//
+// ```ts
+// type A = { x: 1 } | { x: 2 };
+// type B = A & { y: string };
+// type C = UnionToIntersection<B>;
+// ```
+//
+// In the above example, `C` is typed `{x: 1} & {x: 2} & {y: string}` which
+// simplifies to `never`. Using `[U] extends [any]` instead of `U extends any`
+// disables distributivity of union types over conditional types, which types
+// `C` `({x: 1} | {x: 2}) & {y: string}` as expected. Unfortunately, this
+// appears to prevent us assigning to any `MiniflareOptions` instances after
+// creation, which we do quite a lot in tests.
+//
+// Considering we don't have too many plugins, we now just define these types
+// manually, which has the added benefit of faster type checking.
+export type WorkerOptions = z.infer<typeof CORE_PLUGIN.options> &
+  z.infer<typeof CACHE_PLUGIN.options> &
+  z.infer<typeof D1_PLUGIN.options> &
+  z.infer<typeof DURABLE_OBJECTS_PLUGIN.options> &
+  z.infer<typeof KV_PLUGIN.options> &
+  z.infer<typeof R2_PLUGIN.options>;
+export type SharedOptions = z.infer<typeof CORE_PLUGIN.sharedOptions> &
+  z.infer<typeof CACHE_PLUGIN.sharedOptions> &
+  z.infer<typeof D1_PLUGIN.sharedOptions> &
+  z.infer<typeof DURABLE_OBJECTS_PLUGIN.sharedOptions> &
+  z.infer<typeof KV_PLUGIN.sharedOptions> &
+  z.infer<typeof R2_PLUGIN.sharedOptions>;
 
 export const PLUGIN_ENTRIES = Object.entries(PLUGINS) as [
   keyof Plugins,
@@ -23,20 +72,28 @@ export const PLUGIN_ENTRIES = Object.entries(PLUGINS) as [
 ][];
 
 export * from "./shared";
-export { SERVICE_ENTRY, HEADER_PROBE, getGlobalServices } from "./core";
 
 // TODO: be more liberal on exports?
 export * from "./cache";
 export {
+  CORE_PLUGIN,
+  CORE_PLUGIN_NAME,
+  HEADER_PROBE,
+  SERVICE_ENTRY,
+  CoreOptionsSchema,
+  CoreSharedOptionsSchema,
+  getGlobalServices,
   ModuleRuleTypeSchema,
   ModuleRuleSchema,
   ModuleDefinitionSchema,
+  SourceOptionsSchema,
 } from "./core";
 export type {
   ModuleRuleType,
   ModuleRule,
   ModuleDefinition,
   GlobalServicesOptions,
+  SourceOptions,
 } from "./core";
 export * from "./d1";
 export * from "./do";

--- a/packages/tre/src/plugins/kv/index.ts
+++ b/packages/tre/src/plugins/kv/index.ts
@@ -1,14 +1,10 @@
 import { z } from "zod";
 import { Service, Worker_Binding } from "../../runtime";
 import {
-  BINDING_TEXT_NAMESPACE,
-  BINDING_TEXT_PLUGIN,
   PersistenceSchema,
   Plugin,
-  SCRIPT_PLUGIN_NAMESPACE_PERSIST,
-  WORKER_BINDING_SERVICE_LOOPBACK,
-  encodePersist,
   namespaceEntries,
+  pluginNamespacePersistWorker,
 } from "../shared";
 import { KV_PLUGIN_NAME } from "./constants";
 import { KVGateway } from "./gateway";
@@ -60,20 +56,11 @@ export const KV_PLUGIN: Plugin<
     return bindings;
   },
   getServices({ options, sharedOptions }) {
-    const persistBinding = encodePersist(sharedOptions.kvPersist);
+    const persist = sharedOptions.kvPersist;
     const namespaces = namespaceEntries(options.kvNamespaces);
     const services = namespaces.map<Service>(([_, id]) => ({
       name: `${SERVICE_NAMESPACE_PREFIX}:${id}`,
-      worker: {
-        serviceWorkerScript: SCRIPT_PLUGIN_NAMESPACE_PERSIST,
-        compatibilityDate: "2022-09-01",
-        bindings: [
-          ...persistBinding,
-          { name: BINDING_TEXT_PLUGIN, text: KV_PLUGIN_NAME },
-          { name: BINDING_TEXT_NAMESPACE, text: id },
-          WORKER_BINDING_SERVICE_LOOPBACK,
-        ],
-      },
+      worker: pluginNamespacePersistWorker(KV_PLUGIN_NAME, id, persist),
     }));
 
     if (isWorkersSitesEnabled(options)) {

--- a/packages/tre/src/plugins/kv/index.ts
+++ b/packages/tre/src/plugins/kv/index.ts
@@ -1,13 +1,12 @@
 import { z } from "zod";
 import { Service, Worker_Binding } from "../../runtime";
-import { SERVICE_LOOPBACK } from "../core";
 import {
-  BINDING_SERVICE_LOOPBACK,
   BINDING_TEXT_NAMESPACE,
   BINDING_TEXT_PLUGIN,
   PersistenceSchema,
   Plugin,
   SCRIPT_PLUGIN_NAMESPACE_PERSIST,
+  WORKER_BINDING_SERVICE_LOOPBACK,
   encodePersist,
   namespaceEntries,
 } from "../shared";
@@ -72,10 +71,7 @@ export const KV_PLUGIN: Plugin<
           ...persistBinding,
           { name: BINDING_TEXT_PLUGIN, text: KV_PLUGIN_NAME },
           { name: BINDING_TEXT_NAMESPACE, text: id },
-          {
-            name: BINDING_SERVICE_LOOPBACK,
-            service: { name: SERVICE_LOOPBACK },
-          },
+          WORKER_BINDING_SERVICE_LOOPBACK,
         ],
       },
     }));

--- a/packages/tre/src/plugins/kv/sites.ts
+++ b/packages/tre/src/plugins/kv/sites.ts
@@ -10,12 +10,12 @@ import {
   testRegExps,
 } from "../../shared";
 import { FileStorage } from "../../storage";
-import { SERVICE_LOOPBACK } from "../core";
 import {
   BINDING_SERVICE_LOOPBACK,
   BINDING_TEXT_PERSIST,
   HEADER_PERSIST,
   PARAM_FILE_UNSANITISE,
+  WORKER_BINDING_SERVICE_LOOPBACK,
 } from "../shared";
 import { HEADER_SITES, KV_PLUGIN_NAME, PARAM_URL_ENCODED } from "./constants";
 
@@ -208,13 +208,10 @@ export function getSitesService(options: SitesOptions): Service {
       serviceWorkerScript: SCRIPT_SITE,
       compatibilityDate: "2022-09-01",
       bindings: [
+        WORKER_BINDING_SERVICE_LOOPBACK,
         {
           name: BINDING_TEXT_PERSIST,
           text: JSON.stringify(persist),
-        },
-        {
-          name: BINDING_SERVICE_LOOPBACK,
-          service: { name: SERVICE_LOOPBACK },
         },
         {
           name: BINDING_JSON_SITE_FILTER,

--- a/packages/tre/src/plugins/r2/index.ts
+++ b/packages/tre/src/plugins/r2/index.ts
@@ -1,13 +1,12 @@
 import { z } from "zod";
 import { Service, Worker_Binding } from "../../runtime";
-import { SERVICE_LOOPBACK } from "../core";
 import {
-  BINDING_SERVICE_LOOPBACK,
   BINDING_TEXT_NAMESPACE,
   BINDING_TEXT_PLUGIN,
   PersistenceSchema,
   Plugin,
   SCRIPT_PLUGIN_NAMESPACE_PERSIST,
+  WORKER_BINDING_SERVICE_LOOPBACK,
   encodePersist,
   namespaceEntries,
 } from "../shared";
@@ -40,10 +39,6 @@ export const R2_PLUGIN: Plugin<
   },
   getServices({ options, sharedOptions }) {
     const persistBinding = encodePersist(sharedOptions.r2Persist);
-    const loopbackBinding: Worker_Binding = {
-      name: BINDING_SERVICE_LOOPBACK,
-      service: { name: SERVICE_LOOPBACK },
-    };
     const buckets = namespaceEntries(options.r2Buckets);
     return buckets.map<Service>(([_, id]) => ({
       name: `${R2_PLUGIN_NAME}:${id}`,
@@ -53,7 +48,7 @@ export const R2_PLUGIN: Plugin<
           ...persistBinding,
           { name: BINDING_TEXT_PLUGIN, text: R2_PLUGIN_NAME },
           { name: BINDING_TEXT_NAMESPACE, text: id },
-          loopbackBinding,
+          WORKER_BINDING_SERVICE_LOOPBACK,
         ],
         compatibilityDate: "2022-09-01",
       },

--- a/packages/tre/src/plugins/r2/index.ts
+++ b/packages/tre/src/plugins/r2/index.ts
@@ -1,14 +1,10 @@
 import { z } from "zod";
 import { Service, Worker_Binding } from "../../runtime";
 import {
-  BINDING_TEXT_NAMESPACE,
-  BINDING_TEXT_PLUGIN,
   PersistenceSchema,
   Plugin,
-  SCRIPT_PLUGIN_NAMESPACE_PERSIST,
-  WORKER_BINDING_SERVICE_LOOPBACK,
-  encodePersist,
   namespaceEntries,
+  pluginNamespacePersistWorker,
 } from "../shared";
 import { R2Gateway } from "./gateway";
 import { R2Router } from "./router";
@@ -38,20 +34,11 @@ export const R2_PLUGIN: Plugin<
     }));
   },
   getServices({ options, sharedOptions }) {
-    const persistBinding = encodePersist(sharedOptions.r2Persist);
+    const persist = sharedOptions.r2Persist;
     const buckets = namespaceEntries(options.r2Buckets);
     return buckets.map<Service>(([_, id]) => ({
       name: `${R2_PLUGIN_NAME}:${id}`,
-      worker: {
-        serviceWorkerScript: SCRIPT_PLUGIN_NAMESPACE_PERSIST,
-        bindings: [
-          ...persistBinding,
-          { name: BINDING_TEXT_PLUGIN, text: R2_PLUGIN_NAME },
-          { name: BINDING_TEXT_NAMESPACE, text: id },
-          WORKER_BINDING_SERVICE_LOOPBACK,
-        ],
-        compatibilityDate: "2022-09-01",
-      },
+      worker: pluginNamespacePersistWorker(R2_PLUGIN_NAME, id, persist),
     }));
   },
 };

--- a/packages/tre/src/plugins/shared/constants.ts
+++ b/packages/tre/src/plugins/shared/constants.ts
@@ -2,7 +2,12 @@ import { Headers } from "../../http";
 import { Worker_Binding } from "../../runtime";
 import { Persistence, PersistenceSchema } from "./gateway";
 
+export const CORE_PLUGIN_NAME = "core";
+
 export const SOCKET_ENTRY = "entry";
+
+// Service looping back to Miniflare's Node.js process (for storage, etc)
+export const SERVICE_LOOPBACK = `${CORE_PLUGIN_NAME}:loopback`;
 
 export const HEADER_PERSIST = "MF-Persist";
 // Even though we inject the `cf` blob in the entry script, we still need to
@@ -14,6 +19,11 @@ export const BINDING_SERVICE_LOOPBACK = "MINIFLARE_LOOPBACK";
 export const BINDING_TEXT_PLUGIN = "MINIFLARE_PLUGIN";
 export const BINDING_TEXT_NAMESPACE = "MINIFLARE_NAMESPACE";
 export const BINDING_TEXT_PERSIST = "MINIFLARE_PERSIST";
+
+export const WORKER_BINDING_SERVICE_LOOPBACK: Worker_Binding = {
+  name: BINDING_SERVICE_LOOPBACK,
+  service: { name: SERVICE_LOOPBACK },
+};
 
 // TODO: make this an inherited worker in core plugin
 export const SCRIPT_PLUGIN_NAMESPACE_PERSIST = `addEventListener("fetch", (event) => {

--- a/packages/tre/src/plugins/shared/constants.ts
+++ b/packages/tre/src/plugins/shared/constants.ts
@@ -2,12 +2,10 @@ import { Headers } from "../../http";
 import { Worker_Binding } from "../../runtime";
 import { Persistence, PersistenceSchema } from "./gateway";
 
-export const CORE_PLUGIN_NAME = "core";
-
 export const SOCKET_ENTRY = "entry";
 
 // Service looping back to Miniflare's Node.js process (for storage, etc)
-export const SERVICE_LOOPBACK = `${CORE_PLUGIN_NAME}:loopback`;
+export const SERVICE_LOOPBACK = "loopback";
 
 export const HEADER_PERSIST = "MF-Persist";
 // Even though we inject the `cf` blob in the entry script, we still need to

--- a/packages/tre/src/plugins/shared/index.ts
+++ b/packages/tre/src/plugins/shared/index.ts
@@ -12,13 +12,11 @@ export interface PluginServicesOptions<
 > {
   log: Log;
   options: z.infer<Options>;
-  optionsVersion: number;
   sharedOptions: OptionalZodTypeOf<SharedOptions>;
   workerBindings: Worker_Binding[];
   workerIndex: number;
   durableObjectClassNames: DurableObjectClassNames;
   additionalModules: Worker_Module[];
-  loopbackPort: number;
   tmpPath: string;
 }
 
@@ -67,3 +65,4 @@ export function namespaceEntries(
 export * from "./constants";
 export * from "./gateway";
 export * from "./router";
+export * from "./routing";

--- a/packages/tre/src/plugins/shared/routing.ts
+++ b/packages/tre/src/plugins/shared/routing.ts
@@ -1,0 +1,142 @@
+import { URL, domainToUnicode } from "url";
+import { MiniflareError } from "../../shared";
+
+export type RouterErrorCode = "ERR_QUERY_STRING" | "ERR_INFIX_WILDCARD";
+
+export class RouterError extends MiniflareError<RouterErrorCode> {}
+
+export interface WorkerRoute {
+  target: string;
+  route: string;
+
+  protocol?: string;
+  allowHostnamePrefix: boolean;
+  hostname: string;
+  path: string;
+  allowPathSuffix: boolean;
+}
+
+const A_MORE_SPECIFIC = -1;
+const B_MORE_SPECIFIC = 1;
+
+export function parseRoutes(allRoutes: Map<string, string[]>): WorkerRoute[] {
+  const routes: WorkerRoute[] = [];
+  for (const [target, targetRoutes] of allRoutes) {
+    for (const route of targetRoutes) {
+      const hasProtocol = /^[a-z0-9+\-.]+:\/\//i.test(route);
+
+      let urlInput = route;
+      // If route is missing a protocol, give it one so it parses
+      if (!hasProtocol) urlInput = `https://${urlInput}`;
+      const url = new URL(urlInput);
+
+      const protocol = hasProtocol ? url.protocol : undefined;
+
+      const internationalisedAllowHostnamePrefix =
+        url.hostname.startsWith("xn--*");
+      const allowHostnamePrefix =
+        url.hostname.startsWith("*") || internationalisedAllowHostnamePrefix;
+      const anyHostname = url.hostname === "*";
+      if (allowHostnamePrefix && !anyHostname) {
+        let hostname = url.hostname;
+        // If hostname is internationalised (e.g. `xn--gld-tna.se`), decode it
+        if (internationalisedAllowHostnamePrefix) {
+          hostname = domainToUnicode(hostname);
+        }
+        // Remove leading "*"
+        url.hostname = hostname.substring(1);
+      }
+
+      const allowPathSuffix = url.pathname.endsWith("*");
+      if (allowPathSuffix) {
+        url.pathname = url.pathname.substring(0, url.pathname.length - 1);
+      }
+
+      if (url.search) {
+        throw new RouterError(
+          "ERR_QUERY_STRING",
+          `Route "${route}" for "${target}" contains a query string. This is not allowed.`
+        );
+      }
+      if (url.toString().includes("*") && !anyHostname) {
+        throw new RouterError(
+          "ERR_INFIX_WILDCARD",
+          `Route "${route}" for "${target}" contains an infix wildcard. This is not allowed.`
+        );
+      }
+
+      routes.push({
+        target,
+        route,
+
+        protocol,
+        allowHostnamePrefix,
+        hostname: anyHostname ? "" : url.hostname,
+        path: url.pathname,
+        allowPathSuffix,
+      });
+    }
+  }
+
+  // Sort with the highest specificity first
+  routes.sort((a, b) => {
+    // 1. If one route matches on protocol, it is more specific
+    const aHasProtocol = a.protocol !== undefined;
+    const bHasProtocol = b.protocol !== undefined;
+    if (aHasProtocol && !bHasProtocol) return A_MORE_SPECIFIC;
+    if (!aHasProtocol && bHasProtocol) return B_MORE_SPECIFIC;
+
+    // 2. If one route allows hostname prefixes, it is less specific
+    if (!a.allowHostnamePrefix && b.allowHostnamePrefix) return A_MORE_SPECIFIC;
+    if (a.allowHostnamePrefix && !b.allowHostnamePrefix) return B_MORE_SPECIFIC;
+
+    // 3. If one route allows path suffixes, it is less specific
+    if (!a.allowPathSuffix && b.allowPathSuffix) return A_MORE_SPECIFIC;
+    if (a.allowPathSuffix && !b.allowPathSuffix) return B_MORE_SPECIFIC;
+
+    // 4. If one route has more path segments, it is more specific
+    const aPathSegments = a.path.split("/");
+    const bPathSegments = b.path.split("/");
+
+    // Specifically handle known route specificity issue here:
+    // https://developers.cloudflare.com/workers/platform/known-issues#route-specificity
+    const aLastSegmentEmpty = aPathSegments[aPathSegments.length - 1] === "";
+    const bLastSegmentEmpty = bPathSegments[bPathSegments.length - 1] === "";
+    if (aLastSegmentEmpty && !bLastSegmentEmpty) return B_MORE_SPECIFIC;
+    if (!aLastSegmentEmpty && bLastSegmentEmpty) return A_MORE_SPECIFIC;
+
+    if (aPathSegments.length !== bPathSegments.length)
+      return bPathSegments.length - aPathSegments.length;
+
+    // 5. If one route has a longer path, it is more specific
+    if (a.path.length !== b.path.length) return b.path.length - a.path.length;
+
+    // 6. Finally, if one route has a longer hostname, it is more specific
+    return b.hostname.length - a.hostname.length;
+  });
+
+  return routes;
+}
+
+export function matchRoutes(routes: WorkerRoute[], url: URL): string | null {
+  for (const route of routes) {
+    if (route.protocol && route.protocol !== url.protocol) continue;
+
+    if (route.allowHostnamePrefix) {
+      if (!url.hostname.endsWith(route.hostname)) continue;
+    } else {
+      if (url.hostname !== route.hostname) continue;
+    }
+
+    const path = url.pathname + url.search;
+    if (route.allowPathSuffix) {
+      if (!path.startsWith(route.path)) continue;
+    } else {
+      if (path !== route.path) continue;
+    }
+
+    return route.target;
+  }
+
+  return null;
+}

--- a/packages/tre/src/shared/error.ts
+++ b/packages/tre/src/shared/error.ts
@@ -23,7 +23,10 @@ export type MiniflareCoreErrorCode =
   | "ERR_PERSIST_UNSUPPORTED" // Unsupported storage persistence protocol
   | "ERR_PERSIST_REMOTE_UNAUTHENTICATED" // cloudflareFetch implementation not provided
   | "ERR_PERSIST_REMOTE_UNSUPPORTED" // Remote storage is not supported for this database
-  | "ERR_FUTURE_COMPATIBILITY_DATE"; // Compatibility date in the future
+  | "ERR_FUTURE_COMPATIBILITY_DATE" // Compatibility date in the future
+  | "ERR_NO_WORKERS" // No workers defined
+  | "ERR_DUPLICATE_NAME" // Multiple workers defined with same name
+  | "ERR_ROUTABLE_NO_SCRIPT"; // First or routable worker is missing code
 export class MiniflareCoreError extends MiniflareError<MiniflareCoreErrorCode> {}
 
 export class HttpError extends MiniflareError<number> {

--- a/packages/tre/src/shared/error.ts
+++ b/packages/tre/src/shared/error.ts
@@ -25,8 +25,7 @@ export type MiniflareCoreErrorCode =
   | "ERR_PERSIST_REMOTE_UNSUPPORTED" // Remote storage is not supported for this database
   | "ERR_FUTURE_COMPATIBILITY_DATE" // Compatibility date in the future
   | "ERR_NO_WORKERS" // No workers defined
-  | "ERR_DUPLICATE_NAME" // Multiple workers defined with same name
-  | "ERR_ROUTABLE_NO_SCRIPT"; // First or routable worker is missing code
+  | "ERR_DUPLICATE_NAME"; // Multiple workers defined with same name
 export class MiniflareCoreError extends MiniflareError<MiniflareCoreErrorCode> {}
 
 export class HttpError extends MiniflareError<number> {

--- a/packages/tre/src/shared/types.ts
+++ b/packages/tre/src/shared/types.ts
@@ -11,13 +11,6 @@ export function zAwaitable<T extends z.ZodTypeAny>(
 // { a: A, b: B, ... } => A | B | ...
 export type ValueOf<T> = T[keyof T];
 
-// A | B | ... => A & B & ... (https://stackoverflow.com/a/50375286)
-export type UnionToIntersection<U> = (
-  U extends any ? (k: U) => void : never
-) extends (k: infer I) => void
-  ? I
-  : never;
-
 export type OptionalZodTypeOf<T extends z.ZodTypeAny | undefined> =
   T extends z.ZodTypeAny ? z.TypeOf<T> : undefined;
 

--- a/packages/tre/test/index.spec.ts
+++ b/packages/tre/test/index.spec.ts
@@ -34,7 +34,7 @@ test("Miniflare: validates options", async (t) => {
     {
       instanceOf: MiniflareCoreError,
       code: "ERR_DUPLICATE_NAME",
-      message: 'Multiple workers defined with the same name: ""',
+      message: "Multiple workers defined without a `name`",
     }
   );
   t.throws(
@@ -50,7 +50,7 @@ test("Miniflare: validates options", async (t) => {
     {
       instanceOf: MiniflareCoreError,
       code: "ERR_DUPLICATE_NAME",
-      message: 'Multiple workers defined with the same name: "a"',
+      message: 'Multiple workers defined with the same `name`: "a"',
     }
   );
 });

--- a/packages/tre/test/index.spec.ts
+++ b/packages/tre/test/index.spec.ts
@@ -68,7 +68,7 @@ test("Miniflare: routes to multiple workers with fallback", async (t) => {
       },
       {
         name: "b",
-        routes: ["*/api*"], // Less specific than "a"'s
+        routes: ["*/api/*"], // Less specific than "a"'s
         script: `addEventListener("fetch", (event) => {
           event.respondWith(new Response("b"));
         })`,
@@ -82,7 +82,7 @@ test("Miniflare: routes to multiple workers with fallback", async (t) => {
   t.is(await res.text(), "a");
 
   // Check "b" still accessible
-  res = await mf.dispatchFetch("http://localhost/api2");
+  res = await mf.dispatchFetch("http://localhost/api/2");
   t.is(await res.text(), "b");
 
   // Check fallback to first

--- a/packages/tre/test/index.spec.ts
+++ b/packages/tre/test/index.spec.ts
@@ -26,45 +26,31 @@ test("Miniflare: validates options", async (t) => {
   });
 
   // Check workers with the same name rejected
-  t.throws(() => new Miniflare({ workers: [{}, {}] }), {
-    instanceOf: MiniflareCoreError,
-    code: "ERR_DUPLICATE_NAME",
-    message: 'Multiple workers defined with the same name: ""',
-  });
   t.throws(
     () =>
       new Miniflare({
-        workers: [{}, { name: "a" }, { name: "b" }, { name: "a" }],
+        workers: [{ script: "" }, { script: "" }],
+      }),
+    {
+      instanceOf: MiniflareCoreError,
+      code: "ERR_DUPLICATE_NAME",
+      message: 'Multiple workers defined with the same name: ""',
+    }
+  );
+  t.throws(
+    () =>
+      new Miniflare({
+        workers: [
+          { script: "" },
+          { script: "", name: "a" },
+          { script: "", name: "b" },
+          { script: "", name: "a" },
+        ],
       }),
     {
       instanceOf: MiniflareCoreError,
       code: "ERR_DUPLICATE_NAME",
       message: 'Multiple workers defined with the same name: "a"',
-    }
-  );
-
-  // // Check entrypoint worker must have script
-  await t.throwsAsync(() => new Miniflare({ name: "worker" }).ready, {
-    instanceOf: MiniflareCoreError,
-    code: "ERR_ROUTABLE_NO_SCRIPT",
-    message:
-      'Worker [0] ("worker") must have code defined as it\'s routable or the fallback',
-  });
-  // Check routable workers must have scripts
-  await t.throwsAsync(
-    () =>
-      new Miniflare({
-        workers: [
-          { name: "entry", script: "" },
-          { name: "no-routes", routes: [] },
-          { routes: ["*/*"] },
-        ],
-      }).ready,
-    {
-      instanceOf: MiniflareCoreError,
-      code: "ERR_ROUTABLE_NO_SCRIPT",
-      message:
-        "Worker [2] must have code defined as it's routable or the fallback",
     }
   );
 });

--- a/packages/tre/test/plugins/shared/routing.spec.ts
+++ b/packages/tre/test/plugins/shared/routing.spec.ts
@@ -1,0 +1,154 @@
+// noinspection HttpUrlsUsage
+
+import { URL } from "url";
+import { RouterError, matchRoutes, parseRoutes } from "@miniflare/tre";
+import test from "ava";
+
+// See https://developers.cloudflare.com/workers/platform/routes#matching-behavior and
+// https://developers.cloudflare.com/workers/platform/known-issues#route-specificity
+
+test("throws if route contains query string", (t) => {
+  t.throws(() => parseRoutes(new Map([["a", ["example.com/?foo=*"]]])), {
+    instanceOf: RouterError,
+    code: "ERR_QUERY_STRING",
+    message:
+      'Route "example.com/?foo=*" for "a" contains a query string. This is not allowed.',
+  });
+});
+test("throws if route contains infix wildcards", (t) => {
+  t.throws(() => parseRoutes(new Map([["a", ["example.com/*.jpg"]]])), {
+    instanceOf: RouterError,
+    code: "ERR_INFIX_WILDCARD",
+    message:
+      'Route "example.com/*.jpg" for "a" contains an infix wildcard. This is not allowed.',
+  });
+});
+test("routes may begin with http:// or https://", (t) => {
+  let routes = parseRoutes(new Map([["a", ["example.com/*"]]]));
+  t.is(matchRoutes(routes, new URL("http://example.com/foo.jpg")), "a");
+  t.is(matchRoutes(routes, new URL("https://example.com/foo.jpg")), "a");
+  t.is(matchRoutes(routes, new URL("ftp://example.com/foo.jpg")), "a");
+
+  routes = parseRoutes(
+    new Map([
+      ["a", ["http://example.com/*"]],
+      ["b", ["https://example.com/*"]],
+    ])
+  );
+  t.is(matchRoutes(routes, new URL("http://example.com/foo.jpg")), "a");
+  t.is(matchRoutes(routes, new URL("https://example.com/foo.jpg")), "b");
+  t.is(matchRoutes(routes, new URL("ftp://example.com/foo.jpg")), null);
+});
+test("trailing slash automatically implied", (t) => {
+  const routes = parseRoutes(new Map([["a", ["example.com"]]]));
+  t.is(matchRoutes(routes, new URL("http://example.com/")), "a");
+  t.is(matchRoutes(routes, new URL("https://example.com/")), "a");
+});
+test("route hostnames may begin with *", (t) => {
+  let routes = parseRoutes(new Map([["a", ["*example.com/"]]]));
+  t.is(matchRoutes(routes, new URL("https://example.com/")), "a");
+  t.is(matchRoutes(routes, new URL("https://www.example.com/")), "a");
+
+  routes = parseRoutes(new Map([["a", ["*.example.com/"]]]));
+  t.is(matchRoutes(routes, new URL("https://example.com/")), null);
+  t.is(matchRoutes(routes, new URL("https://www.example.com/")), "a");
+});
+test("correctly handles internationalised domain names beginning with *", (t) => {
+  // https://github.com/cloudflare/miniflare/issues/186
+  let routes = parseRoutes(new Map([["a", ["*glöd.se/*"]]]));
+  t.is(matchRoutes(routes, new URL("https://glöd.se/*")), "a");
+  t.is(matchRoutes(routes, new URL("https://www.glöd.se/*")), "a");
+
+  routes = parseRoutes(new Map([["a", ["*.glöd.se/*"]]]));
+  t.is(matchRoutes(routes, new URL("https://glöd.se/*")), null);
+  t.is(matchRoutes(routes, new URL("https://www.glöd.se/*")), "a");
+});
+test("route paths may end with *", (t) => {
+  const routes = parseRoutes(new Map([["a", ["https://example.com/path*"]]]));
+  t.is(matchRoutes(routes, new URL("https://example.com/path")), "a");
+  t.is(matchRoutes(routes, new URL("https://example.com/path2")), "a");
+  t.is(
+    matchRoutes(routes, new URL("https://example.com/path/readme.txt")),
+    "a"
+  );
+  t.is(matchRoutes(routes, new URL("https://example.com/notpath")), null);
+});
+test("matches most specific route", (t) => {
+  let routes = parseRoutes(
+    new Map([
+      ["a", ["www.example.com/*"]],
+      ["b", ["*.example.com/*"]],
+    ])
+  );
+  t.is(matchRoutes(routes, new URL("https://www.example.com/")), "a");
+
+  routes = parseRoutes(
+    new Map([
+      ["a", ["example.com/*"]],
+      ["b", ["example.com/hello/*"]],
+    ])
+  );
+  t.is(matchRoutes(routes, new URL("https://example.com/hello/world")), "b");
+
+  routes = parseRoutes(
+    new Map([
+      ["a", ["example.com/*"]],
+      ["b", ["https://example.com/*"]],
+    ])
+  );
+  t.is(matchRoutes(routes, new URL("https://example.com/hello")), "b");
+
+  routes = parseRoutes(
+    new Map([
+      ["a", ["example.com/pa*"]],
+      ["b", ["example.com/path*"]],
+    ])
+  );
+  t.is(matchRoutes(routes, new URL("https://example.com/p")), null);
+  t.is(matchRoutes(routes, new URL("https://example.com/pa")), "a");
+  t.is(matchRoutes(routes, new URL("https://example.com/pat")), "a");
+  t.is(matchRoutes(routes, new URL("https://example.com/path")), "b");
+});
+test("matches query params", (t) => {
+  const routes = parseRoutes(new Map([["a", ["example.com/hello/*"]]]));
+  t.is(
+    matchRoutes(routes, new URL("https://example.com/hello/world?foo=bar")),
+    "a"
+  );
+});
+test("routes are case-sensitive", (t) => {
+  const routes = parseRoutes(
+    new Map([
+      ["a", ["example.com/images/*"]],
+      ["b", ["example.com/Images/*"]],
+    ])
+  );
+  t.is(matchRoutes(routes, new URL("https://example.com/images/foo.jpg")), "a");
+  t.is(matchRoutes(routes, new URL("https://example.com/Images/foo.jpg")), "b");
+});
+test("escapes regexp control characters", (t) => {
+  const routes = parseRoutes(new Map([["a", ["example.com/*"]]]));
+  t.is(matchRoutes(routes, new URL("https://example.com/")), "a");
+  t.is(matchRoutes(routes, new URL("https://example2com/")), null);
+});
+test('"correctly" handles routes with trailing /*', (t) => {
+  const routes = parseRoutes(
+    new Map([
+      ["a", ["example.com/images/*"]],
+      ["b", ["example.com/images*"]],
+    ])
+  );
+  t.is(matchRoutes(routes, new URL("https://example.com/images")), "b");
+  t.is(matchRoutes(routes, new URL("https://example.com/images123")), "b");
+  t.is(matchRoutes(routes, new URL("https://example.com/images/hello")), "b"); // unexpected
+});
+test("returns null if no routes match", (t) => {
+  const routes = parseRoutes(new Map([["a", ["example.com/*"]]]));
+  t.is(matchRoutes(routes, new URL("https://miniflare.dev/")), null);
+});
+test("matches everything route", (t) => {
+  const routes = parseRoutes(new Map([["a", ["*/*"]]]));
+  t.is(matchRoutes(routes, new URL("http://example.com/")), "a");
+  t.is(matchRoutes(routes, new URL("https://example.com/")), "a");
+  t.is(matchRoutes(routes, new URL("https://miniflare.dev/")), "a");
+});


### PR DESCRIPTION
This change ports Miniflare 2's `mounts` router to Miniflare 3. This attempts to replicate the logic of the `route(s)` field in the Wrangler configuration file: https://developers.cloudflare.com/workers/platform/triggers/routes/#matching-behavior

Internally, this is implemented by binding all routable workers as service bindings in the entry service. The first worker is always bound as a "fallback", in case no routes match. Validation has been added to ensure we a) have a fallback, b) don't have workers with duplicate names that would cause bindings with the same name, and c) all routable/fallback workers have code so they actually get added as `workerd` services.

I've also split some of the core plugin services into "global services". These need to be constructed from a different set of options to the regular plugin services, and relying on the de-duping behaviour here was a bit silly.