### PR TITLE
Initial Miniflare v3 docs

### DIFF
--- a/docs/src/content/get-started/migrating.md
+++ b/docs/src/content/get-started/migrating.md
@@ -4,138 +4,173 @@ order: 3
 
 # ⬆️ Migrating from Version 2
 
-See https://blog.cloudflare.com/miniflare-and-workerd/ for the Miniflare v3 announcement.
+Refer to
+[the Miniflare and workerd blog post](https://blog.cloudflare.com/miniflare-and-workerd/)
+for the Miniflare v3 announcement.
 
-## Missing features
+## Missing Features
 
-Several features from Miniflare v2 are not supported in Miniflare v3's initial release. However, they are on the roadmap, and will be added soon:
-* Step-through debugging
-* Automatically triggering scheduled events via CRON schedules, or manually triggering them via `/.mf/scheduled` or `/cdn-cgi/mf/scheduled` (manually triggering events is supported via the `--test-scheduled` Wrangler flag and visiting `/__scheduled`)
-* Starting an HTTPS server
+Several features from Miniflare v2 are not supported in Miniflare v3's initial
+release. However, they are on the roadmap, and will be added soon:
 
-## API Changes
-
-We’ve tried to keep Miniflare v3’s API close to Miniflare v2 where possible, but many options/methods have been removed or changed with the switch to the open-source `workerd` runtime.
-
-### Changed methods
-
-#### `setOptions()`
-Calling `setOptions()` now requires a full-config, not a partial patch
-
-### Changed options
-
-#### `bindings`
-Values passed to the `bindings` option must now be JSON-serialisable, consider using the `serviceBindings` option if you need to bind custom functions
-
-
-### Removed methods
-
-These methods may be added back in future releases:
-- `startScheduled()` and `dispatchScheduled()`
-- `Response#waitUntil()`
-
-#### `reload()`
-
-Call `setOptions()` with the original config instead
-
-#### Methods which inspect Worker state
-- `getGlobalScope()`
-- `getBindings()`
-- `getModuleExports()`
-- `getKVNamespace()`
-- `getR2Bucket()`
-- `getCaches()`
-- `getDurableObjectNamespace()`
-
-Since Miniflare now uses [`workerd`](https://github.com/cloudflare/workerd), which runs in a different process, these methods can no longer be supported.
-#### `getMount()`
-Miniflare v3 doesn’t have the concept of parent/child Workers. Instead all Workers are at the same level.
-
-#### `createServer()` and `startServer()`
-This method is redundant in v3—Miniflare v3 always starts an HTTP server
-startServer()
-#### `startScheduled()` and `dispatchScheduled()`
-
-[`workerd`](https://github.com/cloudflare/workerd) doesn’t support triggering scheduled events yet, but will in an upcoming release.
-
-#### `dispatchQueue()`
-Use the `queue()` method on service bindings/queue producers
-
-#### `Response#waitUntil()`
-[`workerd`](https://github.com/cloudflare/workerd) doesn’t support waiting for all `waitUntil()`ed promises yet
-
-### Removed options
-These options may be added back in future releases:
-- HTTPS related parameters
-- `crons`
-
-#### `wranglerConfigPath` and `wranglerConfigEnv`
-Miniflare no longer handles Wrangler’s configuration. To programmatically start up a Worker with Wrangler configuration, use the [`unstable_dev()`](https://developers.cloudflare.com/workers/wrangler/api/#unstable_dev) API.
-
-#### `packagePath`
-Specify your script using the `scriptPath` option instead.
-
-#### `upstream`
-Always pass the full upstream URL when calling `dispatchFetch()`.
-
-#### `watch`
-Miniflare’s API is primarily intended for testing use cases, where file watching isn’t too important. This option was here to enable Miniflare’s CLI which has now been removed. If you need to watch files, consider using a separate file watcher and calling `setOptions()` with your original config on change.
-
-#### `logUnhandledRejections`
-Unhandled rejections can be handled in Workers with [`addEventListener("unhandledrejection")`](https://community.cloudflare.com/t/2021-10-21-workers-runtime-release-notes/318571)
-
-
-#### `globalAsyncIO`, `globalTimers`, `globalRandom`, and `inaccurateCpu`
-These options are not supported by [`workerd`](https://github.com/cloudflare/workerd), the open source Cloudflare Workers runtime, and so can't be supported in Miniflare.
-
-#### `actualTime`
-
-This is now the default in Miniflare v3.
-
-#### HTTPS related parameters
-- `https`
-- `httpsKey`
-- `httpsKeyPath`
-- `httpsCert`
-- `httpsCertPath`
-- `httpsPfx`
-- `httpsPfxPath`
-- `httpsPassphrase`
-
-These are not currently supported, but may be added back in a future release of Miniflare.
-
-#### `metaProvider`
-The `cf` object and `X-Forwarded-Proto`/`X-Real-IP` headers can be specified when calling `dispatchFetch()` instead
-
-#### `cFetch`
-Renamed to `cf`
-
-#### `crons`
-This is not currently supported by [`workerd`](https://github.com/cloudflare/workerd), the open source Cloudflare Workers runtime, but will be in a future release.
-
-#### `durableObjectAlarms`
-
-Always enabled in Miniflare v3
-
-#### `globals`
-This is not supported by [`workerd`](https://github.com/cloudflare/workerd), the open source Cloudflare Workers runtime.
-
-#### `mounts`
-Miniflare v3 doesn’t have the concept of parent/child Workers. Instead all Workers are at the same level. The same functionality can be achieved using the `workers` option. Note some options are always top-level, and some options are per-Worker.
-
-
+- Step-through debugging
+- Automatically triggering scheduled events via CRON schedules, or manually
+  triggering them via `/.mf/scheduled` or `/cdn-cgi/mf/scheduled` (manually
+  triggering events is supported via the `--test-scheduled` Wrangler flag and
+  visiting `/__scheduled`)
+- Starting an HTTPS server
 
 ## CLI Changes
 
-Miniflare v3 no longer includes a standalone CLI. To get the same functionality you'll need to switch over to using [Wrangler](https://developers.cloudflare.com/workers/wrangler/). Wrangler v3 uses Miniflare v3 by default—all you need to do is run:
+Miniflare v3 no longer includes a standalone CLI. To get the same functionality
+you'll need to switch over to using
+[Wrangler](https://developers.cloudflare.com/workers/wrangler/). Wrangler v3
+uses Miniflare v3 by default—all you need to do is run:
 
 ```sh
 $ npx wrangler@3 dev
 ```
 
-If there are features from the Miniflare CLI you'd like to see in Wrangler, please open an issue on [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
+If there are features from the Miniflare CLI you'd like to see in Wrangler,
+please open an issue on
+[GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
 
+## API Changes
 
+We have tried to keep Miniflare v3’s API close to Miniflare v2 where possible,
+but many options and methods have been removed or changed with the switch to the
+open-source `workerd` runtime. See the
+[GitHub `README` for the new API docs](https://github.com/cloudflare/miniflare/blob/tre/packages/miniflare/README.md).
+
+### Changed Options
+
+#### `bindings`
+
+Values passed to the `bindings` option must now be JSON-serialisable. Consider
+using the `serviceBindings` option if you need to bind custom functions.
+
+### Removed Options
+
+#### `wranglerConfigPath` and `wranglerConfigEnv`
+
+Miniflare no longer handles Wrangler’s configuration. To programmatically start
+up a Worker with Wrangler configuration, use the
+[`unstable_dev()`](https://developers.cloudflare.com/workers/wrangler/api/#unstable_dev)
+API.
+
+#### `packagePath`
+
+Specify your script using the `scriptPath` option instead.
+
+#### `upstream`
+
+Always pass the full upstream URL when calling `dispatchFetch()`.
+
+#### `watch`
+
+Miniflare’s API is primarily intended for testing use cases, where file watching
+isn’t too important. This option was here to enable Miniflare’s CLI which has
+now been removed. If you need to watch files, consider using a separate file
+watcher and calling `setOptions()` with your original config on change.
+
+#### `logUnhandledRejections`
+
+Unhandled rejections can be handled in Workers with
+[`addEventListener("unhandledrejection")`](https://community.cloudflare.com/t/2021-10-21-workers-runtime-release-notes/318571)
+
+#### `globalAsyncIO`, `globalTimers`, `globalRandom`, and `inaccurateCpu`
+
+These options are not supported by
+[`workerd`](https://github.com/cloudflare/workerd), the open source Cloudflare
+Workers runtime, and so can't be supported in Miniflare.
+
+#### `actualTime`
+
+Miniflare will always return the current time.
+
+#### `https`, `httpsKey`, `httpsKeyPath`, `httpsCert`, `httpsCertPath`, `httpsPfx`, `httpsPfxPath`, and `httpsPassphrase`
+
+Miniflare does not currently support starting HTTPS servers. These options may
+be added back in a future release.
+
+#### `metaProvider`
+
+The `cf` object and `X-Forwarded-Proto`/`X-Real-IP` headers can be specified
+when calling `dispatchFetch()` instead
+
+#### `cFetch`
+
+Renamed to `cf`.
+
+#### `crons`
+
+This is not currently supported by
+[`workerd`](https://github.com/cloudflare/workerd), the open source Cloudflare
+Workers runtime, but will be in a future release.
+
+#### `durableObjectAlarms`
+
+Durable Object alarms are always enabled in Miniflare v3.
+
+#### `globals`
+
+`globals` is not supported by
+[`workerd`](https://github.com/cloudflare/workerd), the open source Cloudflare
+Workers runtime.
+
+#### `mounts`
+
+Miniflare v3 does not have the concept of parent/child Workers. Instead, all
+Workers are at the same level. The same functionality can be achieved using the
+`workers` option. Note some options are always top-level, and some options are
+per-Worker.
+
+### Changed Methods
+
+#### `setOptions()`
+
+Calling `setOptions()` now requires a full configuration object, not a partial
+patch.
+
+### Removed Methods
+
+#### `reload()`
+
+Call `setOptions()` with the original configuration object instead.
+
+#### `getMount()`
+
+Miniflare v3 does not have the concept of parent/child Workers. Instead, all
+Workers are at the same level. Refer to the
+[`3.0.0-next.1` release notes](https://github.com/cloudflare/miniflare/releases/tag/v3.0.0-next.1)
+for an example multi-Worker configuration.
+
+#### `createServer()` and `startServer()`
+
+These methods are now redundant. Miniflare v3 always starts an HTTP server.
+
+#### `startScheduled()` and `dispatchScheduled()`
+
+[`workerd`](https://github.com/cloudflare/workerd) does not support triggering
+scheduled events yet, but will in an upcoming release.
+
+#### `dispatchQueue()`
+
+Use the `queue()` method on
+[service bindings](https://developers.cloudflare.com/workers/platform/bindings/about-service-bindings/)
+or
+[queue producer bindings](https://developers.cloudflare.com/queues/platform/configuration/#producer).
+
+#### `Response#waitUntil()`
+
+[`workerd`](https://github.com/cloudflare/workerd) does not support waiting for
+all `waitUntil()`ed promises yet.
+
+#### `getGlobalScope()`, `getBindings()`, `getModuleExports()`, `getKVNamespace()`, `getR2Bucket()`, `getCaches()`, and `getDurableObjectNamespace()`
+
+These methods returned objects from inside the Workers sandbox. Since Miniflare
+now uses [`workerd`](https://github.com/cloudflare/workerd), which runs in a
+different process, these methods can no longer be supported.
 
 # ⬆️ Migrating from Version 1
 

--- a/docs/src/content/get-started/migrating.md
+++ b/docs/src/content/get-started/migrating.md
@@ -2,6 +2,141 @@
 order: 3
 ---
 
+# ⬆️ Migrating from Version 2
+
+See https://blog.cloudflare.com/miniflare-and-workerd/ for the Miniflare v3 announcement.
+
+## Missing features
+
+Several features from Miniflare v2 are not supported in Miniflare v3's initial release. However, they are on the roadmap, and will be added soon:
+* Step-through debugging
+* Automatically triggering scheduled events via CRON schedules, or manually triggering them via `/.mf/scheduled` or `/cdn-cgi/mf/scheduled` (manually triggering events is supported via the `--test-scheduled` Wrangler flag and visiting `/__scheduled`)
+* Starting an HTTPS server
+
+## API Changes
+
+We’ve tried to keep Miniflare v3’s API close to Miniflare v2 where possible, but many options/methods have been removed or changed with the switch to the open-source `workerd` runtime.
+
+### Changed methods
+
+#### `setOptions()`
+Calling `setOptions()` now requires a full-config, not a partial patch
+
+### Changed options
+
+#### `bindings`
+Values passed to the `bindings` option must now be JSON-serialisable, consider using the `serviceBindings` option if you need to bind custom functions
+
+
+### Removed methods
+
+These methods may be added back in future releases:
+- `startScheduled()` and `dispatchScheduled()`
+- `Response#waitUntil()`
+
+#### `reload()`
+
+Call `setOptions()` with the original config instead
+
+#### Methods which inspect Worker state
+- `getGlobalScope()`
+- `getBindings()`
+- `getModuleExports()`
+- `getKVNamespace()`
+- `getR2Bucket()`
+- `getCaches()`
+- `getDurableObjectNamespace()`
+
+Since Miniflare now uses [`workerd`](https://github.com/cloudflare/workerd), which runs in a different process, these methods can no longer be supported.
+#### `getMount()`
+Miniflare v3 doesn’t have the concept of parent/child Workers. Instead all Workers are at the same level.
+
+#### `createServer()` and `startServer()`
+This method is redundant in v3—Miniflare v3 always starts an HTTP server
+startServer()
+#### `startScheduled()` and `dispatchScheduled()`
+
+[`workerd`](https://github.com/cloudflare/workerd) doesn’t support triggering scheduled events yet, but will in an upcoming release.
+
+#### `dispatchQueue()`
+Use the `queue()` method on service bindings/queue producers
+
+#### `Response#waitUntil()`
+[`workerd`](https://github.com/cloudflare/workerd) doesn’t support waiting for all `waitUntil()`ed promises yet
+
+### Removed options
+These options may be added back in future releases:
+- HTTPS related parameters
+- `crons`
+
+#### `wranglerConfigPath` and `wranglerConfigEnv`
+Miniflare no longer handles Wrangler’s configuration. To programmatically start up a Worker with Wrangler configuration, use the [`unstable_dev()`](https://developers.cloudflare.com/workers/wrangler/api/#unstable_dev) API.
+
+#### `packagePath`
+Specify your script using the `scriptPath` option instead.
+
+#### `upstream`
+Always pass the full upstream URL when calling `dispatchFetch()`.
+
+#### `watch`
+Miniflare’s API is primarily intended for testing use cases, where file watching isn’t too important. This option was here to enable Miniflare’s CLI which has now been removed. If you need to watch files, consider using a separate file watcher and calling `setOptions()` with your original config on change.
+
+#### `logUnhandledRejections`
+Unhandled rejections can be handled in Workers with [`addEventListener("unhandledrejection")`](https://community.cloudflare.com/t/2021-10-21-workers-runtime-release-notes/318571)
+
+
+#### `globalAsyncIO`, `globalTimers`, `globalRandom`, and `inaccurateCpu`
+These options are not supported by [`workerd`](https://github.com/cloudflare/workerd), the open source Cloudflare Workers runtime, and so can't be supported in Miniflare.
+
+#### `actualTime`
+
+This is now the default in Miniflare v3.
+
+#### HTTPS related parameters
+- `https`
+- `httpsKey`
+- `httpsKeyPath`
+- `httpsCert`
+- `httpsCertPath`
+- `httpsPfx`
+- `httpsPfxPath`
+- `httpsPassphrase`
+
+These are not currently supported, but may be added back in a future release of Miniflare.
+
+#### `metaProvider`
+The `cf` object and `X-Forwarded-Proto`/`X-Real-IP` headers can be specified when calling `dispatchFetch()` instead
+
+#### `cFetch`
+Renamed to `cf`
+
+#### `crons`
+This is not currently supported by [`workerd`](https://github.com/cloudflare/workerd), the open source Cloudflare Workers runtime, but will be in a future release.
+
+#### `durableObjectAlarms`
+
+Always enabled in Miniflare v3
+
+#### `globals`
+This is not supported by [`workerd`](https://github.com/cloudflare/workerd), the open source Cloudflare Workers runtime.
+
+#### `mounts`
+Miniflare v3 doesn’t have the concept of parent/child Workers. Instead all Workers are at the same level. The same functionality can be achieved using the `workers` option. Note some options are always top-level, and some options are per-Worker.
+
+
+
+## CLI Changes
+
+Miniflare v3 no longer includes a standalone CLI. To get the same functionality you'll need to switch over to using [Wrangler](https://developers.cloudflare.com/workers/wrangler/). Wrangler v3 uses Miniflare v3 by default—all you need to do is run:
+
+```sh
+$ npx wrangler@3 dev
+```
+
+If there are features from the Miniflare CLI you'd like to see in Wrangler, please open an issue on [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
+
+
+
 # ⬆️ Migrating from Version 1
 
 Miniflare 2 includes [breaking changes](/get-started/changelog#_2-0-0). This

--- a/docs/src/content/get-started/migrating.md
+++ b/docs/src/content/get-started/migrating.md
@@ -22,16 +22,16 @@ release. However, they are on the roadmap, and will be added soon:
 
 ## CLI Changes
 
-Miniflare v3 no longer includes a standalone CLI. To get the same functionality
-you'll need to switch over to using
+Miniflare v3 no longer includes a standalone CLI. To get the same functionality,
+you will need to switch over to using
 [Wrangler](https://developers.cloudflare.com/workers/wrangler/). Wrangler v3
-uses Miniflare v3 by default—all you need to do is run:
+uses Miniflare v3 by default. To use Wrangler, run:
 
 ```sh
 $ npx wrangler@3 dev
 ```
 
-If there are features from the Miniflare CLI you'd like to see in Wrangler,
+If there are features from the Miniflare CLI you would like to see in Wrangler,
 please open an issue on
 [GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose).
 


### PR DESCRIPTION
These aren't done, but the Migrations page is updated to cover the deprecations from v2 to v3