### PR TITLE
[Miniflare 3] Use `localhost` instead of `127.0.0.1` for loopback hostname

### DIFF
--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -668,8 +668,8 @@ export class Miniflare {
   };
 
   #startLoopbackServer(
-    port: string | number,
-    hostname?: string
+    port: number,
+    hostname: string
   ): Promise<StoppableServer> {
     return new Promise((resolve) => {
       const server = stoppable(
@@ -677,7 +677,7 @@ export class Miniflare {
         /* grace */ 0
       );
       server.on("upgrade", this.#handleLoopbackUpgrade);
-      server.listen(port as any, hostname, () => resolve(server));
+      server.listen(port, hostname, () => resolve(server));
     });
   }
 

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -87,7 +87,7 @@ export class Runtime {
       // (e.g. "streams_enable_constructors"), see https://github.com/cloudflare/workerd/pull/21
       "--experimental",
       `--socket-addr=${SOCKET_ENTRY}=${this.opts.entryHost}:${this.opts.entryPort}`,
-      `--external-addr=${SERVICE_LOOPBACK}=127.0.0.1:${this.opts.loopbackPort}`,
+      `--external-addr=${SERVICE_LOOPBACK}=localhost:${this.opts.loopbackPort}`,
       // Configure extra pipe for receiving control messages (e.g. when ready)
       "--control-fd=3",
       // Read config from stdin


### PR DESCRIPTION
Miniflare starts its loopback server on the same host as the `workerd` server, so it's accessible on all the same addresses as the runtime. This allows the loopback server to be the target for the live reload web socket. This means if the `host: "localhost"` option is set, we start a Node `http` server with `localhost` as the hostname. Node will perform a DNS lookup to work out which IP address and interface to listen on, but will only listen on the first entry. In Node 17+, this will be the IPv6 interface. Unfortunately, we previously hardcoded the loopback address as the IPv4 loopback, meaning `workerd` was unable to connect. This change switches to using `localhost`, which `workerd` will resolve to either IPv4 or v6.

Closes cloudflare/workers-sdk#3515