### PR TITLE
[Miniflare 3] Fix source mapping of service workers

### DIFF
--- a/packages/tre/src/index.ts
+++ b/packages/tre/src/index.ts
@@ -43,7 +43,7 @@ import {
 } from "./plugins";
 import {
   JsonErrorSchema,
-  SourceOptions,
+  NameSourceOptions,
   getUserServiceName,
   handlePrettyErrorRequest,
   reviveError,
@@ -517,8 +517,8 @@ export class Miniflare {
     }
   }
 
-  get #workerSrcOpts(): SourceOptions[] {
-    return this.#workerOpts.map<SourceOptions>(({ core }) => core);
+  get #workerSrcOpts(): NameSourceOptions[] {
+    return this.#workerOpts.map<NameSourceOptions>(({ core }) => core);
   }
 
   #handleLoopback = async (

--- a/packages/tre/src/plugins/core/constants.ts
+++ b/packages/tre/src/plugins/core/constants.ts
@@ -1,0 +1,23 @@
+export const CORE_PLUGIN_NAME = "core";
+
+// Service for HTTP socket entrypoint (for checking runtime ready, routing, etc)
+export const SERVICE_ENTRY = `${CORE_PLUGIN_NAME}:entry`;
+// Service prefix for all regular user workers
+const SERVICE_USER_PREFIX = `${CORE_PLUGIN_NAME}:user`;
+// Service prefix for `workerd`'s builtin services (network, external, disk)
+const SERVICE_BUILTIN_PREFIX = `${CORE_PLUGIN_NAME}:builtin`;
+// Service prefix for custom fetch functions defined in `serviceBindings` option
+const SERVICE_CUSTOM_PREFIX = `${CORE_PLUGIN_NAME}:custom`;
+
+export function getUserServiceName(workerName = "") {
+  return `${SERVICE_USER_PREFIX}:${workerName}`;
+}
+export function getBuiltinServiceName(
+  workerIndex: number,
+  bindingName: string
+) {
+  return `${SERVICE_BUILTIN_PREFIX}:${workerIndex}:${bindingName}`;
+}
+export function getCustomServiceName(workerIndex: number, bindingName: string) {
+  return `${SERVICE_CUSTOM_PREFIX}:${workerIndex}:${bindingName}`;
+}

--- a/packages/tre/src/plugins/core/index.ts
+++ b/packages/tre/src/plugins/core/index.ts
@@ -30,6 +30,12 @@ import {
   parseRoutes,
 } from "../shared";
 import {
+  SERVICE_ENTRY,
+  getBuiltinServiceName,
+  getCustomServiceName,
+  getUserServiceName,
+} from "./constants";
+import {
   ModuleLocator,
   SourceOptions,
   SourceOptionsSchema,
@@ -79,25 +85,6 @@ export const CoreSharedOptionsSchema = z.object({
 });
 
 export const CORE_PLUGIN_NAME = "core";
-
-// Service for HTTP socket entrypoint (for checking runtime ready, routing, etc)
-export const SERVICE_ENTRY = `${CORE_PLUGIN_NAME}:entry`;
-// Service prefix for all regular user workers
-const SERVICE_USER_PREFIX = `${CORE_PLUGIN_NAME}:user`;
-// Service prefix for `workerd`'s builtin services (network, external, disk)
-const SERVICE_BUILTIN_PREFIX = `${CORE_PLUGIN_NAME}:builtin`;
-// Service prefix for custom fetch functions defined in `serviceBindings` option
-const SERVICE_CUSTOM_PREFIX = `${CORE_PLUGIN_NAME}:custom`;
-
-export function getUserServiceName(workerName = "") {
-  return `${SERVICE_USER_PREFIX}:${workerName}`;
-}
-function getBuiltinServiceName(workerIndex: number, bindingName: string) {
-  return `${SERVICE_BUILTIN_PREFIX}:${workerIndex}:${bindingName}`;
-}
-function getCustomServiceName(workerIndex: number, bindingName: string) {
-  return `${SERVICE_CUSTOM_PREFIX}:${workerIndex}:${bindingName}`;
-}
 
 const LIVE_RELOAD_SCRIPT_TEMPLATE = (
   port: number
@@ -432,5 +419,6 @@ function getWorkerScript(
 }
 
 export * from "./errors";
+export * from "./constants";
 export * from "./modules";
 export * from "./services";

--- a/packages/tre/test/fixtures/source-maps/modules.ts
+++ b/packages/tre/test/fixtures/source-maps/modules.ts
@@ -1,0 +1,11 @@
+import { reduceError } from "./reduce";
+
+export default <ExportedHandler<{ MESSAGE: string }>>{
+  fetch(request, env) {
+    const error = new Error(env.MESSAGE);
+    return Response.json(reduceError(error), {
+      status: 500,
+      headers: { "MF-Experimental-Error-Stack": "true" },
+    });
+  },
+};

--- a/packages/tre/test/fixtures/source-maps/reduce.ts
+++ b/packages/tre/test/fixtures/source-maps/reduce.ts
@@ -1,0 +1,7 @@
+export function reduceError(e: any) {
+  return {
+    name: e?.name,
+    message: e?.message ?? String(e),
+    stack: e?.stack,
+  };
+}

--- a/packages/tre/test/fixtures/source-maps/service-worker.ts
+++ b/packages/tre/test/fixtures/source-maps/service-worker.ts
@@ -1,0 +1,13 @@
+import { reduceError } from "./reduce";
+
+declare const MESSAGE: string;
+
+addEventListener("fetch", (event) => {
+  const error = new Error(MESSAGE);
+  event.respondWith(
+    Response.json(reduceError(error), {
+      status: 500,
+      headers: { "MF-Experimental-Error-Stack": "true" },
+    })
+  );
+});

--- a/packages/tre/test/fixtures/tsconfig.json
+++ b/packages/tre/test/fixtures/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
+    "lib": ["esnext"],
+    "strict": true,
+    "moduleResolution": "node16",
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types/experimental"]
+  },
+  "include": [
+    "**/*"
+  ]
+}

--- a/packages/tre/test/plugins/core/errors/index.spec.ts
+++ b/packages/tre/test/plugins/core/errors/index.spec.ts
@@ -1,0 +1,121 @@
+import fs from "fs/promises";
+import path from "path";
+import { Miniflare } from "@miniflare/tre";
+import test from "ava";
+import esbuild from "esbuild";
+import { useTmp } from "../../../test-shared";
+
+const FIXTURES_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "test",
+  "fixtures",
+  "source-maps"
+);
+const SERVICE_WORKER_ENTRY_PATH = path.join(FIXTURES_PATH, "service-worker.ts");
+const MODULES_ENTRY_PATH = path.join(FIXTURES_PATH, "modules.ts");
+
+test("source maps workers", async (t) => {
+  // Build fixtures
+  const tmp = await useTmp(t);
+  await esbuild.build({
+    entryPoints: [SERVICE_WORKER_ENTRY_PATH, MODULES_ENTRY_PATH],
+    format: "esm",
+    bundle: true,
+    sourcemap: true,
+    outdir: tmp,
+  });
+  const serviceWorkerPath = path.join(tmp, "service-worker.js");
+  const modulesPath = path.join(tmp, "modules.js");
+  const serviceWorkerContent = await fs.readFile(serviceWorkerPath, "utf8");
+  const modulesContent = await fs.readFile(modulesPath, "utf8");
+
+  // Check service-workers source mapped
+  const mf = new Miniflare({
+    workers: [
+      {
+        bindings: { MESSAGE: "unnamed" },
+        scriptPath: serviceWorkerPath,
+      },
+      {
+        name: "a",
+        routes: ["*/a"],
+        bindings: { MESSAGE: "a" },
+        script: serviceWorkerContent,
+        scriptPath: serviceWorkerPath,
+      },
+    ],
+  });
+  let error = await t.throwsAsync(mf.dispatchFetch("http://localhost"), {
+    message: "unnamed",
+  });
+  t.regex(String(error?.stack), /service-worker\.ts:6:17/);
+  error = await t.throwsAsync(mf.dispatchFetch("http://localhost/a"), {
+    message: "a",
+  });
+  t.regex(String(error?.stack), /service-worker\.ts:6:17/);
+
+  // Check modules workers source mapped
+  await mf.setOptions({
+    workers: [
+      {
+        modules: true,
+        scriptPath: modulesPath,
+        bindings: { MESSAGE: "unnamed" },
+      },
+      {
+        name: "a",
+        routes: ["*/a"],
+        bindings: { MESSAGE: "a" },
+        modules: true,
+        script: modulesContent,
+        scriptPath: modulesPath,
+      },
+      {
+        name: "b",
+        routes: ["*/b"],
+        bindings: { MESSAGE: "b" },
+        modules: [{ type: "ESModule", path: modulesPath }],
+      },
+      {
+        name: "c",
+        routes: ["*/c"],
+        bindings: { MESSAGE: "c" },
+        modules: [
+          { type: "ESModule", path: modulesPath, contents: modulesContent },
+        ],
+      },
+      {
+        name: "d",
+        routes: ["*/d"],
+        bindings: { MESSAGE: "d" },
+        modulesRoot: tmp,
+        modules: [{ type: "ESModule", path: modulesPath }],
+      },
+    ],
+  });
+  error = await t.throwsAsync(mf.dispatchFetch("http://localhost"), {
+    message: "unnamed",
+  });
+  t.regex(String(error?.stack), /modules\.ts:5:19/);
+  error = await t.throwsAsync(mf.dispatchFetch("http://localhost/a"), {
+    message: "a",
+  });
+  t.regex(String(error?.stack), /modules\.ts:5:19/);
+  error = await t.throwsAsync(mf.dispatchFetch("http://localhost/b"), {
+    message: "b",
+  });
+  t.regex(String(error?.stack), /modules\.ts:5:19/);
+  error = await t.throwsAsync(mf.dispatchFetch("http://localhost/c"), {
+    message: "c",
+  });
+  t.regex(String(error?.stack), /modules\.ts:5:19/);
+  error = await t.throwsAsync(mf.dispatchFetch("http://localhost/d"), {
+    message: "d",
+  });
+  t.regex(String(error?.stack), /modules\.ts:5:19/);
+});


### PR DESCRIPTION
cloudflare/workerd#190 changed the script name for service workers to their service name. This change updates Miniflare's heuristics for locating source maps to work with this. It also adds some tests to ensure source mapping is working correctly for the different ways of specifying a script.

_(to be merged after #566)_