### PR TITLE
[Miniflare 3] Correctly resolve relative source mapped URLs

### DIFF
--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -177,7 +177,7 @@ function getSourceMappedStack(
     const sourceMapFile = maybeGetDiskFile(sourceMapPath);
     if (sourceMapFile === undefined) return null;
 
-    return { map: sourceMapFile.contents };
+    return { map: sourceMapFile.contents, url: sourceMapFile.path };
   }
 
   return getSourceMapper()(retrieveSourceMap, error);

--- a/packages/miniflare/test/plugins/core/errors/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/errors/index.spec.ts
@@ -3,7 +3,7 @@ import path from "path";
 import test from "ava";
 import esbuild from "esbuild";
 import { Miniflare } from "miniflare";
-import { useTmp } from "../../../test-shared";
+import { escapeRegexp, useTmp } from "../../../test-shared";
 
 const FIXTURES_PATH = path.resolve(
   __dirname,
@@ -59,11 +59,14 @@ test("source maps workers", async (t) => {
   let error = await t.throwsAsync(mf.dispatchFetch("http://localhost"), {
     message: "unnamed",
   });
-  t.regex(String(error?.stack), /service-worker\.ts:6:17/);
+  const serviceWorkerEntryRegexp = escapeRegexp(
+    `${SERVICE_WORKER_ENTRY_PATH}:6:17`
+  );
+  t.regex(String(error?.stack), serviceWorkerEntryRegexp);
   error = await t.throwsAsync(mf.dispatchFetch("http://localhost/a"), {
     message: "a",
   });
-  t.regex(String(error?.stack), /service-worker\.ts:6:17/);
+  t.regex(String(error?.stack), serviceWorkerEntryRegexp);
 
   // Check modules workers source mapped
   await mf.setOptions({
@@ -120,26 +123,28 @@ test("source maps workers", async (t) => {
   error = await t.throwsAsync(mf.dispatchFetch("http://localhost"), {
     message: "unnamed",
   });
-  t.regex(String(error?.stack), /modules\.ts:5:19/);
+  const modulesEntryRegexp = escapeRegexp(`${MODULES_ENTRY_PATH}:5:19`);
+  t.regex(String(error?.stack), modulesEntryRegexp);
   error = await t.throwsAsync(mf.dispatchFetch("http://localhost/a"), {
     message: "a",
   });
-  t.regex(String(error?.stack), /modules\.ts:5:19/);
+  t.regex(String(error?.stack), modulesEntryRegexp);
   error = await t.throwsAsync(mf.dispatchFetch("http://localhost/b"), {
     message: "b",
   });
-  t.regex(String(error?.stack), /modules\.ts:5:19/);
+  t.regex(String(error?.stack), modulesEntryRegexp);
   error = await t.throwsAsync(mf.dispatchFetch("http://localhost/c"), {
     message: "c",
   });
-  t.regex(String(error?.stack), /modules\.ts:5:19/);
+  t.regex(String(error?.stack), modulesEntryRegexp);
   error = await t.throwsAsync(mf.dispatchFetch("http://localhost/d"), {
     message: "d",
   });
-  t.regex(String(error?.stack), /modules\.ts:5:19/);
+  t.regex(String(error?.stack), modulesEntryRegexp);
   error = await t.throwsAsync(mf.dispatchFetch("http://localhost/e"), {
     instanceOf: TypeError,
     message: "Dependency error",
   });
-  t.regex(String(error?.stack), /nested\/dep\.ts:4:17/);
+  const nestedRegexp = escapeRegexp(`${DEP_ENTRY_PATH}:4:17`);
+  t.regex(String(error?.stack), nestedRegexp);
 });

--- a/packages/miniflare/test/plugins/r2/index.spec.ts
+++ b/packages/miniflare/test/plugins/r2/index.spec.ts
@@ -44,8 +44,12 @@ import {
   viewToBuffer,
 } from "miniflare";
 import { z } from "zod";
-import { MiniflareTestContext, miniflareTest, useTmp } from "../../test-shared";
-import { isWithin } from "../../test-shared/asserts";
+import {
+  MiniflareTestContext,
+  isWithin,
+  miniflareTest,
+  useTmp,
+} from "../../test-shared";
 
 const WITHIN_EPSILON = 10_000;
 

--- a/packages/miniflare/test/test-shared/asserts.ts
+++ b/packages/miniflare/test/test-shared/asserts.ts
@@ -16,3 +16,8 @@ export function isWithin(
     `${actual} is not within ${epsilon} of ${expected}, difference is ${difference}`
   );
 }
+
+export function escapeRegexp(value: string): RegExp {
+  // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping
+  return new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+}

--- a/packages/miniflare/test/test-shared/index.ts
+++ b/packages/miniflare/test/test-shared/index.ts
@@ -1,3 +1,4 @@
+export * from "./asserts";
 export * from "./http";
 export * from "./log";
 export * from "./miniflare";


### PR DESCRIPTION
Previously, if source maps included relative paths, those paths would not be resolved relative to the source map's own file path before inclusion into stack traces. This meant stack traces included relative paths that couldn't be resolved for click-to-definition by IDEs.

This change includes the URL of the source map upon retrieval, allowing `source-map-support` to include absolute source URLs in stack traces.