### PR TITLE
[Miniflare 3] Re-implement D1 gateway using new storage system

### DIFF
--- a/packages/tre/src/plugins/d1/gateway.ts
+++ b/packages/tre/src/plugins/d1/gateway.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { performance } from "perf_hooks";
-import { Database as DatabaseType } from "better-sqlite3";
+import type { Database as DatabaseType } from "better-sqlite3";
 import { z } from "zod";
 import { Response } from "../../http";
 import { HttpError, Log } from "../../shared";

--- a/packages/tre/src/storage2/sql.ts
+++ b/packages/tre/src/storage2/sql.ts
@@ -13,7 +13,7 @@ export type TypedStatement<
 };
 
 export type TypedDatabase = Omit<Database, "prepare"> & {
-  prepare<Params, SingleResult = unknown>(
+  prepare<Params = any[], SingleResult = unknown>(
     source: string
   ): Params extends any[]
     ? TypedStatement<Params, SingleResult>

--- a/packages/tre/src/storage2/sql.ts
+++ b/packages/tre/src/storage2/sql.ts
@@ -4,7 +4,7 @@ import { Database, Statement } from "better-sqlite3";
 // Define types that define the return type at `prepare()` time.
 
 export type TypedStatement<
-  Params extends any[] = any[],
+  Params extends any[] = unknown[],
   SingleResult = unknown
 > = Omit<Statement<Params>, "get" | "all" | "iterate"> & {
   get(...params: Params): SingleResult | undefined;
@@ -13,7 +13,7 @@ export type TypedStatement<
 };
 
 export type TypedDatabase = Omit<Database, "prepare"> & {
-  prepare<Params = any[], SingleResult = unknown>(
+  prepare<Params = unknown[], SingleResult = unknown>(
     source: string
   ): Params extends any[]
     ? TypedStatement<Params, SingleResult>


### PR DESCRIPTION
This PR builds on https://github.com/cloudflare/miniflare/pull/555, and re-implements the D1 gateway using the new storage system. This also brings forward changes #533 and #544 from Miniflare 2, fixing those issues in Miniflare 3 as well. 🙂 

Closes DEVX-591