### PR TITLE
Implement Durable Object jurisdiction API

### DIFF
--- a/packages/durable-objects/src/namespace.ts
+++ b/packages/durable-objects/src/namespace.ts
@@ -230,6 +230,11 @@ export class DurableObjectNamespace {
     this.#ctx = ctx;
   }
 
+  jurisdiction(_name: string): DurableObjectNamespace {
+    // Ignore jurisdiction restrictions in local mode
+    return this;
+  }
+
   newUniqueId(_options?: NewUniqueIdOptions): DurableObjectId {
     // Create new zero-filled 32 byte buffer
     const id = new Uint8Array(32);

--- a/packages/durable-objects/src/namespace.ts
+++ b/packages/durable-objects/src/namespace.ts
@@ -30,6 +30,13 @@ function hexEncode(value: Uint8Array): string {
     .join("");
 }
 
+function checkJurisdiction(jurisdiction?: string): boolean {
+  const allowedJurisdictions = ["eu", "fedramp"];
+  return (
+    jurisdiction === undefined || allowedJurisdictions.includes(jurisdiction)
+  );
+}
+
 export const kObjectName = Symbol("kObjectName");
 
 export class DurableObjectId {
@@ -231,7 +238,7 @@ export class DurableObjectNamespace {
   }
 
   jurisdiction(name: string): DurableObjectNamespace {
-    if (name !== "eu" && name !== "fedramp") {
+    if (!checkJurisdiction(name)) {
       throw new TypeError(
         `jurisdiction called with an unsupported jurisdiction: "${name}"`
       );
@@ -240,7 +247,13 @@ export class DurableObjectNamespace {
     return this;
   }
 
-  newUniqueId(_options?: NewUniqueIdOptions): DurableObjectId {
+  newUniqueId(options?: NewUniqueIdOptions): DurableObjectId {
+    if (!checkJurisdiction(options?.jurisdiction)) {
+      throw new TypeError(
+        `newUniqueId called with an unsupported jurisdiction: "${options?.jurisdiction}"`
+      );
+    }
+
     // Create new zero-filled 32 byte buffer
     const id = new Uint8Array(32);
     // Leave first byte as 0, ensuring no intersection with named IDs

--- a/packages/durable-objects/src/namespace.ts
+++ b/packages/durable-objects/src/namespace.ts
@@ -230,7 +230,12 @@ export class DurableObjectNamespace {
     this.#ctx = ctx;
   }
 
-  jurisdiction(_name: string): DurableObjectNamespace {
+  jurisdiction(name: string): DurableObjectNamespace {
+    if (name !== "eu" && name !== "fedramp") {
+      throw new TypeError(
+        `jurisdiction called with an unsupported jurisdiction: "${name}"`
+      );
+    }
     // Ignore jurisdiction restrictions in local mode
     return this;
   }

--- a/packages/durable-objects/test/namespace.spec.ts
+++ b/packages/durable-objects/test/namespace.spec.ts
@@ -704,7 +704,7 @@ test("DurableObjectStub: hides implementation details", async (t) => {
 
 test("DurableObjectNamespace: jurisdiction: returns DurableObjectNamespace", (t) => {
   const namespace = new DurableObjectNamespace("OBJECT", throws);
-  const jurisdictionNamespace = namespace.jurisdiction("eu")
+  const jurisdictionNamespace = namespace.jurisdiction("eu");
   t.is(namespace, jurisdictionNamespace);
 });
 

--- a/packages/durable-objects/test/namespace.spec.ts
+++ b/packages/durable-objects/test/namespace.spec.ts
@@ -704,7 +704,7 @@ test("DurableObjectStub: hides implementation details", async (t) => {
 
 test("DurableObjectNamespace: jurisdiction: returns DurableObjectNamespace", (t) => {
   const namespace = new DurableObjectNamespace("OBJECT", throws);
-  const jurisdictionNamespace = namespace.jurisdiction('eu')
+  const jurisdictionNamespace = namespace.jurisdiction("eu")
   t.is(namespace, jurisdictionNamespace);
 });
 

--- a/packages/durable-objects/test/namespace.spec.ts
+++ b/packages/durable-objects/test/namespace.spec.ts
@@ -708,6 +708,20 @@ test("DurableObjectNamespace: jurisdiction: returns DurableObjectNamespace", (t)
   t.is(namespace, jurisdictionNamespace);
 });
 
+test("DurableObjectNamespace: jurisdiction: throws TypeError on unsupported value", (t) => {
+  const namespace = new DurableObjectNamespace("OBJECT", throws);
+  t.throws(
+    () => {
+      namespace.jurisdiction("miniflare");
+    },
+    {
+      instanceOf: TypeError,
+      message:
+        'jurisdiction called with an unsupported jurisdiction: "miniflare"',
+    }
+  );
+});
+
 test("DurableObjectNamespace: newUniqueId: generates unique IDs", (t) => {
   const namespace = new DurableObjectNamespace("OBJECT", throws);
   const id1 = namespace.newUniqueId();

--- a/packages/durable-objects/test/namespace.spec.ts
+++ b/packages/durable-objects/test/namespace.spec.ts
@@ -702,6 +702,12 @@ test("DurableObjectStub: hides implementation details", async (t) => {
   t.deepEqual(getObjectProperties(stub), ["fetch", "id", "name"]);
 });
 
+test("DurableObjectNamespace: jurisdiction: returns DurableObjectNamespace", (t) => {
+  const namespace = new DurableObjectNamespace("OBJECT", throws);
+  const jurisdictionNamespace = namespace.jurisdiction('eu')
+  t.is(namespace, jurisdictionNamespace);
+});
+
 test("DurableObjectNamespace: newUniqueId: generates unique IDs", (t) => {
   const namespace = new DurableObjectNamespace("OBJECT", throws);
   const id1 = namespace.newUniqueId();
@@ -818,6 +824,7 @@ test("DurableObjectNamespace: hides implementation details", (t) => {
     "get",
     "idFromName",
     "idFromString",
+    "jurisdiction",
     "newUniqueId",
   ]);
 });

--- a/packages/durable-objects/test/namespace.spec.ts
+++ b/packages/durable-objects/test/namespace.spec.ts
@@ -707,7 +707,6 @@ test("DurableObjectNamespace: jurisdiction: returns DurableObjectNamespace", (t)
   const jurisdictionNamespace = namespace.jurisdiction("eu");
   t.is(namespace, jurisdictionNamespace);
 });
-
 test("DurableObjectNamespace: jurisdiction: throws TypeError on unsupported value", (t) => {
   const namespace = new DurableObjectNamespace("OBJECT", throws);
   t.throws(
@@ -744,6 +743,25 @@ test("DurableObjectNamespace: newUniqueId: IDs tied to generating object", (t) =
     instanceOf: TypeError,
     message: "ID is not for this Durable Object class.",
   });
+});
+test("DurableObjectNamespace: newUniqueId: allows jurisdiction as option", (t) => {
+  const namespace = new DurableObjectNamespace("OBJECT", throws);
+  t.notThrows(() => {
+    namespace.newUniqueId({ jurisdiction: "eu" });
+  });
+});
+test("DurableObjectNamespace: newUniqueId: throws TypeError on unsupported jurisdiction", (t) => {
+  const namespace = new DurableObjectNamespace("OBJECT", throws);
+  t.throws(
+    () => {
+      namespace.newUniqueId({ jurisdiction: "miniflare" });
+    },
+    {
+      instanceOf: TypeError,
+      message:
+        'newUniqueId called with an unsupported jurisdiction: "miniflare"',
+    }
+  );
 });
 test("DurableObjectNamespace: idFromName: generates same ID for same name and object", (t) => {
   const namespace = new DurableObjectNamespace("OBJECT", throws);


### PR DESCRIPTION
This Pull Request implements a `.jurisdiction` method on Durable Object namespaces, which just returns the original namespace.

The jurisdiction option is ignored, just like the option in `newUniqueId`. In the real runtime, these would create a different ID, but I suppose it's not often that these are used to differentiate between IDs, and changing this behaviour would be a breaking change.