### PR TITLE
[Miniflare 2] Fix behaviour mismatch in Request constructor

### DIFF
--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -424,7 +424,7 @@ export class Request extends Body<BaseRequest> {
       init?.body as { [kContentLength]?: number }
     )?.[kContentLength];
 
-    const cf = input instanceof Request ? input.#cf : init?.cf;
+    const cf = input instanceof Request ? init?.cf ?? input.#cf : init?.cf;
     if (input instanceof BaseRequest && !init) {
       // For cloning
       super(input);

--- a/packages/core/test/standards/http.spec.ts
+++ b/packages/core/test/standards/http.spec.ts
@@ -12,6 +12,7 @@ import {
   Body,
   IncomingRequestCfProperties,
   Request,
+  RequestInitCfProperties,
   Response,
   _getBodyLength,
   _getURLList,
@@ -474,6 +475,29 @@ test("Request: supports non-standard properties", (t) => {
   t.deepEqual(req.cf, cf);
   // Check cf has been cloned
   t.not(req.cf, cf);
+});
+test("Request: cf defaults to input.cf", (t) => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    cf,
+  });
+  const req2 = new Request(req);
+  t.deepEqual(req.cf, req2.cf);
+  // Check cf has been cloned
+  t.not(req.cf, req2.cf);
+});
+test("Request: init.cf overrides input.cf", (t) => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    cf,
+  });
+  const req2 = new Request(req, {
+    cf: {
+      cacheKey: "test",
+    },
+  });
+  t.notDeepEqual(req.cf, req2.cf);
+  t.is((req2.cf as RequestInitCfProperties).cacheKey, "test");
 });
 test("Request: doesn't detach ArrayBuffers", async (t) => {
   // Check with ArrayBuffer


### PR DESCRIPTION
When creating a new Request with a Request as init, miniflare handles Request.cf differently than the runtime.

The "source" of the cf property in the runtime is roughly these three places:

https://github.com/cloudflare/workerd/blob/d31668474a22788b94e4bb2abe8f832c5e719de3/src/workerd/api/http.c%2B%2B#L802
https://github.com/cloudflare/workerd/blob/d31668474a22788b94e4bb2abe8f832c5e719de3/src/workerd/api/http.c%2B%2B#L874
https://github.com/cloudflare/workerd/blob/d31668474a22788b94e4bb2abe8f832c5e719de3/src/workerd/api/http.c%2B%2B#L908


This PR makes sure that miniflare matches this behaviour, and closes #535.