### PR TITLE
[Miniflare 3] Add `outboundService` option for customising global `fetch()` target

### DIFF
--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -315,6 +315,12 @@ parameter in module format Workers.
     handler. This allows you to access data and functions defined in Node.js
     from your Worker.
 
+- `outboundService?: string | { network: Network } | { external: ExternalServer } | { disk: DiskDirectory } | (request: Request) => Awaitable<Response>`
+
+  Dispatch this Worker's global `fetch()` and `connect()` requests to the
+  configured service. Service designators follow the same rules above for
+  `serviceBindings`.
+
 - `routes?: string[]`
 
   Array of route patterns for this Worker. These follow the same

--- a/packages/miniflare/src/plugins/core/constants.ts
+++ b/packages/miniflare/src/plugins/core/constants.ts
@@ -12,12 +12,28 @@ const SERVICE_CUSTOM_PREFIX = `${CORE_PLUGIN_NAME}:custom`;
 export function getUserServiceName(workerName = "") {
   return `${SERVICE_USER_PREFIX}:${workerName}`;
 }
+
+// Namespace custom services to avoid conflicts between user-specified names
+// and hardcoded Miniflare names
+export enum CustomServiceKind {
+  UNKNOWN = "#", // User specified name (i.e. `serviceBindings`)
+  KNOWN = "$", // Miniflare specified name (i.e. `outboundService`)
+}
+
+export const CUSTOM_SERVICE_KNOWN_OUTBOUND = "outbound";
+
 export function getBuiltinServiceName(
   workerIndex: number,
+  kind: CustomServiceKind,
   bindingName: string
 ) {
-  return `${SERVICE_BUILTIN_PREFIX}:${workerIndex}:${bindingName}`;
+  return `${SERVICE_BUILTIN_PREFIX}:${workerIndex}:${kind}${bindingName}`;
 }
-export function getCustomServiceName(workerIndex: number, bindingName: string) {
-  return `${SERVICE_CUSTOM_PREFIX}:${workerIndex}:${bindingName}`;
+
+export function getCustomServiceName(
+  workerIndex: number,
+  kind: CustomServiceKind,
+  bindingName: string
+) {
+  return `${SERVICE_CUSTOM_PREFIX}:${workerIndex}:${kind}${bindingName}`;
 }


### PR DESCRIPTION
`workerd` exposes a `globalOutbound` option for customising which service global `fetch()` calls should be dispatched to. For tests, it's useful to be able to mock responses to certain routes or assert certain requests are made. This new option allows `fetch()` call to be sent to another configured Worker. See the added test for an example.

Note support for `undici`'s [`MockAgent`](https://undici.nodejs.org/#/docs/api/MockAgent) API in Miniflare 3 is still planned. This is a lower-level primitive for customising `fetch()` responses.

/cc @vlovich 