### PR TITLE
[Miniflare 3] Fix standalone support for Workers Sites using modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,15 @@
         "node": ">=14.19 <15 || >=16.15 <17 || >=18"
       }
     },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.0.tgz",
+      "integrity": "sha512-9CB/MKf/wdvbfkUdfrj+OkEwZ5b7rws0eogJ4293h+7b6KX5toPwym+VQKmILafNB9YiehqY0DlNrDcDhdWHSQ==",
+      "dev": true,
+      "dependencies": {
+        "mime": "^3.0.0"
+      }
+    },
     "node_modules/@cloudflare/workerd-darwin-64": {
       "version": "1.20230814.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230814.1.tgz",
@@ -3601,6 +3610,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "dev": true,
@@ -5465,6 +5486,7 @@
         "zod": "^3.20.6"
       },
       "devDependencies": {
+        "@cloudflare/kv-asset-handler": "^0.3.0",
         "@cloudflare/workers-types": "^4.20230807.0",
         "@types/better-sqlite3": "^7.6.2",
         "@types/debug": "^4.1.7",
@@ -5532,6 +5554,15 @@
       "requires": {
         "escape-string-regexp": "^5.0.0",
         "execa": "^7.1.0"
+      }
+    },
+    "@cloudflare/kv-asset-handler": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.0.tgz",
+      "integrity": "sha512-9CB/MKf/wdvbfkUdfrj+OkEwZ5b7rws0eogJ4293h+7b6KX5toPwym+VQKmILafNB9YiehqY0DlNrDcDhdWHSQ==",
+      "dev": true,
+      "requires": {
+        "mime": "^3.0.0"
       }
     },
     "@cloudflare/workerd-darwin-64": {
@@ -7683,6 +7714,12 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true
+    },
     "mimic-fn": {
       "version": "4.0.0",
       "dev": true
@@ -7693,6 +7730,7 @@
     "miniflare": {
       "version": "file:packages/miniflare",
       "requires": {
+        "@cloudflare/kv-asset-handler": "^0.3.0",
         "@cloudflare/workers-types": "^4.20230807.0",
         "@types/better-sqlite3": "^7.6.2",
         "@types/debug": "^4.1.7",

--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -234,8 +234,9 @@ parameter in module format Workers.
 
 - `modulesRoot?: string`
 
-  If `modules` is set to an array, modules' "name"s will be their `path`s
-  relative to this value. This ensures file paths in stack traces are correct.
+  If `modules` is set to `true` or an array, modules' "name"s will be their
+  `path`s relative to this value. This ensures file paths in stack traces are
+  correct.
 
 <!-- prettier-ignore-start -->
 <!-- (for disabling `;` insertion in `js` code block) -->

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -44,6 +44,7 @@
     "zod": "^3.20.6"
   },
   "devDependencies": {
+    "@cloudflare/kv-asset-handler": "^0.3.0",
     "@cloudflare/workers-types": "^4.20230807.0",
     "@types/better-sqlite3": "^7.6.2",
     "@types/debug": "^4.1.7",

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -563,10 +563,10 @@ function getWorkerScript(
   options: SourceOptions,
   workerIndex: number
 ): { serviceWorkerScript: string } | { modules: Worker_Module[] } {
+  const modulesRoot =
+    ("modulesRoot" in options ? options.modulesRoot : undefined) ?? "";
   if (Array.isArray(options.modules)) {
     // If `modules` is a manually defined modules array, use that
-    const modulesRoot =
-      ("modulesRoot" in options ? options.modulesRoot : undefined) ?? "";
     return {
       modules: options.modules.map((module) =>
         convertModuleDefinition(sourceMapRegistry, modulesRoot, module)
@@ -589,7 +589,11 @@ function getWorkerScript(
 
   if (options.modules) {
     // If `modules` is `true`, automatically collect modules...
-    const locator = new ModuleLocator(sourceMapRegistry, options.modulesRules);
+    const locator = new ModuleLocator(
+      sourceMapRegistry,
+      modulesRoot,
+      options.modulesRules
+    );
     // If `script` and `scriptPath` are set, resolve modules in `script`
     // against `scriptPath`.
     locator.visitEntrypoint(

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -374,10 +374,15 @@ export const CORE_PLUGIN: Plugin<
     sourceMapRegistry,
   }) {
     // Define regular user worker
+    const additionalModuleNames = additionalModules.map(({ name }) => {
+      assert(name !== undefined);
+      return name;
+    });
     const workerScript = getWorkerScript(
       sourceMapRegistry,
       options,
-      workerIndex
+      workerIndex,
+      additionalModuleNames
     );
     // Add additional modules (e.g. "__STATIC_CONTENT_MANIFEST") if any
     if ("modules" in workerScript) {
@@ -561,7 +566,8 @@ export function getGlobalServices({
 function getWorkerScript(
   sourceMapRegistry: SourceMapRegistry,
   options: SourceOptions,
-  workerIndex: number
+  workerIndex: number,
+  additionalModuleNames: string[]
 ): { serviceWorkerScript: string } | { modules: Worker_Module[] } {
   const modulesRoot =
     ("modulesRoot" in options ? options.modulesRoot : undefined) ?? "";
@@ -592,6 +598,7 @@ function getWorkerScript(
     const locator = new ModuleLocator(
       sourceMapRegistry,
       modulesRoot,
+      additionalModuleNames,
       options.modulesRules
     );
     // If `script` and `scriptPath` are set, resolve modules in `script`

--- a/packages/miniflare/src/plugins/core/modules.ts
+++ b/packages/miniflare/src/plugins/core/modules.ts
@@ -136,6 +136,7 @@ export class ModuleLocator {
   constructor(
     private readonly sourceMapRegistry: SourceMapRegistry,
     private readonly modulesRoot: string,
+    private readonly additionalModuleNames: string[],
     rules?: ModuleRule[]
   ) {
     this.#compiledRules = compileModuleRules(rules);
@@ -256,8 +257,14 @@ ${dim(modulesConfig)}`;
     }
     const spec = specExpression.value;
 
-    // `node:` and `cloudflare:` imports don't need to be included explicitly
-    if (spec.startsWith("node:") || spec.startsWith("cloudflare:")) {
+    // `node:`, `cloudflare:` and `workerd:` imports don't need to be included
+    // explicitly
+    if (
+      spec.startsWith("node:") ||
+      spec.startsWith("cloudflare:") ||
+      spec.startsWith("workerd:") ||
+      this.additionalModuleNames.includes(spec)
+    ) {
       return;
     }
 

--- a/packages/miniflare/src/plugins/kv/router.ts
+++ b/packages/miniflare/src/plugins/kv/router.ts
@@ -64,13 +64,14 @@ export class KVRouter extends Router<KVGateway> {
 
     // Get value from storage
     let value: KVGatewayGetResult | undefined;
-    if (req.headers.get(HEADER_SITES) === null) {
+    const siteRegExps = req.headers.get(HEADER_SITES);
+    if (siteRegExps === null) {
       const gateway = this.gatewayFactory.get(namespace, persist);
       value = await gateway.get(key, options);
     } else {
       // Workers Sites: if this is a sites request, persist should be used as
       // the root without any additional namespace
-      value = await sitesGatewayGet(persist, key, options);
+      value = await sitesGatewayGet(persist, siteRegExps, key, options);
     }
     if (value === undefined) throw new KVError(404, "Not Found");
 
@@ -155,13 +156,14 @@ export class KVRouter extends Router<KVGateway> {
 
     // List keys from storage
     let result: KVGatewayListResult;
-    if (req.headers.get(HEADER_SITES) === null) {
+    const siteRegExps = req.headers.get(HEADER_SITES);
+    if (siteRegExps === null) {
       const gateway = this.gatewayFactory.get(namespace, persist);
       result = await gateway.list(options);
     } else {
       // Workers Sites: if this is a sites request, persist should be used as
       // the root without any additional namespace
-      result = await sitesGatewayList(persist, options);
+      result = await sitesGatewayList(persist, siteRegExps, options);
     }
     return Response.json(result);
   };

--- a/packages/miniflare/src/runtime/config/workerd.ts
+++ b/packages/miniflare/src/runtime/config/workerd.ts
@@ -67,7 +67,7 @@ export type Worker_DurableObjectStorage =
   | { localDisk?: string };
 
 export type Worker_Module = {
-  name?: string;
+  name: string;
 } & (
   | { esModule?: string }
   | { commonJsModule?: string }

--- a/packages/miniflare/test/fixtures/sites/manifest.d.ts
+++ b/packages/miniflare/test/fixtures/sites/manifest.d.ts
@@ -1,0 +1,4 @@
+declare module "__STATIC_CONTENT_MANIFEST" {
+  const value: string;
+  export default value;
+}

--- a/packages/miniflare/test/fixtures/sites/modules.ts
+++ b/packages/miniflare/test/fixtures/sites/modules.ts
@@ -1,0 +1,20 @@
+import { getAssetFromKV } from "@cloudflare/kv-asset-handler";
+import manifestJSON from "__STATIC_CONTENT_MANIFEST";
+const manifest = JSON.parse(manifestJSON);
+
+export default <ExportedHandler<{ __STATIC_CONTENT: KVNamespace }>>{
+  async fetch(request, env, ctx) {
+    return await getAssetFromKV(
+      {
+        request,
+        waitUntil(promise) {
+          return ctx.waitUntil(promise);
+        },
+      },
+      {
+        ASSET_NAMESPACE: env.__STATIC_CONTENT,
+        ASSET_MANIFEST: manifest,
+      }
+    );
+  },
+};

--- a/packages/miniflare/test/fixtures/sites/service-worker.ts
+++ b/packages/miniflare/test/fixtures/sites/service-worker.ts
@@ -1,0 +1,9 @@
+import { getAssetFromKV } from "@cloudflare/kv-asset-handler";
+
+addEventListener("fetch", (e) => {
+  e.respondWith(
+    getAssetFromKV(e).catch(
+      (err) => new Response(err.stack, { status: err.status ?? 500 })
+    )
+  );
+});

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -445,17 +445,19 @@ test("Miniflare: custom upstream as origin", async (t) => {
   t.is(await res.text(), "upstream: http://upstream/extra/path?a=1");
 });
 
-test("Miniflare: `node:` and `cloudflare:` modules", async (t) => {
+test("Miniflare: `node:`, `cloudflare:` and `workerd:` modules", async (t) => {
   const mf = new Miniflare({
     modules: true,
-    compatibilityFlags: ["nodejs_compat"],
+    compatibilityFlags: ["nodejs_compat", "rtti_api"],
     script: `
     import assert from "node:assert";
     import { Buffer } from "node:buffer";
     import { connect } from "cloudflare:sockets"; 
+    import rtti from "workerd:rtti";
     export default {
       fetch() {
         assert.strictEqual(typeof connect, "function");
+        assert.strictEqual(typeof rtti, "object");
         return new Response(Buffer.from("test").toString("base64"))
       }
     }

--- a/packages/miniflare/test/plugins/kv/sites.spec.ts
+++ b/packages/miniflare/test/plugins/kv/sites.spec.ts
@@ -1,0 +1,254 @@
+import assert from "assert";
+import fs from "fs/promises";
+import path from "path";
+import anyTest, { Macro, TestFn } from "ava";
+import esbuild from "esbuild";
+import { Miniflare } from "miniflare";
+import { useTmp } from "../../test-shared";
+
+const FIXTURES_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "test",
+  "fixtures",
+  "sites"
+);
+const SERVICE_WORKER_ENTRY_PATH = path.join(FIXTURES_PATH, "service-worker.ts");
+const MODULES_ENTRY_PATH = path.join(FIXTURES_PATH, "modules.ts");
+
+interface Context {
+  serviceWorkerPath: string;
+  modulesPath: string;
+}
+
+const test = anyTest as TestFn<Context>;
+
+test.before(async (t) => {
+  // Build fixtures
+  const tmp = await useTmp(t);
+  await esbuild.build({
+    entryPoints: [SERVICE_WORKER_ENTRY_PATH, MODULES_ENTRY_PATH],
+    format: "esm",
+    external: ["__STATIC_CONTENT_MANIFEST"],
+    bundle: true,
+    sourcemap: true,
+    outdir: tmp,
+  });
+  t.context.serviceWorkerPath = path.join(tmp, "service-worker.js");
+  t.context.modulesPath = path.join(tmp, "modules.js");
+});
+
+type Route = keyof typeof routeContents;
+const routeContents = {
+  "/": "<p>Index</p>",
+  "/a.txt": "a",
+  "/b/b.txt": "b",
+};
+
+const getMacro: Macro<
+  [{ siteInclude?: string[]; siteExclude?: string[] }, Set<Route>],
+  Context
+> = {
+  async exec(t, options, expectedRoutes) {
+    const tmp = await useTmp(t);
+    for (const [route, contents] of Object.entries(routeContents)) {
+      const routePath = path.join(tmp, route === "/" ? "index.html" : route);
+      await fs.mkdir(path.dirname(routePath), { recursive: true });
+      await fs.writeFile(routePath, contents, "utf8");
+    }
+
+    const mf = new Miniflare({
+      ...options,
+      scriptPath: t.context.serviceWorkerPath,
+      sitePath: tmp,
+    });
+    t.teardown(() => mf.dispose());
+
+    for (const [route, expectedContents] of Object.entries(routeContents)) {
+      const res = await mf.dispatchFetch(`http://localhost:8787${route}`);
+      const expected = expectedRoutes.has(route as Route);
+      const text = (await res.text()).trim();
+      t.is(res.status, expected ? 200 : 404, `${route}: ${text}`);
+      if (expected) t.is(text, expectedContents, route);
+    }
+  },
+};
+
+test(
+  "gets all assets with no filter",
+  getMacro,
+  {},
+  new Set<Route>(["/", "/a.txt", "/b/b.txt"])
+);
+test(
+  "gets included assets with include filter",
+  getMacro,
+  { siteInclude: ["b"] },
+  new Set<Route>(["/b/b.txt"])
+);
+test(
+  "gets all but excluded assets with include filter",
+  getMacro,
+  { siteExclude: ["b"] },
+  new Set<Route>(["/", "/a.txt"])
+);
+test(
+  "gets included assets with include and exclude filters",
+  getMacro,
+  { siteInclude: ["*.txt"], siteExclude: ["b"] },
+  new Set<Route>(["/a.txt"])
+);
+
+// Tests for checking different types of globs are matched correctly
+const matchMacro: Macro<[string], Context> = {
+  async exec(t, include) {
+    const tmp = await useTmp(t);
+    const dir = path.join(tmp, "a", "b", "c");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "test.txt"), "test", "utf8");
+    const mf = new Miniflare({
+      siteInclude: [include],
+      scriptPath: t.context.serviceWorkerPath,
+      sitePath: tmp,
+    });
+    t.teardown(() => mf.dispose());
+    const res = await mf.dispatchFetch("http://localhost:8787/a/b/c/test.txt");
+    t.is(res.status, 200);
+    await res.arrayBuffer();
+  },
+};
+
+test("matches file name pattern", matchMacro, "test.txt");
+test("matches exact pattern", matchMacro, "a/b/c/test.txt");
+test("matches extension patterns", matchMacro, "*.txt");
+test("matches globstar patterns", matchMacro, "**/*.txt");
+test("matches wildcard directory patterns", matchMacro, "a/*/c/*.txt");
+
+test("doesn't cache assets", async (t) => {
+  const tmp = await useTmp(t);
+  const testPath = path.join(tmp, "test.txt");
+  await fs.writeFile(testPath, "1", "utf8");
+
+  const mf = new Miniflare({
+    scriptPath: t.context.serviceWorkerPath,
+    sitePath: tmp,
+  });
+  t.teardown(() => mf.dispose());
+
+  const res1 = await mf.dispatchFetch("http://localhost:8787/test.txt");
+  t.is(res1.headers.get("CF-Cache-Status"), "MISS");
+  t.is(await res1.text(), "1");
+
+  await fs.writeFile(testPath, "2", "utf8");
+  const res2 = await mf.dispatchFetch("http://localhost:8787/test.txt");
+  t.is(res2.headers.get("CF-Cache-Status"), "MISS");
+  t.is(await res2.text(), "2");
+});
+
+test("gets assets with module worker", async (t) => {
+  const tmp = await useTmp(t);
+  const testPath = path.join(tmp, "test.txt");
+  const dirPath = path.join(tmp, "dir");
+  const nestedPath = path.join(dirPath, "nested.txt");
+  await fs.writeFile(testPath, "test", "utf8");
+  await fs.mkdir(dirPath, { recursive: true });
+  await fs.writeFile(nestedPath, "nested", "utf8");
+
+  const mf = new Miniflare({
+    modules: [{ type: "ESModule", path: t.context.modulesPath }],
+    sitePath: tmp,
+  });
+  t.teardown(() => mf.dispose());
+
+  let res = await mf.dispatchFetch("http://localhost:8787/test.txt");
+  t.is(await res.text(), "test");
+  res = await mf.dispatchFetch("http://localhost:8787/dir/nested.txt");
+  t.is(await res.text(), "nested");
+});
+
+test("gets assets with percent-encoded paths", async (t) => {
+  // https://github.com/cloudflare/miniflare/issues/326
+  const tmp = await useTmp(t);
+  const testPath = path.join(tmp, "ń.txt");
+  await fs.writeFile(testPath, "test", "utf8");
+  const mf = new Miniflare({
+    scriptPath: t.context.serviceWorkerPath,
+    sitePath: tmp,
+  });
+  t.teardown(() => mf.dispose());
+  const res = await mf.dispatchFetch("http://localhost:8787/ń.txt");
+  t.is(await res.text(), "test");
+});
+
+test("static content namespace supports listing keys", async (t) => {
+  const tmp = await useTmp(t);
+  await fs.mkdir(path.join(tmp, "a", "b", "c"), { recursive: true });
+  await fs.writeFile(path.join(tmp, "1.txt"), "one");
+  await fs.writeFile(path.join(tmp, "2.txt"), "two");
+  await fs.writeFile(path.join(tmp, "a", "3.txt"), "three");
+  await fs.writeFile(path.join(tmp, "a", "b", "4.txt"), "four");
+  await fs.writeFile(path.join(tmp, "a", "b", "c", "5.txt"), "five");
+  await fs.writeFile(path.join(tmp, "a", "b", "c", "6.txt"), "six");
+  await fs.writeFile(path.join(tmp, "a", "b", "c", "7.txt"), "seven");
+  const mf = new Miniflare({
+    verbose: true,
+    scriptPath: t.context.serviceWorkerPath,
+    sitePath: tmp,
+    siteExclude: ["**/5.txt"],
+  });
+  t.teardown(() => mf.dispose());
+
+  const kv = await mf.getKVNamespace("__STATIC_CONTENT");
+  let result = await kv.list();
+  t.deepEqual(result, {
+    keys: [
+      { name: "$__MINIFLARE_SITES__$/1.txt" },
+      { name: "$__MINIFLARE_SITES__$/2.txt" },
+      { name: "$__MINIFLARE_SITES__$/a%2F3.txt" },
+      { name: "$__MINIFLARE_SITES__$/a%2Fb%2F4.txt" },
+      { name: "$__MINIFLARE_SITES__$/a%2Fb%2Fc%2F6.txt" },
+      { name: "$__MINIFLARE_SITES__$/a%2Fb%2Fc%2F7.txt" },
+    ],
+    list_complete: true,
+    cacheStatus: null,
+  });
+
+  // Check with prefix, cursor and limit
+  result = await kv.list({ prefix: "$__MINIFLARE_SITES__$/a%2F", limit: 1 });
+  assert(!result.list_complete);
+  t.deepEqual(result, {
+    keys: [{ name: "$__MINIFLARE_SITES__$/a%2F3.txt" }],
+    list_complete: false,
+    cursor: "JF9fTUlOSUZMQVJFX1NJVEVTX18kL2ElMkYzLnR4dA==",
+    cacheStatus: null,
+  });
+
+  result = await kv.list({
+    prefix: "$__MINIFLARE_SITES__$/a%2F",
+    limit: 2,
+    cursor: result.cursor,
+  });
+  assert(!result.list_complete);
+  t.deepEqual(result, {
+    keys: [
+      { name: "$__MINIFLARE_SITES__$/a%2Fb%2F4.txt" },
+      { name: "$__MINIFLARE_SITES__$/a%2Fb%2Fc%2F6.txt" },
+    ],
+    list_complete: false,
+    cursor: "JF9fTUlOSUZMQVJFX1NJVEVTX18kL2ElMkZiJTJGYyUyRjYudHh0",
+    cacheStatus: null,
+  });
+
+  result = await kv.list({
+    prefix: "$__MINIFLARE_SITES__$/a%2F",
+    cursor: result.cursor,
+  });
+  t.deepEqual(result, {
+    keys: [{ name: "$__MINIFLARE_SITES__$/a%2Fb%2Fc%2F7.txt" }],
+    list_complete: true,
+    cacheStatus: null,
+  });
+});


### PR DESCRIPTION
Previously, attempting to use Workers Sites with `modules: true` would fail as the automatic module locator didn't know about `__STATIC_CONTENT_MANIFEST`. This change passes through additional modules to the locator. This change also adds support for internal `"workerd:"` modules to the locator (e.g. `workerd:rtti`).

Additionally, `import manifest from "__STATIC_CONTENT_MANIFEST"` was only allowed in the "root" directory of the modules virtual file-system. This change adds stub modules for each additional module in each subdirectory, that re-export the module. This allows the manifest to be imported in any directory.

Closes #630 