### PR TITLE
[Miniflare 2] Remove experimental flag requirement for nodejs_compat modules

### DIFF
--- a/packages/core/src/plugins/node/index.ts
+++ b/packages/core/src/plugins/node/index.ts
@@ -6,18 +6,14 @@ import * as buffer from "./buffer";
 import * as events from "./events";
 import * as util from "./util";
 
-export function additionalNodeModules(experimental: boolean) {
+export function additionalNodeModules(_experimental: boolean) {
   const modules: AdditionalModules = {
+    "node:assert": assert,
     "node:async_hooks": async_hooks,
+    "node:buffer": buffer,
     "node:events": events,
+    "node:util": util,
   };
-
-  if (experimental) {
-    // TODO(soon): remove experimental designations when removed in `workerd`
-    modules["node:assert"] = assert;
-    modules["node:buffer"] = buffer;
-    modules["node:util"] = util;
-  }
 
   return modules;
 }

--- a/packages/core/test/plugins/core.spec.ts
+++ b/packages/core/test/plugins/core.spec.ts
@@ -623,7 +623,13 @@ test("CorePlugin: nodejs_compat compatibility flag includes Node.js modules", as
   let plugin = new CorePlugin({ ...ctx, compat });
   let modules = (await plugin.setup()).additionalModules!;
   const names = Object.keys(modules).sort();
-  t.deepEqual(names, ["node:async_hooks", "node:events"]);
+  t.deepEqual(names, [
+    "node:assert",
+    "node:async_hooks",
+    "node:buffer",
+    "node:events",
+    "node:util",
+  ]);
 
   compat = new Compatibility(undefined, ["nodejs_compat", "experimental"]);
   plugin = new CorePlugin({ ...ctx, compat });
@@ -631,7 +637,7 @@ test("CorePlugin: nodejs_compat compatibility flag includes Node.js modules", as
   const experimentalNames = Object.keys(modules).filter(
     (name) => !names.includes(name)
   );
-  t.deepEqual(experimentalNames, ["node:assert", "node:buffer", "node:util"]);
+  t.deepEqual(experimentalNames, []);
 
   // We're using Node's implementations of these modules' exports, so don't
   // bother testing their functionality. Instead, just check we've got the


### PR DESCRIPTION
Per https://developers.cloudflare.com/workers/runtime-apis/nodejs/ and https://blog.cloudflare.com/workers-node-js-asynclocalstorage/, the Workers runtime now supports these under just the `nodejs_compat` flag.

This PR makes sure miniflare's `nodejs_compat` flag behaviour matches that of the runtime.

Resolves #547 