### PR TITLE
[Miniflare 3] Add back support for `fetchMock`

### DIFF
--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -321,6 +321,14 @@ parameter in module format Workers.
   configured service. Service designators follow the same rules above for
   `serviceBindings`.
 
+- `fetchMock?: import("undici").MockAgent`
+
+  An [`undici` `MockAgent`](https://undici.nodejs.org/#/docs/api/MockAgent) to
+  dispatch this Worker's global `fetch()` requests through.
+
+  > :warning: `outboundService` and `fetchMock` are mutually exclusive options.
+  > At most one of them may be specified per Worker.
+
 - `routes?: string[]`
 
   Array of route patterns for this Worker. These follow the same

--- a/packages/miniflare/src/plugins/index.ts
+++ b/packages/miniflare/src/plugins/index.ts
@@ -83,6 +83,7 @@ export {
   SERVICE_ENTRY,
   CoreOptionsSchema,
   CoreSharedOptionsSchema,
+  createFetchMock,
   getGlobalServices,
   ModuleRuleTypeSchema,
   ModuleRuleSchema,

--- a/packages/miniflare/src/shared/error.ts
+++ b/packages/miniflare/src/shared/error.ts
@@ -25,7 +25,8 @@ export type MiniflareCoreErrorCode =
   | "ERR_FUTURE_COMPATIBILITY_DATE" // Compatibility date in the future
   | "ERR_NO_WORKERS" // No workers defined
   | "ERR_DUPLICATE_NAME" // Multiple workers defined with same name
-  | "ERR_DIFFERENT_UNIQUE_KEYS"; // Multiple Durable Object bindings declared for same class with different unsafe unique keys
+  | "ERR_DIFFERENT_UNIQUE_KEYS" // Multiple Durable Object bindings declared for same class with different unsafe unique keys
+  | "ERR_MULTIPLE_OUTBOUNDS"; // Both `outboundService` and `fetchMock` specified
 export class MiniflareCoreError extends MiniflareError<MiniflareCoreErrorCode> {}
 
 export class HttpError extends MiniflareError<number> {


### PR DESCRIPTION
This builds on top of #629, adding back support for `undici` `MockAgent`s (https://undici.nodejs.org/#/docs/api/MockAgent) via the `fetchMock` option. This makes it easy to mock outbound `fetch()` requests in tests. This API is the same as Miniflare 2.