### PR TITLE
Implement non-standard SubtleCrypto timingSafeEqual

### DIFF
--- a/packages/core/src/standards/crypto.ts
+++ b/packages/core/src/standards/crypto.ts
@@ -1,4 +1,4 @@
-import { createHash, webcrypto } from "crypto";
+import { createHash, timingSafeEqual, webcrypto } from "crypto";
 import { WritableStream } from "stream/web";
 import { DOMException } from "@miniflare/core";
 import { viewToBuffer } from "@miniflare/shared";
@@ -215,6 +215,7 @@ export function createCrypto(blockGlobalRandom = false): WorkerCrypto {
       if (propertyKey === "importKey") return importKey;
       if (propertyKey === "exportKey") return exportKey;
       if (propertyKey === "sign") return sign;
+      if (propertyKey === "timingSafeEqual") return timingSafeEqual;
       if (propertyKey === "verify") return verify;
 
       let result = Reflect.get(target, propertyKey, receiver);

--- a/packages/core/test/standards/crypto.spec.ts
+++ b/packages/core/test/standards/crypto.spec.ts
@@ -184,6 +184,22 @@ test("crypto: sign/verify: supports other algorithm", async (t) => {
   t.true(await crypto.subtle.verify("HMAC", key, signature, data));
 });
 
+test("crypto: timingSafeEqual equals", (t) => {
+  const array1 = new Uint8Array(12);
+  array1.fill(0, 0);
+  const array2 = new Uint8Array(12);
+  array2.fill(0, 0);
+  t.is(crypto.subtle.timingSafeEqual(array1, array2), true);
+});
+test("crypto: timingSafeEqual not equals", (t) => {
+  const array1 = new Uint8Array(12);
+  array1.fill(0, 0);
+  const array2 = new Uint8Array(12);
+  array2.fill(0, 0);
+  array2[7] = 1;
+  t.is(crypto.subtle.timingSafeEqual(array1, array2), false);
+});
+
 // Checking other functions aren't broken by proxy...
 
 test("crypto: gets random values", (t) => {


### PR DESCRIPTION
`workerd` implements a non-standard extension method `timingSafeEqual` to the Web Crypto API under Subtle Crypto. Fortunately, node also provides a similar implementation, under the regular `crypto`.

This PR is not concerned about the safety of the implementation, as miniflare is intended for local development purposes only.

Marking as draft as the types for crypto.subtle come from node's types in miniflare and typecheck fails. @mrbbot how should we approach overriding the type for the crypto module? The method exists in [workerd](https://github.com/cloudflare/workerd/blob/9e5d8f18f172c207a95334b22910678498c6c078/src/workerd/api/crypto.h#L541) and workers-types.