### PR TITLE
[Miniflare 3] Serve linked source maps from loopback server (enable breakpoint debugging for TypeScript)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1872,6 +1872,12 @@
       "integrity": "sha512-n94yQo4LI3w7erwf84mhRUkUJfhLoCZiLyoOZ/QFsDbcWNZePrLwbQpvZBUG2TNxwV3VjCKPxkiiQA6pe3TrTA==",
       "dev": true
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1182435",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1182435.tgz",
+      "integrity": "sha512-EmlkWb62wSbQNE1gRZZsi4KZYRaF5Skpp183LhRU7+sadKR06O1dHCjZmFSEG6Kv7P6S/UYLxcY3NlYwqKM99w==",
+      "dev": true
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "dev": true,
@@ -5475,6 +5481,7 @@
         "@types/stoppable": "^1.1.1",
         "@types/ws": "^8.5.3",
         "devalue": "^4.3.0",
+        "devtools-protocol": "^0.0.1182435",
         "semiver": "^1.1.0"
       },
       "engines": {
@@ -6617,6 +6624,12 @@
       "integrity": "sha512-n94yQo4LI3w7erwf84mhRUkUJfhLoCZiLyoOZ/QFsDbcWNZePrLwbQpvZBUG2TNxwV3VjCKPxkiiQA6pe3TrTA==",
       "dev": true
     },
+    "devtools-protocol": {
+      "version": "0.0.1182435",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1182435.tgz",
+      "integrity": "sha512-EmlkWb62wSbQNE1gRZZsi4KZYRaF5Skpp183LhRU7+sadKR06O1dHCjZmFSEG6Kv7P6S/UYLxcY3NlYwqKM99w==",
+      "dev": true
+    },
     "dir-glob": {
       "version": "3.0.1",
       "dev": true,
@@ -7700,6 +7713,7 @@
         "better-sqlite3": "^8.1.0",
         "capnp-ts": "^0.7.0",
         "devalue": "^4.3.0",
+        "devtools-protocol": "^0.0.1182435",
         "exit-hook": "^2.2.1",
         "glob-to-regexp": "^0.4.1",
         "http-cache-semantics": "^4.1.0",

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -56,6 +56,7 @@
     "@types/stoppable": "^1.1.1",
     "@types/ws": "^8.5.3",
     "devalue": "^4.3.0",
+    "devtools-protocol": "^0.0.1182435",
     "semiver": "^1.1.0"
   },
   "engines": {

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { Service, Worker_Binding, Worker_Module } from "../../runtime";
 import { Awaitable, Log, OptionalZodTypeOf } from "../../shared";
 import { GatewayConstructor } from "./gateway";
+import { SourceMapRegistry } from "./registry";
 import { RouterConstructor } from "./router";
 
 // Maps **service** names to the Durable Object class names exported by them
@@ -41,6 +42,7 @@ export interface PluginServicesOptions<
   workerIndex: number;
   additionalModules: Worker_Module[];
   tmpPath: string;
+  sourceMapRegistry: SourceMapRegistry;
 
   // ~~Leaky abstractions~~ "Plugin specific options" :)
   durableObjectClassNames: DurableObjectClassNames;
@@ -91,5 +93,6 @@ export function namespaceEntries(
 export * from "./constants";
 export * from "./gateway";
 export * from "./range";
+export * from "./registry";
 export * from "./router";
 export * from "./routing";

--- a/packages/miniflare/src/plugins/shared/registry.ts
+++ b/packages/miniflare/src/plugins/shared/registry.ts
@@ -1,0 +1,105 @@
+import crypto from "crypto";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import type { RawSourceMap } from "source-map";
+import { Response } from "../../http";
+import { Log } from "../../shared";
+
+function maybeParseURL(url: string): URL | undefined {
+  if (path.isAbsolute(url)) return;
+  try {
+    return new URL(url);
+  } catch {}
+}
+
+export class SourceMapRegistry {
+  static PATHNAME_PREFIX = "/core/source-map/";
+
+  constructor(
+    private readonly log: Log,
+    private readonly loopbackPort: number
+  ) {}
+
+  readonly #map = new Map<string /* id */, string /* sourceMapPath */>();
+
+  register(script: string, scriptPath: string): string /* newScript */ {
+    // Try to find the last source mapping URL in the file, if none could be
+    // found, return the script as is
+    const mappingURLIndex = script.lastIndexOf("//# sourceMappingURL=");
+    if (mappingURLIndex === -1) return script;
+
+    // `pathToFileURL()` will resolve `scriptPath` relative to the current
+    // working directory if needed
+    const scriptURL = pathToFileURL(scriptPath);
+
+    const sourceSegment = script.substring(0, mappingURLIndex);
+    const mappingURLSegment = script
+      .substring(mappingURLIndex)
+      .replace(/^\/\/# sourceMappingURL=(.+)/, (substring, mappingURL) => {
+        // If the mapping URL is already a URL (e.g. `data:`), return it as is
+        if (maybeParseURL(mappingURL) !== undefined) return substring;
+
+        // Otherwise, resolve it relative to the script, and register it
+        const resolvedMappingURL = new URL(mappingURL, scriptURL);
+        const resolvedMappingPath = fileURLToPath(resolvedMappingURL);
+
+        // We intentionally register source maps in a map to prevent arbitrary
+        // file access via the loopback server.
+        const id = crypto.randomUUID();
+        this.#map.set(id, resolvedMappingPath);
+        mappingURL = `http://localhost:${this.loopbackPort}${SourceMapRegistry.PATHNAME_PREFIX}${id}`;
+
+        this.log.verbose(
+          `Registered source map ${JSON.stringify(
+            resolvedMappingPath
+          )} at ${mappingURL}`
+        );
+
+        return `//# sourceMappingURL=${mappingURL}`;
+      });
+
+    return sourceSegment + mappingURLSegment;
+  }
+
+  async get(url: URL): Promise<Response | undefined> {
+    // Try to get source map from registry
+    const id = url.pathname.substring(SourceMapRegistry.PATHNAME_PREFIX.length);
+    const sourceMapPath = this.#map.get(id);
+    if (sourceMapPath === undefined) return;
+
+    // Try to load and parse source map from disk
+    let contents: string;
+    try {
+      contents = await fs.readFile(sourceMapPath, "utf8");
+    } catch (e) {
+      this.log.warn(
+        `Error reading source map ${JSON.stringify(sourceMapPath)}: ${e}`
+      );
+      return;
+    }
+    let map: RawSourceMap;
+    try {
+      map = JSON.parse(contents);
+    } catch (e) {
+      this.log.warn(
+        `Error parsing source map ${JSON.stringify(sourceMapPath)}: ${e}`
+      );
+      return;
+    }
+
+    // Modify the `sourceRoot` so source files get the correct paths. Note,
+    // `sourceMapPath` will always be an absolute path.
+    const sourceMapDir = path.dirname(sourceMapPath);
+    map.sourceRoot =
+      map.sourceRoot === undefined
+        ? sourceMapDir
+        : path.resolve(sourceMapDir, map.sourceRoot);
+
+    return Response.json(map, {
+      // This source map will be served from the loopback server to DevTools,
+      // which will likely be on a different origin.
+      headers: { "Access-Control-Allow-Origin": "*" },
+    });
+  }
+}

--- a/packages/miniflare/test/plugins/core/errors/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/errors/index.spec.ts
@@ -1,8 +1,15 @@
+import assert from "assert";
 import fs from "fs/promises";
+import http from "http";
+import { AddressInfo } from "net";
 import path from "path";
 import test from "ava";
+import Protocol from "devtools-protocol";
 import esbuild from "esbuild";
-import { Miniflare } from "miniflare";
+import { DeferredPromise, Miniflare } from "miniflare";
+import { RawSourceMap } from "source-map";
+import { fetch } from "undici";
+import NodeWebSocket from "ws";
 import { escapeRegexp, useTmp } from "../../../test-shared";
 
 const FIXTURES_PATH = path.resolve(
@@ -19,6 +26,7 @@ const FIXTURES_PATH = path.resolve(
 const SERVICE_WORKER_ENTRY_PATH = path.join(FIXTURES_PATH, "service-worker.ts");
 const MODULES_ENTRY_PATH = path.join(FIXTURES_PATH, "modules.ts");
 const DEP_ENTRY_PATH = path.join(FIXTURES_PATH, "nested/dep.ts");
+const REDUCE_PATH = path.join(FIXTURES_PATH, "reduce.ts");
 
 test("source maps workers", async (t) => {
   // Build fixtures
@@ -40,8 +48,18 @@ test("source maps workers", async (t) => {
   const serviceWorkerContent = await fs.readFile(serviceWorkerPath, "utf8");
   const modulesContent = await fs.readFile(modulesPath, "utf8");
 
-  // Check service-workers source mapped
+  // The OS should assign random ports in sequential order, meaning
+  // `inspectorPort` is unlikely to be immediately chosen as a random port again
+  const server = http.createServer();
+  const inspectorPort = await new Promise<number>((resolve, reject) => {
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      server.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+
   const mf = new Miniflare({
+    inspectorPort,
     workers: [
       {
         bindings: { MESSAGE: "unnamed" },
@@ -54,8 +72,69 @@ test("source maps workers", async (t) => {
         script: serviceWorkerContent,
         scriptPath: serviceWorkerPath,
       },
+      {
+        name: "b",
+        routes: ["*/b"],
+        modules: true,
+        scriptPath: modulesPath,
+        bindings: { MESSAGE: "b" },
+      },
+      {
+        name: "c",
+        routes: ["*/c"],
+        bindings: { MESSAGE: "c" },
+        modules: true,
+        script: modulesContent,
+        scriptPath: modulesPath,
+      },
+      {
+        name: "d",
+        routes: ["*/d"],
+        bindings: { MESSAGE: "d" },
+        modules: [{ type: "ESModule", path: modulesPath }],
+      },
+      {
+        name: "e",
+        routes: ["*/e"],
+        bindings: { MESSAGE: "e" },
+        modules: [
+          { type: "ESModule", path: modulesPath, contents: modulesContent },
+        ],
+      },
+      {
+        name: "f",
+        routes: ["*/f"],
+        bindings: { MESSAGE: "f" },
+        modulesRoot: tmp,
+        modules: [{ type: "ESModule", path: modulesPath }],
+      },
+      {
+        name: "g",
+        routes: ["*/g"],
+        modules: [
+          // Check importing module with source map (e.g. Wrangler no bundle with built dependencies)
+          {
+            type: "ESModule",
+            path: modulesPath,
+            contents: `import { createErrorResponse } from "./nested/dep.js"; export default { fetch: createErrorResponse };`,
+          },
+          { type: "ESModule", path: depPath },
+        ],
+      },
+      {
+        name: "h",
+        // Generated with `esbuild --sourcemap=inline --sources-content=false worker.ts`
+        script: `"use strict";
+addEventListener("fetch", (event) => {
+  event.respondWith(new Response("body"));
+});
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsid29ya2VyLnRzIl0sCiAgIm1hcHBpbmdzIjogIjtBQUFBLGlCQUFpQixTQUFTLENBQUMsVUFBVTtBQUNuQyxRQUFNLFlBQVksSUFBSSxTQUFTLE1BQU0sQ0FBQztBQUN4QyxDQUFDOyIsCiAgIm5hbWVzIjogW10KfQo=
+`,
+      },
     ],
   });
+
+  // Check service-workers source mapped
   let error = await t.throwsAsync(mf.dispatchFetch("http://localhost"), {
     message: "unnamed",
   });
@@ -69,69 +148,10 @@ test("source maps workers", async (t) => {
   t.regex(String(error?.stack), serviceWorkerEntryRegexp);
 
   // Check modules workers source mapped
-  await mf.setOptions({
-    workers: [
-      {
-        modules: true,
-        scriptPath: modulesPath,
-        bindings: { MESSAGE: "unnamed" },
-      },
-      {
-        name: "a",
-        routes: ["*/a"],
-        bindings: { MESSAGE: "a" },
-        modules: true,
-        script: modulesContent,
-        scriptPath: modulesPath,
-      },
-      {
-        name: "b",
-        routes: ["*/b"],
-        bindings: { MESSAGE: "b" },
-        modules: [{ type: "ESModule", path: modulesPath }],
-      },
-      {
-        name: "c",
-        routes: ["*/c"],
-        bindings: { MESSAGE: "c" },
-        modules: [
-          { type: "ESModule", path: modulesPath, contents: modulesContent },
-        ],
-      },
-      {
-        name: "d",
-        routes: ["*/d"],
-        bindings: { MESSAGE: "d" },
-        modulesRoot: tmp,
-        modules: [{ type: "ESModule", path: modulesPath }],
-      },
-      {
-        name: "e",
-        routes: ["*/e"],
-        modules: [
-          // Check importing module with source map (e.g. Wrangler no bundle with built dependencies)
-          {
-            type: "ESModule",
-            path: modulesPath,
-            contents: `import { createErrorResponse } from "./nested/dep.js"; export default { fetch: createErrorResponse };`,
-          },
-          { type: "ESModule", path: depPath },
-        ],
-      },
-    ],
-  });
-  error = await t.throwsAsync(mf.dispatchFetch("http://localhost"), {
-    message: "unnamed",
-  });
-  const modulesEntryRegexp = escapeRegexp(`${MODULES_ENTRY_PATH}:5:19`);
-  t.regex(String(error?.stack), modulesEntryRegexp);
-  error = await t.throwsAsync(mf.dispatchFetch("http://localhost/a"), {
-    message: "a",
-  });
-  t.regex(String(error?.stack), modulesEntryRegexp);
   error = await t.throwsAsync(mf.dispatchFetch("http://localhost/b"), {
     message: "b",
   });
+  const modulesEntryRegexp = escapeRegexp(`${MODULES_ENTRY_PATH}:5:19`);
   t.regex(String(error?.stack), modulesEntryRegexp);
   error = await t.throwsAsync(mf.dispatchFetch("http://localhost/c"), {
     message: "c",
@@ -142,9 +162,101 @@ test("source maps workers", async (t) => {
   });
   t.regex(String(error?.stack), modulesEntryRegexp);
   error = await t.throwsAsync(mf.dispatchFetch("http://localhost/e"), {
+    message: "e",
+  });
+  t.regex(String(error?.stack), modulesEntryRegexp);
+  error = await t.throwsAsync(mf.dispatchFetch("http://localhost/f"), {
+    message: "f",
+  });
+  t.regex(String(error?.stack), modulesEntryRegexp);
+  error = await t.throwsAsync(mf.dispatchFetch("http://localhost/g"), {
     instanceOf: TypeError,
     message: "Dependency error",
   });
   const nestedRegexp = escapeRegexp(`${DEP_ENTRY_PATH}:4:17`);
   t.regex(String(error?.stack), nestedRegexp);
+
+  // Check source mapping URLs rewritten
+  let sources = await getSources(inspectorPort, "core:user:");
+  t.deepEqual(sources, [REDUCE_PATH, SERVICE_WORKER_ENTRY_PATH]);
+  sources = await getSources(inspectorPort, "core:user:a");
+  t.deepEqual(sources, [REDUCE_PATH, SERVICE_WORKER_ENTRY_PATH]);
+  sources = await getSources(inspectorPort, "core:user:b");
+  t.deepEqual(sources, [MODULES_ENTRY_PATH, REDUCE_PATH]);
+  sources = await getSources(inspectorPort, "core:user:c");
+  t.deepEqual(sources, [MODULES_ENTRY_PATH, REDUCE_PATH]);
+  sources = await getSources(inspectorPort, "core:user:d");
+  t.deepEqual(sources, [MODULES_ENTRY_PATH, REDUCE_PATH]);
+  sources = await getSources(inspectorPort, "core:user:e");
+  t.deepEqual(sources, [MODULES_ENTRY_PATH, REDUCE_PATH]);
+  sources = await getSources(inspectorPort, "core:user:f");
+  t.deepEqual(sources, [MODULES_ENTRY_PATH, REDUCE_PATH]);
+  sources = await getSources(inspectorPort, "core:user:g");
+  t.deepEqual(sources, [DEP_ENTRY_PATH, REDUCE_PATH]); // (entry point script overridden)
+
+  // Check respects map's existing `sourceRoot`
+  const sourceRoot = "a/b/c/d/e";
+  const serviceWorkerMapPath = serviceWorkerPath + ".map";
+  const serviceWorkerMap: RawSourceMap = JSON.parse(
+    await fs.readFile(serviceWorkerMapPath, "utf8")
+  );
+  serviceWorkerMap.sourceRoot = sourceRoot;
+  await fs.writeFile(serviceWorkerMapPath, JSON.stringify(serviceWorkerMap));
+  t.deepEqual(await getSources(inspectorPort, "core:user:"), [
+    path.resolve(tmp, sourceRoot, path.relative(tmp, REDUCE_PATH)),
+    path.resolve(
+      tmp,
+      sourceRoot,
+      path.relative(tmp, SERVICE_WORKER_ENTRY_PATH)
+    ),
+  ]);
+
+  // Check does nothing with URL source mapping URLs
+  const sourceMapURL = await getSourceMapURL(inspectorPort, "core:user:h");
+  t.regex(sourceMapURL, /^data:application\/json;base64/);
 });
+
+function getSourceMapURL(
+  inspectorPort: number,
+  serviceName: string
+): Promise<string> {
+  let sourceMapURL: string | undefined;
+  const promise = new DeferredPromise<string>();
+  const inspectorUrl = `ws://127.0.0.1:${inspectorPort}/${serviceName}`;
+  const ws = new NodeWebSocket(inspectorUrl);
+  ws.on("message", async (raw) => {
+    try {
+      const message = JSON.parse(raw.toString("utf8"));
+      if (message.method === "Debugger.scriptParsed") {
+        const params: Protocol.Debugger.ScriptParsedEvent = message.params;
+        if (params.sourceMapURL === undefined || params.sourceMapURL === "") {
+          return;
+        }
+        sourceMapURL = params.sourceMapURL;
+        ws.close();
+      }
+    } catch (e) {
+      promise.reject(e);
+    }
+  });
+  ws.on("open", () => {
+    ws.send(JSON.stringify({ id: 0, method: "Debugger.enable", params: {} }));
+  });
+  ws.on("close", () => {
+    assert(sourceMapURL !== undefined, "Expected `sourceMapURL`");
+    promise.resolve(sourceMapURL);
+  });
+  return promise;
+}
+
+async function getSources(inspectorPort: number, serviceName: string) {
+  const sourceMapURL = await getSourceMapURL(inspectorPort, serviceName);
+  // The loopback server will be listening on `127.0.0.1`, which
+  // `localhost` should resolve to, but `undici` only looks at the first
+  // DNS entry, which will be `::1` on Node 17+.
+  // noinspection JSObjectNullOrUndefined
+  const res = await fetch(sourceMapURL.replace("localhost", "127.0.0.1"));
+  const { sourceRoot, sources } = (await res.json()) as RawSourceMap;
+  assert(sourceRoot !== undefined);
+  return sources.map((source) => path.resolve(sourceRoot, source)).sort();
+}


### PR DESCRIPTION
Hey! 👋 With cloudflare/workerd#710, `workerd` supports breakpoint debugging! Support for this in Miniflare just worked, assuming you were using a plain JavaScript worker, or you had inline source maps. `workerd` doesn't know where workers are located on disk, it just knows files' locations relative to each other. This means it's unable to resolve locations of corresponding linked `.map` files in `sourceMappingURL` comments.

Miniflare _does_ have this information though. This PR detects linked source maps and rewrites `sourceMappingURL` comments to `http` URLs pointing to Miniflare's loopback server. This then looks for the source map relative to the known on-disk source location. Source maps' `sourceRoot` attributes are updated to ensure correct locations are displayed in DevTools.

**This enables breakpoint debugging for compiled TypeScript with linked source maps!** :tada:

![image](https://github.com/cloudflare/miniflare/assets/15955327/3345bf30-d721-4cca-9c94-dc0855282295)
![image](https://github.com/cloudflare/miniflare/assets/15955327/c7450726-b9be-4f1e-8beb-d8b2cbf3e090)

Closes DEVX-872