### PR TITLE
[Miniflare 3] Mark WebSocket `fetch()` close test as flaky

### DIFF
--- a/packages/miniflare/test/http/fetch.spec.ts
+++ b/packages/miniflare/test/http/fetch.spec.ts
@@ -12,7 +12,7 @@ import {
   fetch,
 } from "miniflare";
 import { WebSocketServer } from "ws";
-import { useServer } from "../test-shared";
+import { flaky, useServer } from "../test-shared";
 
 const noop = () => {};
 
@@ -109,7 +109,7 @@ test("fetch: includes headers from web socket upgrade response", async (t) => {
   t.not(res.webSocket, undefined);
   t.is(res.headers.get("set-cookie"), "key=value");
 });
-test("fetch: dispatches close events on client and server close", async (t) => {
+const fetchDispatchCloseFlakyTest = flaky(async (t) => {
   let clientCloses = 0;
   let serverCloses = 0;
   const clientClosePromise = new DeferredPromise<void>();
@@ -185,6 +185,10 @@ test("fetch: dispatches close events on client and server close", async (t) => {
   await serverSideClose(true);
   await serverClosePromise;
 });
+test(
+  "fetch: dispatches close events on client and server close",
+  fetchDispatchCloseFlakyTest
+);
 test("fetch: throws on ws(s) protocols", async (t) => {
   await t.throwsAsync(
     fetch("ws://localhost/", {

--- a/packages/miniflare/test/test-shared/asserts.ts
+++ b/packages/miniflare/test/test-shared/asserts.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import { ExecutionContext } from "ava";
+import { Awaitable } from "miniflare";
 
 export function isWithin(
   t: ExecutionContext,
@@ -20,4 +21,23 @@ export function isWithin(
 export function escapeRegexp(value: string): RegExp {
   // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping
   return new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+}
+
+export function flaky(
+  impl: (t: ExecutionContext) => Awaitable<void>
+): (t: ExecutionContext) => Promise<void> {
+  const maxAttempts = 3;
+  return async (t) => {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const result = await t.try(impl);
+      if (result.passed || attempt === maxAttempts) {
+        result.commit();
+        return;
+      } else {
+        result.discard();
+        t.log(`Attempt #${attempt} failed!`);
+        t.log(...result.errors);
+      }
+    }
+  };
 }


### PR DESCRIPTION
We're seeing this `t.is(code, 3003)` assertion flake quite a bit in CI. Instead of being `3003`, the close code is `1006` which means "Abnormal Closure". I haven't been able to reproduce this locally, so suspect this is just some transient network failure with the Actions runner. Retrying the test seems to help, so this PR introduces a `flaky` helper for wrapping test implementations with. This retires a test 3 times.