### PR TITLE
[Miniflare 3] Bump to `better-sqlite3@8.1.0`, closes #518

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -878,9 +878,10 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "7.6.2",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.1.0.tgz",
+      "integrity": "sha512-p1m09H+Oi8R9TPj810pdNswMFuVgRNgCJEWypp6jlkOgSwMIrNyuj3hW78xEuBRGok5RzeaUW8aBtTWF3l/TQA==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.0"
@@ -4988,7 +4989,7 @@
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-walk": "^8.2.0",
-        "better-sqlite3": "^7.6.2",
+        "better-sqlite3": "^8.1.0",
         "capnp-ts": "^0.7.0",
         "exit-hook": "^2.2.1",
         "get-port": "^5.1.1",
@@ -5147,7 +5148,7 @@
         "@types/ws": "^8.5.3",
         "acorn": "^8.8.0",
         "acorn-walk": "^8.2.0",
-        "better-sqlite3": "^7.6.2",
+        "better-sqlite3": "^8.1.0",
         "capnp-ts": "^0.7.0",
         "exit-hook": "^2.2.1",
         "get-port": "^5.1.1",
@@ -5575,7 +5576,9 @@
       "version": "1.5.1"
     },
     "better-sqlite3": {
-      "version": "7.6.2",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.1.0.tgz",
+      "integrity": "sha512-p1m09H+Oi8R9TPj810pdNswMFuVgRNgCJEWypp6jlkOgSwMIrNyuj3hW78xEuBRGok5RzeaUW8aBtTWF3l/TQA==",
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.0"

--- a/packages/tre/package.json
+++ b/packages/tre/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "acorn": "^8.8.0",
     "acorn-walk": "^8.2.0",
-    "better-sqlite3": "^7.6.2",
+    "better-sqlite3": "^8.1.0",
     "capnp-ts": "^0.7.0",
     "exit-hook": "^2.2.1",
     "get-port": "^5.1.1",


### PR DESCRIPTION
Fixes installation on Node 19

Closes cloudflare/workers-sdk#2318