### PR TITLE
Bump version to v3.20230801.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@miniflare/root",
-  "version": "3.20230801.0",
+  "version": "3.20230801.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@miniflare/root",
-      "version": "3.20230801.0",
+      "version": "3.20230801.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miniflare/root",
-  "version": "3.20230801.0",
+  "version": "3.20230801.1",
   "private": true,
   "description": "Fun, full-featured, fully-local simulator for Cloudflare Workers",
   "keywords": [

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniflare",
-  "version": "3.20230801.0",
+  "version": "3.20230801.1",
   "description": "Fun, full-featured, fully-local simulator for Cloudflare Workers",
   "keywords": [
     "cloudflare",


### PR DESCRIPTION
Incrementing the patch version from `0` to `1` to republish after the `0` version was published with workerd dep `^1.20230801.0` instead of `1.20230801.0` (had `^` prefix but shouldn't have)