### PR TITLE
[Miniflare 3] Implement new storage system

### DIFF
--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -877,3 +877,4 @@ export * from "./plugins";
 export * from "./runtime";
 export * from "./shared";
 export * from "./storage";
+export * from "./storage2";

--- a/packages/tre/src/plugins/kv/gateway.ts
+++ b/packages/tre/src/plugins/kv/gateway.ts
@@ -87,7 +87,7 @@ export interface KVGatewayGetOptions {
 export interface KVGatewayGetResult<Metadata = unknown> {
   value: ReadableStream<Uint8Array>;
   expiration?: number; // seconds since unix epoch
-  metadata: Metadata;
+  metadata?: Metadata;
 }
 
 export interface KVGatewayPutOptions<Metadata = unknown> {
@@ -107,10 +107,50 @@ export interface KVGatewayListKey {
   expiration?: number; // seconds since unix epoch
   metadata?: string; // JSON-stringified metadata
 }
-export interface KVGatewayListResult {
+export type KVGatewayListResult = {
   keys: KVGatewayListKey[];
-  cursor?: string;
-  list_complete: boolean;
+} & (
+  | { list_complete: false; cursor: string }
+  | { list_complete: true; cursor: undefined }
+);
+
+export function validateGetOptions(
+  key: string,
+  options?: KVGatewayGetOptions
+): void {
+  validateKey(key);
+  // Validate cacheTtl, but ignore it as there's only one "edge location":
+  // the user's computer
+  const cacheTtl = options?.cacheTtl;
+  if (cacheTtl !== undefined && (isNaN(cacheTtl) || cacheTtl < MIN_CACHE_TTL)) {
+    throw new KVError(
+      400,
+      `Invalid ${PARAM_CACHE_TTL} of ${cacheTtl}. Cache TTL must be at least ${MIN_CACHE_TTL}.`
+    );
+  }
+}
+
+export function validateListOptions(options: KVGatewayListOptions): void {
+  // Validate key limit
+  const limit = options.limit;
+  if (limit !== undefined) {
+    if (isNaN(limit) || limit < 1) {
+      throw new KVError(
+        400,
+        `Invalid ${PARAM_LIST_LIMIT} of ${limit}. Please specify an integer greater than 0.`
+      );
+    }
+    if (limit > MAX_LIST_KEYS) {
+      throw new KVError(
+        400,
+        `Invalid ${PARAM_LIST_LIMIT} of ${limit}. Please specify an integer less than ${MAX_LIST_KEYS}.`
+      );
+    }
+  }
+
+  // Validate key prefix
+  const prefix = options.prefix;
+  if (prefix !== undefined) validateKeyLength(prefix);
 }
 
 export class KVGateway {
@@ -129,20 +169,7 @@ export class KVGateway {
     key: string,
     options?: KVGatewayGetOptions
   ): Promise<KVGatewayGetResult<Metadata> | undefined> {
-    validateKey(key);
-    // Validate cacheTtl, but ignore it as there's only one "edge location":
-    // the user's computer
-    const cacheTtl = options?.cacheTtl;
-    if (
-      cacheTtl !== undefined &&
-      (isNaN(cacheTtl) || cacheTtl < MIN_CACHE_TTL)
-    ) {
-      throw new KVError(
-        400,
-        `Invalid ${PARAM_CACHE_TTL} of ${cacheTtl}. Cache TTL must be at least ${MIN_CACHE_TTL}.`
-      );
-    }
-
+    validateGetOptions(key, options);
     const entry = await this.storage.get(key);
     if (entry === null) return;
     return {
@@ -233,36 +260,19 @@ export class KVGateway {
   }
 
   async list(options: KVGatewayListOptions = {}): Promise<KVGatewayListResult> {
-    // Validate key limit
-    const limit = options.limit ?? MAX_LIST_KEYS;
-    if (isNaN(limit) || limit < 1) {
-      throw new KVError(
-        400,
-        `Invalid ${PARAM_LIST_LIMIT} of ${limit}. Please specify an integer greater than 0.`
-      );
-    }
-    if (limit > MAX_LIST_KEYS) {
-      throw new KVError(
-        400,
-        `Invalid ${PARAM_LIST_LIMIT} of ${limit}. Please specify an integer less than ${MAX_LIST_KEYS}.`
-      );
-    }
-
-    // Validate key prefix
-    const prefix = options.prefix;
-    if (prefix !== undefined) validateKeyLength(prefix);
-
-    const cursor = options.cursor;
+    validateListOptions(options);
+    const { limit = MAX_LIST_KEYS, prefix, cursor } = options;
     const res = await this.storage.list({ limit, prefix, cursor });
-    return {
-      keys: res.keys.map((key) => ({
-        name: key.key,
-        expiration: maybeApply(millisToSeconds, key.expiration),
-        // workerd expects metadata to be a JSON-serialised string
-        metadata: maybeApply(JSON.stringify, key.metadata),
-      })),
-      cursor: res.cursor,
-      list_complete: res.cursor === undefined,
-    };
+    const keys = res.keys.map<KVGatewayListKey>((key) => ({
+      name: key.key,
+      expiration: maybeApply(millisToSeconds, key.expiration),
+      // workerd expects metadata to be a JSON-serialised string
+      metadata: maybeApply(JSON.stringify, key.metadata),
+    }));
+    if (res.cursor === undefined) {
+      return { keys, list_complete: true, cursor: undefined };
+    } else {
+      return { keys, list_complete: false, cursor: res.cursor };
+    }
   }
 }

--- a/packages/tre/src/plugins/kv/sites.ts
+++ b/packages/tre/src/plugins/kv/sites.ts
@@ -1,23 +1,61 @@
 import assert from "assert";
-import { pathToFileURL } from "url";
+import fs from "fs/promises";
+import path from "path";
 import { Request } from "../../http";
 import { Service, Worker_Binding, Worker_Module } from "../../runtime";
 import {
   MatcherRegExps,
+  base64Decode,
+  base64Encode,
   deserialiseRegExps,
   globsToRegExps,
+  lexicographicCompare,
   serialiseRegExps,
   testRegExps,
 } from "../../shared";
-import { FileStorage } from "../../storage";
+import { createFileReadableStream } from "../../storage2";
 import {
   BINDING_SERVICE_LOOPBACK,
   BINDING_TEXT_PERSIST,
   HEADER_PERSIST,
-  PARAM_FILE_UNSANITISE,
+  Persistence,
   WORKER_BINDING_SERVICE_LOOPBACK,
 } from "../shared";
-import { HEADER_SITES, KV_PLUGIN_NAME, PARAM_URL_ENCODED } from "./constants";
+import {
+  HEADER_SITES,
+  KV_PLUGIN_NAME,
+  MAX_LIST_KEYS,
+  PARAM_URL_ENCODED,
+} from "./constants";
+import {
+  KVGatewayGetOptions,
+  KVGatewayGetResult,
+  KVGatewayListOptions,
+  KVGatewayListResult,
+  validateGetOptions,
+  validateListOptions,
+} from "./gateway";
+
+async function* listKeysInDirectoryInner(
+  rootPath: string,
+  currentPath: string
+): AsyncGenerator<string> {
+  const fileEntries = await fs.readdir(currentPath, { withFileTypes: true });
+  for (const fileEntry of fileEntries) {
+    const filePath = path.join(currentPath, fileEntry.name);
+    if (fileEntry.isDirectory()) {
+      yield* listKeysInDirectoryInner(rootPath, filePath);
+    } else {
+      // Get key name by removing root directory & path separator
+      // (assumes `rootPath` is fully-resolved)
+      yield filePath.substring(rootPath.length + 1);
+    }
+  }
+}
+function listKeysInDirectory(rootPath: string): AsyncGenerator<string> {
+  rootPath = path.resolve(rootPath);
+  return listKeysInDirectoryInner(rootPath, rootPath);
+}
 
 export interface SitesOptions {
   sitePath: string;
@@ -153,12 +191,9 @@ export async function getSitesBindings(
 
   // Build __STATIC_CONTENT_MANIFEST contents
   const staticContentManifest: Record<string, string> = {};
-  const storage = new FileStorage(options.sitePath, /* sanitise */ false);
-  const result = await storage.list();
-  assert.strictEqual(result.cursor, "");
-  for (const { name } of result.keys) {
-    if (testSiteRegExps(siteRegExps, name)) {
-      staticContentManifest[name] = encodeSitesKey(name);
+  for await (const key of listKeysInDirectory(options.sitePath)) {
+    if (testSiteRegExps(siteRegExps, key)) {
+      staticContentManifest[key] = encodeSitesKey(key);
     }
   }
   const __STATIC_CONTENT_MANIFEST = JSON.stringify(staticContentManifest);
@@ -199,8 +234,7 @@ export function getSitesService(options: SitesOptions): Service {
 
   // Use unsanitised file storage to ensure file names containing e.g. dots
   // resolve correctly.
-  const persist = pathToFileURL(options.sitePath);
-  persist.searchParams.set(PARAM_FILE_UNSANITISE, "true");
+  const persist = path.resolve(options.sitePath);
 
   return {
     name: SERVICE_NAMESPACE_SITE,
@@ -220,4 +254,79 @@ export function getSitesService(options: SitesOptions): Service {
       ],
     },
   };
+}
+
+// Define Workers Sites specific KV gateway functions. We serve directly from
+// disk with Workers Sites to ensure we always send the most up-to-date files.
+// Otherwise, we'd have to copy files from disk to our own SQLite/blob store
+// whenever any of them changed.
+
+export async function sitesGatewayGet(
+  persist: Persistence,
+  key: string,
+  opts?: KVGatewayGetOptions
+): Promise<KVGatewayGetResult | undefined> {
+  // `persist` is a resolved path set in `getSitesService()`
+  assert(typeof persist === "string");
+
+  validateGetOptions(key, opts);
+  const filePath = path.join(persist, key);
+  if (!filePath.startsWith(persist)) return;
+  try {
+    return { value: await createFileReadableStream(filePath) };
+  } catch (e: unknown) {
+    if (
+      typeof e === "object" &&
+      e !== null &&
+      "code" in e &&
+      // @ts-expect-error `e.code` should be `unknown`, fixed in TypeScript 4.9
+      e.code === "ENOENT"
+    ) {
+      return;
+    }
+    throw e;
+  }
+}
+
+export async function sitesGatewayList(
+  persist: Persistence,
+  opts: KVGatewayListOptions = {}
+): Promise<KVGatewayListResult> {
+  // `persist` is a resolved path set in `getSitesService()`
+  assert(typeof persist === "string");
+
+  validateListOptions(opts);
+  const { limit = MAX_LIST_KEYS, prefix, cursor } = opts;
+
+  // Get sorted array of all keys matching prefix
+  let keys: KVGatewayListResult["keys"] = [];
+  for await (const name of listKeysInDirectory(persist)) {
+    if (prefix === undefined || name.startsWith(prefix)) keys.push({ name });
+  }
+  keys.sort((a, b) => lexicographicCompare(a.name, b.name));
+
+  // Apply cursor
+  const startAfter = cursor === undefined ? "" : base64Decode(cursor);
+  let startIndex = 0;
+  if (startAfter !== "") {
+    // We could do a binary search here, but listing Workers Sites namespaces
+    // is an incredibly unlikely operation, so doesn't need to be optimised
+    startIndex = keys.findIndex(({ name }) => name === startAfter);
+    // If we couldn't find where to start, return nothing
+    if (startIndex === -1) startIndex = keys.length;
+    // Since we want to start AFTER this index, add 1 to it
+    startIndex++;
+  }
+
+  // Apply limit
+  const endIndex = startIndex + limit;
+  const nextCursor =
+    endIndex < keys.length ? base64Encode(keys[endIndex - 1].name) : undefined;
+  keys = keys.slice(startIndex, endIndex);
+
+  if (nextCursor === undefined) {
+    return { keys, list_complete: true, cursor: undefined };
+  } else {
+    return { keys, list_complete: false, cursor: nextCursor };
+  }
 }

--- a/packages/tre/src/plugins/shared/range.ts
+++ b/packages/tre/src/plugins/shared/range.ts
@@ -2,6 +2,8 @@ import { ReadableStream } from "stream/web";
 import { TextEncoder } from "util";
 import { Headers, Response } from "../../http";
 
+// TODO(soon): move this to storage2 directory when Cache gateway ported
+
 const encoder = new TextEncoder();
 
 // Matches case-insensitive string "bytes", ignoring surrounding whitespace,

--- a/packages/tre/src/shared/clock.ts
+++ b/packages/tre/src/shared/clock.ts
@@ -4,3 +4,7 @@ export const defaultClock: Clock = () => Date.now();
 export function millisToSeconds(millis: number): number {
   return Math.floor(millis / 1000);
 }
+
+export function secondsToMillis(seconds: number): number {
+  return seconds * 1000;
+}

--- a/packages/tre/src/shared/types.ts
+++ b/packages/tre/src/shared/types.ts
@@ -26,3 +26,10 @@ export type Json = Literal | { [key: string]: Json } | Json[];
 export const JsonSchema: z.ZodType<Json> = z.lazy(() =>
   z.union([LiteralSchema, z.array(JsonSchema), z.record(JsonSchema)])
 );
+
+export function maybeApply<From, To>(
+  f: (value: From) => To,
+  maybeValue: From | undefined
+): To | undefined {
+  return maybeValue === undefined ? undefined : f(maybeValue);
+}

--- a/packages/tre/src/storage/file.ts
+++ b/packages/tre/src/storage/file.ts
@@ -8,6 +8,7 @@ import {
   sanitisePath,
   viewToArray,
 } from "../shared";
+import { NewStorage, createFileStorage } from "../storage2";
 import { LocalStorage } from "./local";
 import {
   Range,
@@ -123,6 +124,7 @@ export interface FileMeta<Meta = unknown> extends StoredMeta<Meta> {
 export class FileStorage extends LocalStorage {
   protected readonly root: string;
   #sqliteDatabase?: DatabaseType;
+  #newStorage?: NewStorage;
 
   constructor(
     root: string,
@@ -307,5 +309,9 @@ export class FileStorage extends LocalStorage {
     if (this.#sqliteDatabase !== undefined) return this.#sqliteDatabase;
     mkdirSync(path.dirname(this.root), { recursive: true });
     return (this.#sqliteDatabase = new Database(this.root + ".sqlite3"));
+  }
+
+  getNewStorage(): NewStorage {
+    return (this.#newStorage ??= createFileStorage(this.root));
   }
 }

--- a/packages/tre/src/storage/memory.ts
+++ b/packages/tre/src/storage/memory.ts
@@ -1,5 +1,6 @@
 import Database, { Database as DatabaseType } from "better-sqlite3";
 import { defaultClock } from "../shared";
+import { NewStorage, createMemoryStorage } from "../storage2";
 import { LocalStorage } from "./local";
 import {
   Range,
@@ -13,6 +14,7 @@ import {
 
 export class MemoryStorage extends LocalStorage {
   #sqliteDatabase?: DatabaseType;
+  #newStorage?: NewStorage;
 
   constructor(
     protected map = new Map<string, StoredValueMeta>(),
@@ -108,5 +110,9 @@ export class MemoryStorage extends LocalStorage {
 
   getSqliteDatabase(): DatabaseType {
     return (this.#sqliteDatabase ??= new Database(":memory:"));
+  }
+
+  getNewStorage(): NewStorage {
+    return (this.#newStorage ??= createMemoryStorage());
   }
 }

--- a/packages/tre/src/storage/storage.ts
+++ b/packages/tre/src/storage/storage.ts
@@ -8,6 +8,7 @@ import {
   lexicographicCompare,
   nonCircularClone,
 } from "../shared";
+import { NewStorage } from "../storage2";
 
 export interface StoredMeta<Meta = unknown> {
   /** Unix timestamp in seconds when this key expires */
@@ -200,6 +201,16 @@ export abstract class Storage {
   getSqliteDatabase(): DatabaseType {
     const name = this.constructor.name;
     throw new Error(`SQLite storage not implemented for ${name}`);
+  }
+
+  // Whilst we are migrating gateways over to the new storage system, we'd like
+  // to keep the `GatewayConstructor` type using the old `Storage` type.
+  // Gateways implemented using new storage should call this method on their
+  // passed storages to get an appropriate implementation.
+  // TODO(soon): remove this once all gateways migrated
+  getNewStorage(): NewStorage {
+    const name = this.constructor.name;
+    throw new Error(`New storage not implemented for ${name}`);
   }
 }
 

--- a/packages/tre/src/storage2/blob/index.ts
+++ b/packages/tre/src/storage2/blob/index.ts
@@ -1,0 +1,1 @@
+export * from "./streams";

--- a/packages/tre/src/storage2/blob/index.ts
+++ b/packages/tre/src/storage2/blob/index.ts
@@ -1,1 +1,2 @@
+export * from "./store";
 export * from "./streams";

--- a/packages/tre/src/storage2/blob/store.ts
+++ b/packages/tre/src/storage2/blob/store.ts
@@ -1,0 +1,192 @@
+import assert from "assert";
+import crypto from "crypto";
+import fs from "fs/promises";
+import path from "path";
+import { arrayBuffer } from "stream/consumers";
+import { ReadableStream } from "stream/web";
+import {
+  InclusiveRange,
+  MultipartOptions,
+  MultipartReadableStream,
+  createArrayReadableStream,
+  createFileReadableStream,
+  createFileWritableStream,
+  createMultipartArrayReadableStream,
+  createMultipartFileReadableStream,
+} from "./streams";
+
+const MODE_READ_ONLY = 0o444;
+
+// Serialisable, opaque, unguessable blob identifier
+export type BlobId = string;
+
+export interface BlobStore {
+  // Database for binary large objects. Provides single and multi-ranged
+  // streaming reads and writes.
+  //
+  // Blobs have unguessable identifiers, can be deleted, but are otherwise
+  // immutable. These properties make it possible to perform atomic updates with
+  // the SQLite metadata store. No other operations will be able to interact
+  // with the blob until it's committed to the metadata store, because they
+  // won't be able to guess the ID, and we don't allow listing blobs.
+  //
+  // For example, if we put a blob in the store, then fail to insert the blob ID
+  // into the SQLite database for some reason during a transaction (e.g.
+  // `onlyIf` condition failed), no other operations can read that blob because
+  // the ID is lost (we'll just background-delete the blob in this case).
+
+  get(
+    id: BlobId,
+    range?: InclusiveRange
+  ): Promise<ReadableStream<Uint8Array> | null>;
+  get(
+    id: BlobId,
+    ranges: InclusiveRange[],
+    opts: MultipartOptions
+  ): Promise<MultipartReadableStream | null>;
+
+  put(stream: ReadableStream<Uint8Array>): Promise<BlobId>;
+
+  delete(id: BlobId): Promise<void>;
+}
+
+function generateBlobId(): BlobId {
+  const idBuffer = Buffer.alloc(32 + 8);
+  crypto.randomFillSync(idBuffer, 0, 32);
+  idBuffer.writeBigUint64BE(process.hrtime.bigint(), 32);
+  return idBuffer.toString("hex");
+}
+
+export class MemoryBlobStore implements BlobStore {
+  readonly #blobs = new Map<string, Uint8Array>();
+
+  get(
+    id: BlobId,
+    range?: InclusiveRange
+  ): Promise<ReadableStream<Uint8Array> | null>;
+  get(
+    id: BlobId,
+    ranges: InclusiveRange[],
+    opts: MultipartOptions
+  ): Promise<MultipartReadableStream | null>;
+  async get(
+    id: BlobId,
+    ranges?: InclusiveRange | InclusiveRange[],
+    opts?: MultipartOptions
+  ): Promise<ReadableStream<Uint8Array> | MultipartReadableStream | null> {
+    const blob = this.#blobs.get(id);
+    if (blob === undefined) return null;
+    if (Array.isArray(ranges)) {
+      assert(opts !== undefined);
+      return createMultipartArrayReadableStream(blob, ranges, opts);
+    } else {
+      return createArrayReadableStream(blob, ranges);
+    }
+  }
+
+  async put(stream: ReadableStream<Uint8Array>): Promise<BlobId> {
+    const id = generateBlobId();
+    const buffer = await arrayBuffer(stream);
+    const blob = new Uint8Array(buffer);
+
+    // Store blob, making sure we're storing a new key
+    assert(!this.#blobs.has(id));
+    this.#blobs.set(id, blob);
+
+    return id;
+  }
+
+  async delete(id: BlobId): Promise<void> {
+    this.#blobs.delete(id);
+  }
+}
+
+export class FileBlobStore implements BlobStore {
+  readonly #root: string;
+
+  constructor(root: string) {
+    this.#root = path.resolve(root);
+  }
+
+  #idFilePath(id: BlobId) {
+    const filePath = path.join(this.#root, id);
+    return filePath.startsWith(this.#root) ? filePath : null;
+  }
+
+  get(
+    id: BlobId,
+    range?: InclusiveRange
+  ): Promise<ReadableStream<Uint8Array> | null>;
+  get(
+    id: BlobId,
+    ranges: InclusiveRange[],
+    opts: MultipartOptions
+  ): Promise<MultipartReadableStream | null>;
+  async get(
+    id: BlobId,
+    ranges?: InclusiveRange | InclusiveRange[],
+    opts?: MultipartOptions
+  ): Promise<ReadableStream<Uint8Array> | MultipartReadableStream | null> {
+    // Get path for this ID, returning null if it's outside the root
+    const filePath = this.#idFilePath(id);
+    if (filePath === null) return null;
+    // Get correct response for range, returning null if not found
+    try {
+      // The caller should only pass an array with >= 2 ranges, but allow less
+      if (Array.isArray(ranges)) {
+        assert(opts !== undefined);
+        return await createMultipartFileReadableStream(filePath, ranges, opts);
+      } else {
+        return await createFileReadableStream(filePath, ranges);
+      }
+    } catch (e: unknown) {
+      if (
+        typeof e === "object" &&
+        e !== null &&
+        "code" in e &&
+        // @ts-expect-error `e.code` should be `unknown`, fixed in TypeScript 4.9
+        e.code === "ENOENT"
+      ) {
+        return null;
+      }
+      throw e;
+    }
+  }
+
+  async put(stream: ReadableStream<Uint8Array>): Promise<BlobId> {
+    const id = generateBlobId();
+
+    // Get path for this ID, this should never be null as blob IDs are encoded
+    const filePath = this.#idFilePath(id);
+    assert(filePath !== null);
+
+    // Write stream to file with exclusive flag to assert new file creation
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    const writable = await createFileWritableStream(filePath, true /* excl. */);
+    // Mark the created file as read-only, this still allows it to be deleted
+    await fs.chmod(filePath, MODE_READ_ONLY);
+    // Write the stream, using the existing writable handle
+    await stream.pipeTo(writable);
+
+    return id;
+  }
+
+  async delete(id: BlobId): Promise<void> {
+    // Get path for this ID and delete, ignoring if outside root or not found
+    const filePath = this.#idFilePath(id);
+    try {
+      if (filePath !== null) await fs.unlink(filePath);
+    } catch (e: unknown) {
+      if (
+        typeof e === "object" &&
+        e !== null &&
+        "code" in e &&
+        // @ts-expect-error `e.code` should be `unknown`, fixed in TypeScript 4.9
+        e.code === "ENOENT"
+      ) {
+        return;
+      }
+      throw e;
+    }
+  }
+}

--- a/packages/tre/src/storage2/blob/streams.ts
+++ b/packages/tre/src/storage2/blob/streams.ts
@@ -1,0 +1,323 @@
+import assert from "assert";
+import { webcrypto } from "crypto";
+import { PathLike, promises as fs } from "fs";
+import {
+  ReadableByteStreamController,
+  ReadableStream,
+  ReadableStreamBYOBRequest,
+  WritableStream,
+} from "stream/web";
+
+const DEFAULT_CHUNK_SIZE = 1024;
+const MULTIPART_BOUNDARY_PREFIX = "miniflare-boundary-";
+
+const encoder = new TextEncoder();
+
+export interface InclusiveRange {
+  start: number; // inclusive
+  end: number; // inclusive
+}
+function assertRange({ start, end }: InclusiveRange) {
+  assert(0 <= start && start <= end, `Invalid range: [${start},${end}]`);
+}
+
+export type ValidReadableStreamBYOBRequest = Omit<
+  ReadableStreamBYOBRequest,
+  "view"
+> & { readonly view: Uint8Array };
+export function unwrapBYOBRequest(
+  controller: ReadableByteStreamController
+): ValidReadableStreamBYOBRequest {
+  // `controller.byobRequest` is typed as `undefined` in `@types/node`, but
+  // should actually be `ReadableStreamBYOBRequest | undefined`. Unfortunately,
+  // annotating `byobRequest` as `ReadableStreamBYOBRequest | undefined` doesn't
+  // help here. Because of TypeScript's data flow analysis, it thinks
+  // `controller.view` is `never`.
+  const byobRequest = controller.byobRequest as
+    | ReadableStreamBYOBRequest
+    | undefined;
+  assert(byobRequest !== undefined);
+
+  // Specifying `autoAllocateChunkSize` means we'll always have a view,
+  // even when using a default reader
+  assert(byobRequest.view !== null);
+  // Just asserted `view` is non-null, so this cast is safe
+  return byobRequest as ValidReadableStreamBYOBRequest;
+}
+
+export interface RangeSource {
+  // Reads from the source at `position` for up-to `length` bytes into `view`,
+  // returning the number of bytes read. `length <= view.byteLength` will hold.
+  readInto(view: Uint8Array, position: number, length: number): Promise<number>;
+  // Cleans up the source
+  close?(): Promise<void>;
+}
+function createArrayRangeSource(array: Uint8Array): RangeSource {
+  return {
+    async readInto(view, position, length) {
+      assert(length <= view.byteLength);
+      // `subarray()` will clamp `position + length` to `array.byteLength`
+      const subarray = array.subarray(position, position + length);
+      view.set(subarray);
+      return subarray.length;
+    },
+  };
+}
+async function createFileRangeSource(filePath: PathLike): Promise<RangeSource> {
+  // Open handle before creating stream, so not founds throws outside of stream
+  const handle = await fs.open(filePath, "r");
+  return {
+    async readInto(view, position, length) {
+      assert(length <= view.byteLength);
+      const { bytesRead } = await handle.read(view, 0, length, position);
+      return bytesRead;
+    },
+    close() {
+      return handle.close();
+    },
+  };
+}
+
+export function createReadableStream(
+  source: RangeSource,
+  range?: InclusiveRange
+): ReadableStream<Uint8Array> {
+  // Based off https://streams.spec.whatwg.org/#example-rbs-pull
+  if (range !== undefined) assertRange(range);
+  let position = range?.start ?? 0;
+  return new ReadableStream({
+    type: "bytes",
+    autoAllocateChunkSize: DEFAULT_CHUNK_SIZE,
+    async pull(controller) {
+      const byobRequest = unwrapBYOBRequest(controller);
+      const v = byobRequest.view;
+
+      let length = v.byteLength;
+      if (range !== undefined) {
+        // `+ 1` is because `range.end` is inclusive
+        length = Math.min(length, range.end - position + 1);
+      }
+
+      const bytesRead = await source.readInto(v, position, length);
+      if (bytesRead === 0) {
+        await source.close?.();
+        controller.close();
+      } else {
+        position += bytesRead;
+      }
+      byobRequest.respond(bytesRead);
+    },
+    cancel() {
+      return source.close?.();
+    },
+  });
+}
+
+// Reading multiple ranges and generating a multipart response is a lot more
+// complicated than single ranges. To keep the common case fast and simple,
+// split this out into a separate function.
+
+export interface MultipartOptions {
+  contentLength: number;
+  contentType?: string;
+}
+export interface MultipartReadableStream {
+  multipartContentType: string;
+  body: ReadableStream<Uint8Array>;
+}
+export function createMultipartReadableStream(
+  source: RangeSource,
+  ranges: InclusiveRange[],
+  opts: MultipartOptions
+): MultipartReadableStream {
+  for (const range of ranges) assertRange(range);
+
+  // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests#multipart_ranges
+  // for details on `multipart/byteranges` responses
+  const boundary = MULTIPART_BOUNDARY_PREFIX + webcrypto.randomUUID();
+  const multipartContentType = `multipart/byteranges; boundary=${boundary}`;
+
+  // At any point, we'll either be:
+  //   (1) Writing boundary/headers data (followed by writing the range)
+  //   (2) Writing trailer data (followed by closing the stream)
+  //   (3) Writing a range of the file
+  //
+  // (1) and (2) are both writing dynamically generated bytes to the stream, so
+  // treat them as one state. Define a type-level constraint for the states.
+  //
+  // Note `state` will be `undefined` on the first call to `nextState()`,
+  // transitioning to either (1) or (2).
+  let state:
+    | { array: Uint8Array /* (1), (2) */; nextRange?: InclusiveRange /* (1) */ }
+    | { range: InclusiveRange /* (3) */ }
+    | undefined;
+  let position = 0;
+
+  // Shallow clone `ranges`, so we don't affect caller by `shift()`ing elements
+  ranges = ranges.slice();
+
+  function nextState(): boolean /* done */ {
+    if (state === undefined || "range" in state) {
+      let toWrite: string;
+      const nextRange = ranges.shift();
+      if (nextRange === undefined) {
+        // Finished writing all ranges, now write the trailer [-->(2)]
+        toWrite = `--${boundary}--`;
+      } else {
+        // Write boundary and headers, then the range [-->(1)]
+        toWrite = `--${boundary}\r\n`;
+        if (opts.contentType !== undefined) {
+          toWrite += `Content-Type: ${opts.contentType}\r\n`;
+        }
+        const start = nextRange.start;
+        const end = Math.min(nextRange.end, opts.contentLength - 1);
+        toWrite += `Content-Range: bytes ${start}-${end}/${opts.contentLength}\r\n\r\n`;
+      }
+      // If this isn't the first thing we've written, we'll need to prepend CRLF
+      if (state !== undefined) toWrite = `\r\n${toWrite}`;
+
+      position = 0;
+      state = { array: encoder.encode(toWrite), nextRange };
+    } else {
+      if (state.nextRange === undefined) {
+        // Finished writing trailer, so we're done [-->*]
+        return true;
+      } else {
+        // Finished writing boundary and headers, now write the range [-->(3)]
+        position = state.nextRange.start;
+        state = { range: state.nextRange };
+      }
+    }
+    return false;
+  }
+
+  // We should never be done after the initial transition. Even if we have
+  // no ranges, we'll still write the trailer.
+  assert(!nextState());
+
+  const body = new ReadableStream({
+    type: "bytes",
+    autoAllocateChunkSize: DEFAULT_CHUNK_SIZE,
+    async pull(controller) {
+      // We call `nextState()` in `start()`, which either sets a defined `state`
+      // or `returns true` indicating we're finished. If we were finished, we
+      // would've closed the stream, and `pull()` shouldn't be called again.
+      assert(state !== undefined);
+
+      // `pull` is optional in `ReadableByteStreamControllerCallback`, but we've
+      // definitely defined it, because this is the function we're in right now
+      assert(this.pull !== undefined);
+
+      const byobRequest = unwrapBYOBRequest(controller);
+      const v = byobRequest.view;
+
+      if ("range" in state) {
+        // We're writing a range of the file
+        const range = state.range;
+        // `+ 1` is because `range.end` is inclusive
+        const length = Math.min(v.byteLength, range.end - position + 1);
+        const bytesRead = await source.readInto(v, position, length);
+        if (bytesRead === 0) {
+          // We've finished writing this range, move onto the next state. We
+          // should never be done after this. Even if we have no more ranges,
+          // we'll still write the trailer.
+          assert(!nextState());
+          // For BYOB, we're required to write bytes or close the stream
+          return this.pull(controller);
+        } else {
+          position += bytesRead;
+          byobRequest.respond(bytesRead);
+        }
+      } else {
+        // We're copying an array
+        const array = state.array;
+        const length = Math.min(v.byteLength, array.byteLength - position);
+        if (length === 0) {
+          // We've finished writing this array, move onto the next state.
+          if (nextState()) {
+            // If we're done, cleanup
+            await source.close?.();
+            controller.close();
+            byobRequest.respond(0);
+          } else {
+            // For BYOB, we're required to write bytes or close the stream
+            return this.pull(controller);
+          }
+        } else {
+          // `subarray()` returns a view over the same underlying buffer
+          v.set(array.subarray(position, position + length));
+          position += length;
+          byobRequest.respond(length);
+        }
+      }
+    },
+    cancel() {
+      return source.close?.();
+    },
+  });
+
+  return { multipartContentType, body };
+}
+
+export function createArrayReadableStream(
+  array: Uint8Array,
+  range?: InclusiveRange
+): ReadableStream<Uint8Array> {
+  // TODO(perf): small array optimisation: if `array.byteLength < DEFAULT_CHUNK_SIZE`,
+  //  as will likely be the case in local testing, enqueue range of array directly,
+  //  without allocating `DEFAULT_CHUNK_SIZE` buffer to copy into
+  // We could use `new Blob([array]).stream()` for this, but the returned value
+  // isn't a byte-stream, so doesn't allow BYOB reads
+  const source = createArrayRangeSource(array);
+  return createReadableStream(source, range);
+}
+
+export async function createFileReadableStream(
+  filePath: PathLike,
+  range?: InclusiveRange
+): Promise<ReadableStream<Uint8Array>> {
+  const source = await createFileRangeSource(filePath);
+  return createReadableStream(source, range);
+}
+
+export function createMultipartArrayReadableStream(
+  array: Uint8Array,
+  ranges: InclusiveRange[],
+  opts: MultipartOptions
+): MultipartReadableStream {
+  const source = createArrayRangeSource(array);
+  return createMultipartReadableStream(source, ranges, opts);
+}
+
+export async function createMultipartFileReadableStream(
+  filePath: PathLike,
+  ranges: InclusiveRange[],
+  opts: MultipartOptions
+): Promise<MultipartReadableStream> {
+  const source = await createFileRangeSource(filePath);
+  return createMultipartReadableStream(source, ranges, opts);
+}
+
+export async function createFileWritableStream(
+  filePath: PathLike,
+  exclusive = false
+): Promise<WritableStream<Uint8Array>> {
+  // Based off https://streams.spec.whatwg.org/#example-ws-backpressure
+  // Open handle before returning, so file errors throws outside of stream.
+  // If exclusive flag is set, throw if `filePath` already exists.
+  const handle = await fs.open(filePath, exclusive ? "wx" : "w");
+  return new WritableStream({
+    write(chunk) {
+      const promise = handle.write(chunk, 0, chunk.length);
+      // `write()`s return is typed as `Promise<void>` in `@types/node`, but
+      // should probably be `Promise<unknown>`, as any `Promise` is valid.
+      return promise as Promise<unknown> as Promise<void>;
+    },
+    close() {
+      return handle.close();
+    },
+    abort() {
+      return handle.close();
+    },
+  });
+}

--- a/packages/tre/src/storage2/index.ts
+++ b/packages/tre/src/storage2/index.ts
@@ -1,0 +1,1 @@
+export * from "./blob";

--- a/packages/tre/src/storage2/index.ts
+++ b/packages/tre/src/storage2/index.ts
@@ -1,1 +1,3 @@
 export * from "./blob";
+export * from "./sql";
+export * from "./storage";

--- a/packages/tre/src/storage2/index.ts
+++ b/packages/tre/src/storage2/index.ts
@@ -1,3 +1,4 @@
 export * from "./blob";
+export * from "./keyvalue";
 export * from "./sql";
 export * from "./storage";

--- a/packages/tre/src/storage2/keyvalue.ts
+++ b/packages/tre/src/storage2/keyvalue.ts
@@ -1,0 +1,255 @@
+import assert from "assert";
+import { ReadableStream } from "stream/web";
+import { base64Decode, base64Encode, defaultClock } from "../shared";
+import {
+  InclusiveRange,
+  MultipartOptions,
+  MultipartReadableStream,
+} from "./blob";
+import { TypedDatabase } from "./sql";
+import { NewStorage } from "./storage";
+
+export interface KeyEntry<Metadata = unknown> {
+  key: string;
+  expiration?: number; // milliseconds since unix epoch
+  metadata?: Metadata;
+}
+export interface KeyValueEntry<Metadata = unknown> extends KeyEntry<Metadata> {
+  value: ReadableStream<Uint8Array>;
+}
+export interface KeyMultipartValueEntry<Metadata = unknown>
+  extends KeyEntry<Metadata> {
+  value: MultipartReadableStream;
+}
+
+export interface KeyEntriesQuery {
+  prefix?: string;
+  cursor?: string;
+  limit: number;
+}
+export interface KeyEntries<Metadata = unknown> {
+  keys: KeyEntry<Metadata>[];
+  cursor?: string;
+}
+
+interface Row {
+  key: string;
+  blob_id: string;
+  expiration: number | null; // milliseconds since unix epoch
+  metadata: string | null;
+}
+const SQL_SCHEMA = `
+CREATE TABLE IF NOT EXISTS _mf_entries (
+  key TEXT PRIMARY KEY,
+  blob_id TEXT NOT NULL,
+  expiration INTEGER,
+  metadata TEXT
+);
+CREATE INDEX IF NOT EXISTS _mf_entries_expiration_idx ON _mf_entries(expiration);
+`;
+function sqlStmts(db: TypedDatabase) {
+  const stmtGetBlobIdByKey = db.prepare<Pick<Row, "key">, Pick<Row, "blob_id">>(
+    "SELECT blob_id FROM _mf_entries WHERE key = :key"
+  );
+  const stmtPut = db.prepare<Row>(
+    `INSERT OR REPLACE INTO _mf_entries (key, blob_id, expiration, metadata)
+    VALUES (:key, :blob_id, :expiration, :metadata)`
+  );
+
+  return {
+    getByKey: db.prepare<Pick<Row, "key">, Row>(
+      "SELECT key, blob_id, expiration, metadata FROM _mf_entries WHERE key = :key"
+    ),
+    put: db.transaction((newEntry: Row) => {
+      // TODO(perf): would be really nice if we didn't have to use a transaction
+      //  here, need old blob ID for cleanup
+      const key = newEntry.key;
+      const entry = stmtGetBlobIdByKey.get({ key });
+      stmtPut.run(newEntry);
+      return entry?.blob_id;
+    }),
+    deleteByKey: db.prepare<
+      Pick<Row, "key">,
+      Pick<Row, "blob_id" | "expiration">
+    >("DELETE FROM _mf_entries WHERE key = :key RETURNING blob_id, expiration"),
+    deleteExpired: db.prepare<{ now: number }, Pick<Row, "blob_id">>(
+      // `expiration` may be `NULL`, but `NULL < ...` should be falsy
+      "DELETE FROM _mf_entries WHERE expiration < :now RETURNING blob_id"
+    ),
+    list: db.prepare<
+      {
+        now: number;
+        escaped_prefix: string;
+        start_after: string;
+        limit: number;
+      },
+      Omit<Row, "blob_id">
+    >(
+      `SELECT key, expiration, metadata FROM _mf_entries
+        WHERE key LIKE :escaped_prefix || '%' ESCAPE '\\'
+        AND key > :start_after
+        AND (expiration IS NULL OR expiration >= :now)
+        ORDER BY key LIMIT :limit`
+    ),
+  };
+}
+
+function escapePrefix(prefix: string) {
+  // Prefix all instances of `\`, `_` and `%` with `\`
+  return prefix.replace(/[\\_%]/g, "\\$&");
+}
+
+function rowEntry<Metadata>(entry: Omit<Row, "blob_id">): KeyEntry<Metadata> {
+  return {
+    key: entry.key,
+    expiration: entry.expiration ?? undefined,
+    metadata: entry.metadata === null ? undefined : JSON.parse(entry.metadata),
+  };
+}
+
+export class KeyValueStorage<Metadata = unknown> {
+  readonly #stmts: ReturnType<typeof sqlStmts>;
+
+  constructor(
+    private readonly storage: NewStorage,
+    private readonly clock = defaultClock
+  ) {
+    storage.db.pragma("case_sensitive_like = TRUE");
+    storage.db.exec(SQL_SCHEMA);
+    this.#stmts = sqlStmts(storage.db);
+  }
+
+  #hasExpired(entry: Pick<Row, "expiration">) {
+    return entry.expiration !== null && entry.expiration < this.clock();
+  }
+
+  #backgroundDelete(blobId: string) {
+    // Once rows are deleted, or if they failed to insert, we delete the
+    // corresponding blobs in the background, ignoring errors. Blob IDs are
+    // unguessable, so if there aren't any references to them, they can't be
+    // accessed. This means if we fail to delete a blob for any reason, it
+    // doesn't matter, we'll just have a dangling file taking up disk space.
+    queueMicrotask(() => this.storage.blob.delete(blobId).catch(() => {}));
+  }
+
+  get(
+    key: string,
+    range?: InclusiveRange
+  ): Promise<KeyValueEntry<Metadata> | null>;
+  get(
+    key: string,
+    ranges: InclusiveRange[],
+    optsFactory: (metadata: Metadata) => MultipartOptions
+  ): Promise<KeyMultipartValueEntry<Metadata> | null>;
+  async get(
+    key: string,
+    ranges?: InclusiveRange | InclusiveRange[],
+    optsFactory?: (metadata: Metadata) => MultipartOptions
+  ): Promise<
+    KeyValueEntry<Metadata> | KeyMultipartValueEntry<Metadata> | null
+  > {
+    // Try to get key from metadata store, returning null if not found
+    const row = this.#stmts.getByKey.get({ key });
+    if (row === undefined) return null;
+
+    if (this.#hasExpired(row)) {
+      // If expired, delete from metadata and blob stores. Assuming a
+      // monotonically increasing clock, this doesn't need to be in a
+      // transaction with the above get. If we call `get()` again, the current
+      // time will be >= now, so the entry will still be expired. Trying to
+      // delete an already deleted row won't do anything, and we'll ignore the
+      // blob not found error.
+      this.#stmts.deleteByKey.run({ key });
+      // Garbage collect expired blob
+      this.#backgroundDelete(row.blob_id);
+      return null;
+    }
+
+    const entry = rowEntry<Metadata>(row);
+    if (Array.isArray(ranges)) {
+      // If this is a multi-range request, get multipart options from metadata,
+      // then return a multipart stream...
+      assert(optsFactory !== undefined && entry.metadata !== undefined);
+      const opts = optsFactory(entry.metadata);
+      const value = await this.storage.blob.get(row.blob_id, ranges, opts);
+      if (value === null) return null;
+
+      const valueEntry = entry as KeyMultipartValueEntry<Metadata>;
+      valueEntry.value = value;
+      return valueEntry;
+    } else {
+      // ...otherwise just return a regular stream
+      const value = await this.storage.blob.get(row.blob_id, ranges);
+      if (value === null) return null;
+
+      const valueEntry = entry as KeyValueEntry<Metadata>;
+      valueEntry.value = value;
+      return valueEntry;
+    }
+  }
+
+  async put(entry: KeyValueEntry<Metadata>): Promise<void> {
+    // Empty keys are not permitted because we default to starting after "" when
+    // listing. See `list()` for more details.
+    assert.notStrictEqual(entry.key, "");
+    const blobId = await this.storage.blob.put(entry.value);
+    // Put new entry into metadata store, returning old entry's blob ID if any
+    const maybeOldBlobId = this.#stmts.put({
+      key: entry.key,
+      blob_id: blobId,
+      expiration: entry.expiration ?? null,
+      metadata:
+        entry.metadata === undefined ? null : JSON.stringify(entry.metadata),
+    });
+    // Garbage collect previous entry's blob
+    if (maybeOldBlobId !== undefined) this.#backgroundDelete(maybeOldBlobId);
+  }
+
+  async delete(key: string): Promise<boolean> {
+    // Try to delete key from metadata store, returning false if not found
+    const row = this.#stmts.deleteByKey.get({ key });
+    if (row === undefined) return false;
+    // Garbage collect deleted entry's blob
+    this.#backgroundDelete(row.blob_id);
+    // Return true iff this entry hasn't expired
+    return !this.#hasExpired(row);
+  }
+
+  async list(opts: KeyEntriesQuery): Promise<KeyEntries<Metadata>> {
+    // Find non-expired entries matching query after cursor
+    const now = this.clock();
+    const rows = this.#stmts.list.all({
+      now,
+      escaped_prefix: escapePrefix(opts.prefix ?? ""),
+      // Note the "" default here prohibits empty string keys. The consumers
+      // of this class are KV and Cache. KV validates keys are non-empty.
+      // Cache keys are usually URLs, but can be customised with `cf.cacheKey`.
+      // If this is empty, we can just not cache the response, since that
+      // satisfies the Cache API contract.
+      start_after: opts.cursor === undefined ? "" : base64Decode(opts.cursor),
+      // Increase the queried limit by 1, if we return this many results, we
+      // know there are more rows. We'll truncate to the original limit before
+      // returning results.
+      limit: opts.limit + 1,
+    });
+
+    // Garbage collect expired entries. As with `get()`, assuming a
+    // monotonically increasing clock, this doesn't need to be in a transaction.
+    const expiredRows = this.#stmts.deleteExpired.all({ now });
+    for (const row of expiredRows) this.#backgroundDelete(row.blob_id);
+
+    // If there are more results, we'll be returning a cursor
+    const hasMoreRows = rows.length === opts.limit + 1;
+    rows.splice(opts.limit, 1);
+
+    const keys = rows.map((row) => rowEntry<Metadata>(row));
+
+    // The cursor encodes a key to start after rather than the key to start at
+    // to ensure keys added between `list()` calls are returned.
+    const nextCursor = hasMoreRows
+      ? base64Encode(rows[opts.limit - 1].key)
+      : undefined;
+
+    return { keys, cursor: nextCursor };
+  }
+}

--- a/packages/tre/src/storage2/sql.ts
+++ b/packages/tre/src/storage2/sql.ts
@@ -1,0 +1,21 @@
+import { Database, Statement } from "better-sqlite3";
+
+// `better-sqlite3`'s `Statement` methods have `any`-typed return values.
+// Define types that define the return type at `prepare()` time.
+
+export type TypedStatement<
+  Params extends any[] = any[],
+  SingleResult = unknown
+> = Omit<Statement<Params>, "get" | "all" | "iterate"> & {
+  get(...params: Params): SingleResult | undefined;
+  all(...params: Params): SingleResult[];
+  iterate(...params: Params): IterableIterator<SingleResult>;
+};
+
+export type TypedDatabase = Omit<Database, "prepare"> & {
+  prepare<Params, SingleResult = unknown>(
+    source: string
+  ): Params extends any[]
+    ? TypedStatement<Params, SingleResult>
+    : TypedStatement<[Params], SingleResult>;
+};

--- a/packages/tre/src/storage2/storage.ts
+++ b/packages/tre/src/storage2/storage.ts
@@ -1,0 +1,26 @@
+import fs from "fs";
+import path from "path";
+import Database from "better-sqlite3";
+import { BlobStore, FileBlobStore, MemoryBlobStore } from "./blob";
+import { TypedDatabase } from "./sql";
+
+// TODO: rename to `Storage` and move to `src/storage` once all gateways migrated
+export interface NewStorage {
+  db: TypedDatabase;
+  blob: BlobStore;
+}
+
+export function createMemoryStorage(): NewStorage {
+  const db = new Database(":memory:") as TypedDatabase;
+  const blob = new MemoryBlobStore();
+  return { db, blob };
+}
+
+export function createFileStorage(root: string): NewStorage {
+  root = path.resolve(root);
+  fs.mkdirSync(root, { recursive: true });
+  const db = new Database(path.join(root, "db.sqlite")) as TypedDatabase;
+  db.pragma("journal_mode = WAL");
+  const blob = new FileBlobStore(path.join(root, "blobs"));
+  return { db, blob };
+}

--- a/packages/tre/test/plugins/r2/index.spec.ts
+++ b/packages/tre/test/plugins/r2/index.spec.ts
@@ -157,7 +157,6 @@ class TestR2Bucket implements R2Bucket {
     } else if (ArrayBuffer.isView(value)) {
       valueBlob = new Blob([viewToArray(value)]);
     } else if (value instanceof ReadableStream) {
-      // @ts-expect-error `ReadableStream` is an `AsyncIterable`
       valueBlob = await blob(value);
     } else {
       valueBlob = new Blob([value]);

--- a/packages/tre/test/storage2/blob/store.spec.ts
+++ b/packages/tre/test/storage2/blob/store.spec.ts
@@ -1,0 +1,159 @@
+import assert from "assert";
+import { Blob } from "buffer";
+import { existsSync } from "fs";
+import fs from "fs/promises";
+import path from "path";
+import { arrayBuffer, text } from "stream/consumers";
+import { BlobStore, FileBlobStore, MemoryBlobStore } from "@miniflare/tre";
+import test, { ExecutionContext, Macro } from "ava";
+import { useTmp } from "../../test-shared";
+
+type BlobStoreFactory = (t: ExecutionContext) => Promise<BlobStore>;
+const MemoryBlobStoreFactory: BlobStoreFactory = async () =>
+  new MemoryBlobStore();
+const FileBlobStoreFactory: BlobStoreFactory = async (t) => {
+  const tmp = await useTmp(t);
+  return new FileBlobStore(tmp);
+};
+
+const getMacro: Macro<[BlobStoreFactory]> = {
+  async exec(t, factory) {
+    const store = await factory(t);
+    const id = await store.put(new Blob(["0123456789"]).stream());
+
+    // Check full range
+    let stream = await store.get(id);
+    assert(stream !== null);
+    t.is(await text(stream), "0123456789");
+
+    // Check single range
+    stream = await store.get(id, { start: 3, end: 7 });
+    assert(stream !== null);
+    t.is(await text(stream), "34567");
+
+    // Check multiple ranges
+    const multipartStream = await store.get(
+      id,
+      [
+        { start: 1, end: 3 },
+        { start: 5, end: 6 },
+        { start: 9, end: 9 },
+      ],
+      {
+        contentLength: 10,
+        contentType: "text/plain",
+      }
+    );
+    assert(multipartStream !== null);
+    const [contentType, boundary] =
+      multipartStream.multipartContentType.split("=");
+    t.is(contentType, "multipart/byteranges; boundary");
+    const actualText = await text(multipartStream.body);
+    const expectedText = [
+      `--${boundary}`,
+      "Content-Type: text/plain",
+      "Content-Range: bytes 1-3/10",
+      "",
+      "123",
+      `--${boundary}`,
+      "Content-Type: text/plain",
+      "Content-Range: bytes 5-6/10",
+      "",
+      "56",
+      `--${boundary}`,
+      "Content-Type: text/plain",
+      "Content-Range: bytes 9-9/10",
+      "",
+      "9",
+      `--${boundary}--`,
+    ].join("\r\n");
+    t.is(actualText, expectedText);
+
+    // Check getting invalid ID returns null
+    stream = await store.get("bad");
+    t.is(stream, null);
+  },
+};
+test("MemoryBlobStore: get", getMacro, MemoryBlobStoreFactory);
+test("FileBlobStore: get", getMacro, FileBlobStoreFactory);
+test("FileBlobStore: get: file-system specific functionality", async (t) => {
+  const tmp = await useTmp(t);
+  await fs.writeFile(path.join(tmp, "secrets.txt"), "password123");
+  const root = path.join(tmp, "root");
+  const store = new FileBlobStore(root);
+
+  // Check getting ID outside root returns null
+  let stream = await store.get("../secrets.txt");
+  t.is(stream, null);
+
+  // Check with non-standard nested blob IDs used by Workers Sites
+  const subPath = path.join(root, "a", "b", "c");
+  await fs.mkdir(subPath, { recursive: true });
+  await fs.writeFile(path.join(subPath, "test.txt"), "thing");
+  stream = await store.get("a/b/c/test.txt");
+  assert(stream !== null);
+  t.is(await text(stream), "thing");
+});
+
+const putMacro: Macro<[BlobStoreFactory]> = {
+  async exec(t, factory) {
+    const store = await factory(t);
+    const id = await store.put(new Blob(["value"]).stream());
+    const value = await store.get(id);
+    assert(value !== null);
+    t.is(await text(value), "value");
+  },
+};
+test("MemoryBlobStore: put", putMacro, MemoryBlobStoreFactory);
+test("FileBlobStore: put", putMacro, FileBlobStoreFactory);
+test("FileBlobStore: put: file-system specific functionality", async (t) => {
+  const tmp = await useTmp(t);
+  const root = path.join(tmp, "root");
+  const store = new FileBlobStore(root);
+
+  // Check created file is read-only
+  const id = await store.put(new Blob(["😈"]).stream());
+  const filePath = path.join(root, id);
+  await t.throwsAsync(fs.writeFile(filePath, "new"), {
+    code: process.platform === "win32" ? "EPERM" : "EACCES",
+  });
+});
+
+const deleteMacro: Macro<[BlobStoreFactory]> = {
+  async exec(t, factory) {
+    const store = await factory(t);
+
+    // Check delete removes blob
+    let id = await store.put(new Blob(["value"]).stream());
+    let value = await store.get(id);
+    assert(value !== null);
+    await arrayBuffer(value); // (drain)
+    await store.delete(id);
+    value = await store.get(id);
+    t.is(value, null);
+
+    // Check delete whilst getting still returns value
+    id = await store.put(new Blob(["value"]).stream());
+    value = await store.get(id);
+    assert(value !== null);
+    await store.delete(id);
+    t.is(await text(value), "value");
+
+    // Check deleting invalid ID does nothing
+    await store.delete("whoops");
+  },
+};
+test("MemoryBlobStore: delete", deleteMacro, MemoryBlobStoreFactory);
+test("FileBlobStore: delete", deleteMacro, FileBlobStoreFactory);
+test("FileBlobStore: delete: file-system specific functionality", async (t) => {
+  const tmp = await useTmp(t);
+  const root = path.join(tmp, "root");
+  const store = new FileBlobStore(root);
+
+  // Check deleting ID outside root does nothing
+  const importantPath = path.join(tmp, "unicorn.txt");
+  await fs.writeFile(importantPath, "❤️🦄");
+  await store.delete("../unicorn.txt");
+  await store.delete("dir/../../unicorn.txt");
+  t.true(existsSync(importantPath));
+});

--- a/packages/tre/test/storage2/blob/streams.spec.ts
+++ b/packages/tre/test/storage2/blob/streams.spec.ts
@@ -1,0 +1,328 @@
+import assert, { AssertionError } from "assert";
+import fs from "fs/promises";
+import path from "path";
+import { arrayBuffer } from "stream/consumers";
+import { TextEncoderStream } from "stream/web";
+import {
+  createArrayReadableStream,
+  createFileReadableStream,
+  createFileWritableStream,
+  createMultipartArrayReadableStream,
+  createMultipartFileReadableStream,
+} from "@miniflare/tre";
+import test, { Macro } from "ava";
+import { useTmp, utf8Decode, utf8Encode } from "../../test-shared";
+
+function arrayInit<T>(n: number, f: (i: number) => T): T[] {
+  return Array.from(Array(n)).map((_, i) => f(i));
+}
+function concat(...arrays: Uint8Array[]): Uint8Array {
+  // `Buffer`s are `Uint8Array`s, but for deep-equal, we need types to match
+  return new Uint8Array(Buffer.concat(arrays));
+}
+
+// [0, 1, 2, ..., 255] (i.e. `singleData[i] === i`)
+const singleData = new Uint8Array(arrayInit(256, (i) => i));
+// [0, 0, 1, 1, 2, ..., 254, 255, 255]
+const doubleData = new Uint8Array(arrayInit(512, (i) => Math.floor(i / 2)));
+// // [0, 0, 0, 1, 1, 1, 2, ..., 254, 255, 255, 255]
+const tripleData = new Uint8Array(arrayInit(768, (i) => Math.floor(i / 3)));
+const testData = concat(singleData, doubleData, tripleData);
+
+const readableMacro: Macro<[typeof createFileReadableStream]> = {
+  async exec(t, f) {
+    const tmp = await useTmp(t);
+    const testPath = path.join(tmp, "test.txt");
+    await fs.writeFile(testPath, testData);
+
+    // Check with default reader
+    let stream = await f(testPath);
+    const reader = stream.getReader();
+    t.deepEqual(
+      (await reader.read()).value,
+      // 256 + 512 + 256 (default auto-allocated buffer is 1024 bytes)
+      concat(singleData, doubleData, tripleData.slice(0, 256))
+    );
+    t.deepEqual((await reader.read()).value, tripleData.slice(256));
+    t.true((await reader.read()).done);
+
+    // Check with BYOB reader
+    stream = await f(testPath);
+    let byobReader = stream.getReader({ mode: "byob" });
+    let buffer = new ArrayBuffer(4);
+    let result = await byobReader.read(new Uint8Array(buffer));
+    assert(!result.done);
+    t.deepEqual(result.value, new Uint8Array([0, 1, 2, 3]));
+    buffer = result.value.buffer;
+    result = await byobReader.read(new Uint8Array(buffer));
+    assert(!result.done);
+    t.deepEqual(result.value, new Uint8Array([4, 5, 6, 7]));
+    await byobReader.cancel();
+
+    // Check with range
+    stream = await f(testPath, { start: 8, end: 20 });
+    byobReader = stream.getReader({ mode: "byob" });
+    buffer = new ArrayBuffer(8);
+    result = await byobReader.read(new Uint8Array(buffer));
+    assert(!result.done);
+    t.deepEqual(result.value, new Uint8Array([8, 9, 10, 11, 12, 13, 14, 15]));
+    buffer = result.value.buffer;
+    result = await byobReader.read(new Uint8Array(buffer));
+    assert(!result.done);
+    t.deepEqual(result.value, new Uint8Array([16, 17, 18, 19, 20]));
+    buffer = result.value.buffer;
+    result = await byobReader.read(new Uint8Array(buffer));
+    assert(result.done);
+
+    // Check accepts single byte ranges
+    stream = await f(testPath, { start: 0, end: 0 });
+    t.deepEqual(new Uint8Array(await arrayBuffer(stream)), new Uint8Array([0]));
+    stream = await f(testPath, { start: 7, end: 7 });
+    t.deepEqual(new Uint8Array(await arrayBuffer(stream)), new Uint8Array([7]));
+
+    // Check rejects invalid ranges
+    await t.throwsAsync(f(testPath, { start: -1, end: 5 }), {
+      instanceOf: AssertionError,
+      message: "Invalid range: [-1,5]",
+    });
+    await t.throwsAsync(f(testPath, { start: 5, end: 3 }), {
+      instanceOf: AssertionError,
+      message: "Invalid range: [5,3]",
+    });
+  },
+};
+
+test(
+  "createArrayReadableStream: streams contents from array",
+  readableMacro,
+  async (_testPath, range) => createArrayReadableStream(testData, range)
+);
+test(
+  "createFileReadableStream: streams file contents from disk",
+  readableMacro,
+  createFileReadableStream
+);
+test("createFileReadableStream: rejects if file not found", async (t) => {
+  const tmp = await useTmp(t);
+  const badPath = path.join(tmp, "bad.txt");
+  await t.throwsAsync(createFileReadableStream(badPath), { code: "ENOENT" });
+});
+
+const crlfArray = utf8Encode("\r\n");
+const emptyArray = new Uint8Array();
+// Returns concatenation of lines separated by CRLF sequences
+function crlfLines(...lines: (string | Uint8Array)[]): Uint8Array {
+  return concat(
+    ...lines.flatMap((line, i) => [
+      // If line is a string, UTF-8 encode it, otherwise use as is...
+      typeof line === "string" ? utf8Encode(line) : line,
+      // ...then concat CRLF if this isn't the last line
+      i < lines.length - 1 ? crlfArray : emptyArray,
+    ])
+  );
+}
+
+const multipartMacro: Macro<[typeof createMultipartFileReadableStream]> = {
+  async exec(t, f) {
+    const tmp = await useTmp(t);
+    const testPath = path.join(tmp, "test.txt");
+    await fs.writeFile(testPath, testData);
+
+    // Check with multiple (including single byte) ranges and default reader
+    let stream = await f(
+      testPath,
+      [
+        { start: 5, end: 10 },
+        { start: 23, end: 29 },
+        { start: 0, end: 0 },
+        { start: 3, end: 3 },
+      ],
+      { contentLength: testData.byteLength }
+    );
+    let [contentType, boundary] = stream.multipartContentType.split("=");
+    t.is(contentType, "multipart/byteranges; boundary");
+    let actualArray = new Uint8Array(await arrayBuffer(stream.body));
+    let expectedArray = crlfLines(
+      `--${boundary}`,
+      "Content-Range: bytes 5-10/1536",
+      "",
+      new Uint8Array([5, 6, 7, 8, 9, 10]),
+      `--${boundary}`,
+      "Content-Range: bytes 23-29/1536",
+      "",
+      new Uint8Array([23, 24, 25, 26, 27, 28, 29]),
+      `--${boundary}`,
+      "Content-Range: bytes 0-0/1536",
+      "",
+      new Uint8Array([0]),
+      `--${boundary}`,
+      "Content-Range: bytes 3-3/1536",
+      "",
+      new Uint8Array([3]),
+      `--${boundary}--`
+    );
+    t.deepEqual(actualArray, expectedArray);
+
+    // Check with single range and BYOB reader
+    stream = await f(testPath, [{ start: 17, end: 20 }], {
+      contentLength: testData.byteLength,
+    });
+    [contentType, boundary] = stream.multipartContentType.split("=");
+    t.is(contentType, "multipart/byteranges; boundary");
+    const byobReader = stream.body.getReader({ mode: "byob" });
+    let buffer = new ArrayBuffer(128);
+
+    let expected = `--${boundary}`;
+    let result = await byobReader.read(
+      new Uint8Array(buffer, 0, expected.length)
+    );
+    assert(!result.done);
+    t.deepEqual(utf8Decode(result.value), expected);
+    buffer = result.value.buffer;
+
+    expected = `\r\nContent-Range: bytes 17-20/1536\r\n\r\n`;
+    result = await byobReader.read(new Uint8Array(buffer, 0, expected.length));
+    assert(!result.done);
+    t.deepEqual(utf8Decode(result.value), expected);
+    buffer = result.value.buffer;
+
+    result = await byobReader.read(new Uint8Array(buffer, 0, 4));
+    assert(!result.done);
+    t.deepEqual(result.value, new Uint8Array([17, 18, 19, 20]));
+    buffer = result.value.buffer;
+
+    expected = `\r\n--${boundary}--`;
+    result = await byobReader.read(new Uint8Array(buffer, 0, expected.length));
+    assert(!result.done);
+    t.deepEqual(utf8Decode(result.value), expected);
+    buffer = result.value.buffer;
+
+    result = await byobReader.read(new Uint8Array(buffer));
+    assert(result.done);
+
+    // Check with no ranges
+    stream = await f(testPath, [], {
+      contentLength: testData.byteLength,
+    });
+    [contentType, boundary] = stream.multipartContentType.split("=");
+    t.is(contentType, "multipart/byteranges; boundary");
+    actualArray = new Uint8Array(await arrayBuffer(stream.body));
+    expectedArray = utf8Encode(`--${boundary}--`);
+    t.deepEqual(actualArray, expectedArray);
+
+    // Check rejects invalid ranges
+    await t.throwsAsync(
+      f(
+        testPath,
+        [
+          { start: 0, end: 3 },
+          { start: -1, end: 4 },
+          { start: 7, end: 9 },
+        ],
+        { contentLength: testData.byteLength }
+      ),
+      { instanceOf: AssertionError, message: "Invalid range: [-1,4]" }
+    );
+    await t.throwsAsync(
+      f(testPath, [{ start: 16, end: 4 }], {
+        contentLength: testData.byteLength,
+      }),
+      { instanceOf: AssertionError, message: "Invalid range: [16,4]" }
+    );
+
+    // Check with content type
+    stream = await f(
+      testPath,
+      [
+        { start: 4, end: 6 },
+        { start: 8, end: 9 },
+      ],
+      {
+        contentLength: testData.byteLength,
+        contentType: "application/octet-stream",
+      }
+    );
+    [contentType, boundary] = stream.multipartContentType.split("=");
+    t.is(contentType, "multipart/byteranges; boundary");
+    actualArray = new Uint8Array(await arrayBuffer(stream.body));
+    expectedArray = crlfLines(
+      `--${boundary}`,
+      "Content-Type: application/octet-stream",
+      "Content-Range: bytes 4-6/1536",
+      "",
+      new Uint8Array([4, 5, 6]),
+      `--${boundary}`,
+      "Content-Type: application/octet-stream",
+      "Content-Range: bytes 8-9/1536",
+      "",
+      new Uint8Array([8, 9]),
+      `--${boundary}--`
+    );
+    t.deepEqual(actualArray, expectedArray);
+  },
+};
+
+test(
+  "createMultipartArrayReadableStream: streams contents from array",
+  multipartMacro,
+  async (_testPath, ranges, opts) =>
+    createMultipartArrayReadableStream(testData, ranges, opts)
+);
+test(
+  "createMultipartFileReadableStream: streams file contents from disk",
+  multipartMacro,
+  createMultipartFileReadableStream
+);
+test("createMultipartFileReadableStream: rejects if file not found", async (t) => {
+  const tmp = await useTmp(t);
+  const badPath = path.join(tmp, "bad.txt");
+  await t.throwsAsync(
+    createMultipartFileReadableStream(badPath, [], { contentLength: 0 }),
+    { code: "ENOENT" }
+  );
+});
+
+test("createFileWritableStream: streams file contents to disk", async (t) => {
+  const tmp = await useTmp(t);
+  const testPath = path.join(tmp, "test.txt");
+
+  // Check writes file
+  let stream = await createFileWritableStream(testPath);
+  const writer = stream.getWriter();
+  await writer.write(utf8Encode("abc"));
+  await writer.write(utf8Encode("de"));
+  await writer.write(utf8Encode("f"));
+  await writer.close();
+  t.is(await fs.readFile(testPath, "utf8"), "abcdef");
+
+  // Check overwrites file
+  stream = await createFileWritableStream(testPath);
+  const encoderStream = new TextEncoderStream();
+  const pipePromise = encoderStream.readable.pipeTo(stream);
+  const stringWriter = encoderStream.writable.getWriter();
+  await stringWriter.write("1");
+  await stringWriter.write("23");
+  await stringWriter.write("456");
+  await stringWriter.close();
+  await pipePromise;
+  t.is(await fs.readFile(testPath, "utf8"), "123456");
+
+  // Check fails to overwrite file with exclusive flag
+  await t.throwsAsync(createFileWritableStream(testPath, true), {
+    code: "EEXIST",
+  });
+});
+
+test("createFileReadableStream/createFileWritableStream: copies file", async (t) => {
+  const tmp = await useTmp(t);
+  const testPath = path.join(tmp, "test.txt");
+  const copyPath = path.join(tmp, "copy.txt");
+  await fs.writeFile(testPath, testData);
+
+  const readableStream = await createFileReadableStream(testPath);
+  const writableStream = await createFileWritableStream(copyPath);
+  await readableStream.pipeTo(writableStream);
+
+  const copyData = await fs.readFile(copyPath);
+  t.deepEqual(new Uint8Array(copyData), testData);
+});

--- a/types/streams.d.ts
+++ b/types/streams.d.ts
@@ -1,63 +1,40 @@
-// Types adapted from https://github.com/MattiasBuelens/web-streams-polyfill/
-//
-// The MIT License (MIT)
-//
-// Copyright (c) 2020 Mattias Buelens
-// Copyright (c) 2016 Diwank Singh Tomer
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 declare module "stream/web" {
+  interface ReadableStreamBYOBRequest {
+    readonly view: Uint8Array | null;
+    respond(bytesWritten: number): void;
+    respondWithNewView(view: ArrayBufferView): void;
+  }
+
   interface ReadableStream<R = any> {
-    values(options?: { preventCancel?: boolean }): AsyncIterableIterator<R>;
     getReader(): ReadableStreamDefaultReader<R>;
     getReader(options: { mode: "byob" }): ReadableStreamBYOBReader;
   }
 
   interface ReadableStreamBYOBReader {
-    readonly closed: Promise<undefined>;
-    cancel(reason?: any): Promise<undefined>;
+    readonly closed: Promise<void>;
+    cancel(reason?: any): Promise<void>;
     read<T extends ArrayBufferView>(
       view: T
-    ): Promise<ReadableStreamBYOBReadResult<T>>;
+    ): Promise<ReadableStreamDefaultReadResult<T>>;
     releaseLock(): void;
-    // Non-standard: https://community.cloudflare.com/t/2021-10-21-workers-runtime-release-notes/318571
-    readAtLeast<T extends ArrayBufferView>(
-      bytes: number,
-      view: T
-    ): Promise<ReadableStreamBYOBReadResult<T>>;
   }
+}
 
-  export type ReadableStreamBYOBReadResult<T extends ArrayBufferView> =
-    | {
-        done: false;
-        value: T;
-      }
-    | {
-        done: true;
-        value: T | undefined;
-      };
+declare module "stream/consumers" {
+  import { Blob } from "buffer";
+  import { Readable } from "stream";
 
-  class CompressionStream extends TransformStream {
-    constructor(format: "gzip" | "deflate");
-  }
-  class DecompressionStream extends TransformStream {
-    constructor(format: "gzip" | "deflate");
-  }
+  // `@types/node`'s types for `stream/consumers` omit `AsyncIterable<any>`,
+  // meaning passing `ReadableStream`s from `stream/web` fails
+  type StreamLike =
+    | NodeJS.ReadableStream
+    | Readable
+    | AsyncIterator<any>
+    | AsyncIterable<any>;
+
+  function buffer(stream: StreamLike): Promise<Buffer>;
+  function text(stream: StreamLike): Promise<string>;
+  function arrayBuffer(stream: StreamLike): Promise<ArrayBuffer>;
+  function blob(stream: StreamLike): Promise<Blob>;
+  function json(stream: StreamLike): Promise<unknown>;
 }


### PR DESCRIPTION
This PR implements a new underlying storage system for Miniflare, based off #525 and internal discussions. The storage system is split into 2 parts: an SQLite-backed metadata store, and a streaming file-system backed/in-memory blob store. Blobs use unguessable identifiers to support atomic transactions with the SQLite metadata store. See `BlobStore` for more details. This is a breaking change to the persistence format.

This PR also re-implements the KV gateway using the new storage system, as an example of what a data store consuming this system might look like. Notably, this implementation uses an intermediate expiring key-value-metadata store, that will be shared by the Cache gateway in the future.

Best reviewed commit-by-commit.

Closes DEVX-583, DEVX-584, DEVX-585, DEVX-586, DEVX-587, DEVX-588 and DEVX-589.
