### PR TITLE
[Miniflare 3] Make process exits/server stops more aggressive to prevent test hangs

### DIFF
--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -465,9 +465,7 @@ export class Miniflare {
       verbose: this.#sharedOpts.core.verbose,
     };
     this.#runtime = new Runtime(opts);
-    this.#removeRuntimeExitHook = exitHook(
-      () => void this.#runtime?.dispose(/* force */ true)
-    );
+    this.#removeRuntimeExitHook = exitHook(() => void this.#runtime?.dispose());
 
     // Update config and wait for runtime to start
     await this.#assembleAndUpdateConfig(/* initial */ true);
@@ -673,7 +671,10 @@ export class Miniflare {
     hostname?: string
   ): Promise<StoppableServer> {
     return new Promise((resolve) => {
-      const server = stoppable(http.createServer(this.#handleLoopback));
+      const server = stoppable(
+        http.createServer(this.#handleLoopback),
+        /* grace */ 0
+      );
       server.on("upgrade", this.#handleLoopbackUpgrade);
       server.listen(port as any, hostname, () => resolve(server));
     });

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -130,18 +130,14 @@ export class Runtime {
     return waitForPort(SOCKET_ENTRY, controlPipe, options);
   }
 
-  get exitPromise(): Promise<void> | undefined {
-    return this.#processExitPromise;
-  }
-
-  dispose(force = false): Awaitable<void> {
+  dispose(): Awaitable<void> {
     // `kill()` uses `SIGTERM` by default. In `workerd`, this waits for HTTP
     // connections to close before exiting. Notably, Chrome sometimes keeps
     // connections open for about 10s, blocking exit. We'd like `dispose()`/
     // `setOptions()` to immediately terminate the existing process.
-    // Therefore, use `SIGINT` which force closes all connections.
+    // Therefore, use `SIGKILL` which force closes all connections.
     // See https://github.com/cloudflare/workerd/pull/244.
-    this.#process?.kill(force ? "SIGKILL" : "SIGINT");
+    this.#process?.kill("SIGKILL");
     return this.#processExitPromise;
   }
 }

--- a/packages/miniflare/test/test-shared/http.ts
+++ b/packages/miniflare/test/test-shared/http.ts
@@ -2,6 +2,7 @@ import http from "http";
 import { AddressInfo } from "net";
 import { URL } from "url";
 import { ExecutionContext } from "ava";
+import stoppable from "stoppable";
 import NodeWebSocket, { WebSocketServer } from "ws";
 
 export async function useServer(
@@ -10,7 +11,7 @@ export async function useServer(
   webSocketListener?: (socket: NodeWebSocket, req: http.IncomingMessage) => void
 ): Promise<{ http: URL; ws: URL }> {
   return new Promise((resolve) => {
-    const server = http.createServer(listener);
+    const server = stoppable(http.createServer(listener), /* grace */ 0);
     // Only setup web socket server if listener provided
     if (webSocketListener) {
       const wss = new WebSocketServer({ server });
@@ -18,7 +19,11 @@ export async function useServer(
     }
     // 0 binds to random unused port
     server.listen(0, () => {
-      t.teardown(() => server.close());
+      t.teardown(() => {
+        return new Promise((resolve, reject) =>
+          server.stop((err) => (err ? reject(err) : resolve()))
+        );
+      });
       const port = (server.address() as AddressInfo).port;
       resolve({
         http: new URL(`http://localhost:${port}`),


### PR DESCRIPTION
This PR switches to using `SIGKILL` when terminating the runtime, and removes the grace period for connected sockets to close themselves when stopping servers. The aim here is to minimise the chances of hanging tests.