### PR TITLE
[Miniflare 3] Add stub CLI recommending `wrangler dev`

### DIFF
--- a/packages/tre/bootstrap.js
+++ b/packages/tre/bootstrap.js
@@ -1,0 +1,10 @@
+const { Log } = require(".");
+
+const log = new Log();
+log.error(
+  [
+    "`miniflare@3` no longer includes a CLI. Please use `npx wrangler dev` instead.",
+    "As of `wrangler@3`, this will use Miniflare by default.",
+    "See https://miniflare.dev/get-started/migrating for more details.",
+  ].join("\n")
+);

--- a/packages/tre/package.json
+++ b/packages/tre/package.json
@@ -23,7 +23,8 @@
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "files": [
-    "dist/src"
+    "dist/src",
+    "bootstrap.js"
   ],
   "dependencies": {
     "acorn": "^8.8.0",


### PR DESCRIPTION
Miniflare 3 no longer includes a CLI. We're encouraging people to use Wrangler instead.

Closes DEVX-627