### PR TITLE
[Miniflare 3] Fix nested module names on Windows

### DIFF
--- a/packages/miniflare/src/plugins/core/modules.ts
+++ b/packages/miniflare/src/plugins/core/modules.ts
@@ -309,7 +309,8 @@ export function convertModuleDefinition(
   def: ModuleDefinition
 ): Worker_Module {
   // The runtime requires module identifiers to be relative paths
-  const name = path.relative(modulesRoot, def.path);
+  let name = path.relative(modulesRoot, def.path);
+  if (path.sep === "\\") name = name.replaceAll("\\", "/");
   const contents = def.contents ?? readFileSync(def.path);
   switch (def.type) {
     case "ESModule":

--- a/packages/miniflare/test/fixtures/source-maps/nested/dep.ts
+++ b/packages/miniflare/test/fixtures/source-maps/nested/dep.ts
@@ -1,0 +1,9 @@
+import { reduceError } from "../reduce";
+
+export function createErrorResponse() {
+  const error = new TypeError("Dependency error");
+  return Response.json(reduceError(error), {
+    status: 500,
+    headers: { "MF-Experimental-Error-Stack": "true" },
+  });
+}

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -270,3 +270,27 @@ test("Miniflare: `node:` and `cloudflare:` modules", async (t) => {
   const res = await mf.dispatchFetch("http://localhost");
   t.is(await res.text(), "dGVzdA==");
 });
+
+test("Miniflare: modules in sub-directories", async (t) => {
+  const mf = new Miniflare({
+    modules: [
+      {
+        type: "ESModule",
+        path: "index.js",
+        contents: `import { b } from "./sub1/index.js"; export default { fetch() { return new Response(String(b + 3)); } }`,
+      },
+      {
+        type: "ESModule",
+        path: "sub1/index.js",
+        contents: `import { c } from "./sub2/index.js"; export const b = c + 20;`,
+      },
+      {
+        type: "ESModule",
+        path: "sub1/sub2/index.js",
+        contents: `export const c = 100;`,
+      },
+    ],
+  });
+  const res = await mf.dispatchFetch("http://localhost");
+  t.is(await res.text(), "123");
+});


### PR DESCRIPTION
Miniflare extracts a relative module "name" from module paths. On Windows, this process lead to names with `\`s in them. This meant imports had to look like `import { ... } from "dir\\thing.js"` which isn't right. This change normalises all import names to contain forward slashes instead. Source mapping code is unaffected, as Node will automatically normalise `/` to `\`s on Windows.