### PR TITLE
Allow `setOptions()` to set runtime port

### DIFF
--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -455,6 +455,17 @@ export class Miniflare {
     // noinspection JSObjectNullOrUndefined
     this.#loopbackPort = address.port;
 
+    await this.#startRuntime();
+
+    // Update config and wait for runtime to start
+    await this.#assembleAndUpdateConfig(/* initial */ true);
+  }
+
+  async #startRuntime() {
+    await this.#runtime?.dispose();
+
+    assert(this.#loopbackPort !== undefined);
+
     // Start runtime
     const port = this.#sharedOpts.core.port ?? 0;
     const opts: RuntimeOptions = {
@@ -466,9 +477,6 @@ export class Miniflare {
     };
     this.#runtime = new Runtime(opts);
     this.#removeRuntimeExitHook = exitHook(() => void this.#runtime?.dispose());
-
-    // Update config and wait for runtime to start
-    await this.#assembleAndUpdateConfig(/* initial */ true);
   }
 
   async #handleLoopbackCustomService(
@@ -847,6 +855,8 @@ export class Miniflare {
     this.#sharedOpts = sharedOpts;
     this.#workerOpts = workerOpts;
     this.#log = this.#sharedOpts.core.log ?? this.#log;
+
+    await this.#startRuntime();
 
     // Send to runtime and wait for updates to process
     await this.#assembleAndUpdateConfig();

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -69,6 +69,7 @@ import {
   Timers,
   defaultTimers,
   formatResponse,
+  maybeApply,
 } from "./shared";
 import { Storage } from "./storage";
 import { CoreHeaders } from "./workers";
@@ -468,7 +469,7 @@ export class Miniflare {
     this.#removeRuntimeExitHook = exitHook(() => void this.#runtime?.dispose());
 
     // Update config and wait for runtime to start
-    await this.#assembleAndUpdateConfig(/* initial */ true);
+    await this.#assembleAndUpdateConfig();
   }
 
   async #handleLoopbackCustomService(
@@ -781,22 +782,15 @@ export class Miniflare {
     return { services: Array.from(services.values()), sockets };
   }
 
-  async #assembleAndUpdateConfig(initial = false) {
+  async #assembleAndUpdateConfig() {
+    const initial = !this.#runtimeEntryURL;
     assert(this.#runtime !== undefined);
     const config = await this.#assembleConfig();
     const configBuffer = serializeConfig(config);
-    const maybePort = await this.#runtime.updateConfig(
-      configBuffer,
-      {
-        signal: this.#disposeController.signal,
-      },
-      !initial && this.#runtimeEntryURL !== undefined
-        ? {
-            entryHost: this.#runtimeEntryURL.host,
-            entryPort: parseInt(this.#runtimeEntryURL.port),
-          }
-        : {}
-    );
+    const maybePort = await this.#runtime.updateConfig(configBuffer, {
+      signal: this.#disposeController.signal,
+      entryPort: maybeApply(parseInt, this.#runtimeEntryURL?.port),
+    });
     if (this.#disposeController.signal.aborted) return;
     if (maybePort === undefined) {
       throw new MiniflareCoreError(

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -70,12 +70,15 @@ export interface RuntimeOptions {
 
 export class Runtime {
   readonly #command: string;
-  readonly #args: string[];
 
   #process?: childProcess.ChildProcess;
   #processExitPromise?: Promise<void>;
 
   constructor(private opts: RuntimeOptions) {
+    this.#command = workerdPath;
+  }
+
+  get #args() {
     const args: string[] = [
       "serve",
       // Required to use binary capnp config
@@ -98,17 +101,23 @@ export class Runtime {
       args.push("--verbose");
     }
 
-    this.#command = workerdPath;
-    this.#args = args;
+    return args;
   }
 
   async updateConfig(
     configBuffer: Buffer,
-    options?: Abortable
+    options?: Abortable,
+    {
+      entryHost = this.opts.entryHost,
+      entryPort = this.opts.entryPort,
+    }: Partial<Pick<RuntimeOptions, "entryHost" | "entryPort">> = {}
   ): Promise<number | undefined> {
     // 1. Stop existing process (if any) and wait for exit
     await this.dispose();
     // TODO: what happens if runtime crashes?
+
+    this.opts.entryHost = entryHost;
+    this.opts.entryPort = entryPort;
 
     // 2. Start new process
     const runtimeProcess = childProcess.spawn(this.#command, this.#args, {

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -112,7 +112,7 @@ export class Runtime {
     await this.dispose();
     // TODO: what happens if runtime crashes?
 
-    if (options?.entryPort) {
+    if (options?.entryPort !== undefined) {
       this.opts.entryPort = options.entryPort;
     }
 

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -106,18 +106,15 @@ export class Runtime {
 
   async updateConfig(
     configBuffer: Buffer,
-    options?: Abortable,
-    {
-      entryHost = this.opts.entryHost,
-      entryPort = this.opts.entryPort,
-    }: Partial<Pick<RuntimeOptions, "entryHost" | "entryPort">> = {}
+    options?: Abortable & Partial<Pick<RuntimeOptions, "entryPort">>
   ): Promise<number | undefined> {
     // 1. Stop existing process (if any) and wait for exit
     await this.dispose();
     // TODO: what happens if runtime crashes?
 
-    this.opts.entryHost = entryHost;
-    this.opts.entryPort = entryPort;
+    if (options?.entryPort) {
+      this.opts.entryPort = options.entryPort;
+    }
 
     // 2. Start new process
     const runtimeProcess = childProcess.spawn(this.#command, this.#args, {

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -55,6 +55,23 @@ test("Miniflare: validates options", async (t) => {
   );
 });
 
+test("Miniflare: keeps port between updates", async (t) => {
+  const opts: MiniflareOptions = {
+    port: 0,
+    script: `addEventListener("fetch", (event) => {
+      event.respondWith(new Response("a"));
+    })`,
+  };
+  const mf = new Miniflare(opts);
+  const initialURL = await mf.ready;
+
+  await mf.setOptions(opts);
+  const updatedURL = await mf.ready;
+
+  t.not(initialURL.port, "0");
+  t.is(initialURL.port, updatedURL.port);
+});
+
 test("Miniflare: routes to multiple workers with fallback", async (t) => {
   const opts: MiniflareOptions = {
     workers: [


### PR DESCRIPTION
No idea if this is even vaguely right, but here's a first stab at fixing #608.