### PR TITLE
Change r2 put response encoding

### DIFF
--- a/packages/miniflare/src/plugins/r2/router.ts
+++ b/packages/miniflare/src/plugins/r2/router.ts
@@ -144,7 +144,7 @@ export class R2Router extends Router<R2Gateway> {
         valueSize,
         metadata
       );
-      return encodeResult(result);
+      return encodeJSONResult(result);
     } else if (metadata.method === "createMultipartUpload") {
       const result = await gateway.createMultipartUpload(
         metadata.object,


### PR DESCRIPTION
Without this, the `await env.MY_BUCKET.put(...)` of https://developers.cloudflare.com/r2/api/workers/workers-api-usage/ hangs indefinitely

This problem matches the description in https://github.com/cloudflare/workers-sdk/issues/3688 and https://discord.com/channels/595317990191398933/1138945222873731264/1138945222873731264.