### PR TITLE
[Miniflare 2] Fix binding of `?N` parameters in D1 prepared statements

### DIFF
--- a/packages/d1/test/d1js.spec.ts
+++ b/packages/d1/test/d1js.spec.ts
@@ -175,6 +175,18 @@ test("D1PreparedStatement: bind", async (t) => {
     .bind("green")
     .all<ColourRow>();
   t.is(colourResults.results?.length, 1);
+
+  // Check with numbered parameters (execute and query)
+  // https://github.com/cloudflare/miniflare/issues/504
+  await db
+    .prepare("INSERT INTO colours (id, name, rgb) VALUES (?3, ?1, ?2)")
+    .bind("yellow", 0xffff00, 4)
+    .run();
+  const colourResult = await db
+    .prepare("SELECT * FROM colours WHERE id = ?1")
+    .bind(4)
+    .first<ColourRow>();
+  t.deepEqual(colourResult, { id: 4, name: "yellow", rgb: 0xffff00 });
 });
 
 // Lots of strange edge cases here...


### PR DESCRIPTION
`better-sqlite3` expects parameters of the form `?1, ?2, ...` to be bound as an object of the form `{ 1: params[0], 2: params[1], ...}`. In #480, we accidentally removed the code that handled this case. This PR adds it back, and lifts out some common functionality into a `#prepareAndBind()` function. :)

Thanks @ruslantalpa for spotting the removed code.

Closes #504
Closes #526
Closes cloudflare/workers-sdk#2811
Closes cloudflare/workers-sdk#2887