### PR TITLE
[Miniflare 3] Explicitly pass `process.env` when spawning `workerd`

### DIFF
--- a/packages/tre/src/runtime/index.ts
+++ b/packages/tre/src/runtime/index.ts
@@ -76,6 +76,7 @@ export class Runtime {
     // 2. Start new process
     const runtimeProcess = childProcess.spawn(this.#command, this.#args, {
       stdio: "pipe",
+      env: process.env,
     });
     this.#process = runtimeProcess;
     this.#processExitPromise = waitForExit(runtimeProcess);


### PR DESCRIPTION
Wrangler changes the current directory in some of its tests. `workerd` will warn when the `PWD` environment doesn't match the actual current directory, which is the case here. We can fix this by modifying `process.env.PWD` in tests, but then we need to explicitly pass the new environment.