### PR TITLE
BuildPlugin: fix `build.watch_dir` to allow passing in array

### DIFF
--- a/packages/core/src/plugins/build.ts
+++ b/packages/core/src/plugins/build.ts
@@ -41,7 +41,13 @@ export class BuildPlugin extends Plugin<BuildOptions> implements BuildOptions {
     description: "Directory to watch for rebuilding on changes",
     fromWrangler: ({ build, miniflare }) => {
       const watchPaths = miniflare?.build_watch_dirs ?? [];
-      if (build?.watch_dir) watchPaths.push(build.watch_dir);
+      if (build?.watch_dir) {
+        watchPaths.push(
+          ...(Array.isArray(build.watch_dir)
+            ? build.watch_dir
+            : [build.watch_dir])
+        );
+      }
       if (watchPaths.length) return watchPaths;
 
       // If build command set and no paths set, fallback to watching "src"

--- a/packages/core/test/plugins/build.spec.ts
+++ b/packages/core/test/plugins/build.spec.ts
@@ -98,6 +98,18 @@ test("BuildPlugin: parses options from wrangler config", (t) => {
     buildBasePath: undefined,
     buildWatchPaths: undefined,
   });
+  // build.watch_dir should accept an array of strings
+  options = parsePluginWranglerConfig(BuildPlugin, {
+    build: {
+      watch_dir: ["source", "source1"],
+    },
+    miniflare: {
+      build_watch_dirs: ["source2", "source3"],
+    },
+  });
+  t.like(options, {
+    buildWatchPaths: ["source2", "source3", "source", "source1"],
+  });
 });
 test("BuildPlugin: logs options", (t) => {
   const logs = logPluginOptions(BuildPlugin, {

--- a/packages/shared/src/wrangler.ts
+++ b/packages/shared/src/wrangler.ts
@@ -124,7 +124,7 @@ export interface WranglerConfig extends WranglerEnvironmentConfig {
   build?: {
     command?: string;
     cwd?: string;
-    watch_dir?: string;
+    watch_dir?: string | string[];
     upload?: {
       format?: "service-worker" | "modules";
       dir?: string;


### PR DESCRIPTION
Align Miniflare behaviour with wrangler.toml functionality (see https://developers.cloudflare.com/workers/wrangler/configuration/#custom-builds `watch_dir`).