### PR TITLE
[Miniflare 3] Trust CA root certificates on Windows and `NODE_EXTRA_CA_CERTS`

### DIFF
--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -45,6 +45,25 @@ import {
 } from "./modules";
 import { ServiceDesignatorSchema } from "./services";
 
+// `workerd`'s `trustBrowserCas` should probably be named `trustSystemCas`.
+// Rather than using a bundled CA store like Node, it uses
+// `SSL_CTX_set_default_verify_paths()` to use the system CA store:
+// https://github.com/capnproto/capnproto/blob/6e26d260d1d91e0465ca12bbb5230a1dfa28f00d/c%2B%2B/src/kj/compat/tls.c%2B%2B#L745
+// Unfortunately, this doesn't work on Windows. Luckily, Node exposes its own
+// bundled CA store's certificates, so we just use those.
+const trustedCertificates =
+  process.platform === "win32" ? Array.from(tls.rootCertificates) : [];
+if (process.env.NODE_EXTRA_CA_CERTS !== undefined) {
+  // Try load extra CA certs if defined, ignoring errors. Node will log a
+  // warning if it fails to load this anyway. Note, this we only load this once
+  // at process startup to match Node's behaviour:
+  // https://nodejs.org/api/cli.html#node_extra_ca_certsfile
+  try {
+    const extra = readFileSync(process.env.NODE_EXTRA_CA_CERTS, "utf8");
+    trustedCertificates.push(extra);
+  } catch {}
+}
+
 const encoder = new TextEncoder();
 const numericCompare = new Intl.Collator(undefined, { numeric: true }).compare;
 
@@ -368,16 +387,10 @@ export function getGlobalServices({
         // https://github.com/cloudflare/miniflare/issues/412
         allow: ["public", "private"],
         deny: [],
-        // `trustBrowserCas` should probably be named `trustSystemCas`.
-        // Rather than using a bundled CA store like Node, it uses
-        // `SSL_CTX_set_default_verify_paths()` to use the system CA store:
-        // https://github.com/capnproto/capnproto/blob/6e26d260d1d91e0465ca12bbb5230a1dfa28f00d/c%2B%2B/src/kj/compat/tls.c%2B%2B#L745
-        // Unfortunately, this doesn't work on Windows. Luckily, Node exposes
-        // its own bundled CA store's certificates, so we just pass those.
-        tlsOptions:
-          process.platform === "win32"
-            ? { trustedCertificates: tls.rootCertificates as string[] }
-            : { trustBrowserCas: true },
+        tlsOptions: {
+          trustBrowserCas: true,
+          trustedCertificates,
+        },
       },
     },
   ];

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -294,3 +294,16 @@ test("Miniflare: modules in sub-directories", async (t) => {
   const res = await mf.dispatchFetch("http://localhost");
   t.is(await res.text(), "123");
 });
+
+test("Miniflare: HTTPS fetches using browser CA certificates", async (t) => {
+  const mf = new Miniflare({
+    modules: true,
+    script: `export default {
+      fetch() {
+        return fetch("https://workers.cloudflare.com/cf.json");
+      }
+    }`,
+  });
+  const res = await mf.dispatchFetch("http://localhost");
+  t.true(res.ok);
+});

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -1,9 +1,6 @@
 declare namespace NodeJS {
   export interface ProcessEnv {
     NODE_ENV?: string;
-    MINIFLARE_EXEC_NAME?: string;
-    MINIFLARE_SUBREQUEST_LIMIT?: string;
-    MINIFLARE_INTERNAL_SUBREQUEST_LIMIT?: string;
-    MINIFLARE_TEST_REDIS_URL?: string;
+    NODE_EXTRA_CA_CERTS?: string;
   }
 }


### PR DESCRIPTION
`workerd`'s `trustBrowserCas` uses `SSL_CTX_set_default_verify_paths()` to enable the system trust store. Unfortunately, this doesn't work on Windows, meaning any HTTPS `fetch()` would fail, with an `unable to get local issuer certificate` error. This PR passes the root certificates from Node's bundled CA store to `workerd` as `trustedCertificates` on Windows.

Wrangler also passes the Cloudflare root certificate using the `NODE_EXTRA_CA_CERTS` environment variable. This PR also loads CA certs from this variable, fixing HTTPS `fetch()`s with WARP enabled. This can also be used for trusting self-signed certificates.

Closes https://github.com/cloudflare/workers-sdk/issues/3264
Closes https://github.com/cloudflare/workers-sdk/issues/3218