### PR TITLE
fix: add `type: "module"` to vitest-environment-miniflare

### DIFF
--- a/.changeset/fuzzy-poets-share.md
+++ b/.changeset/fuzzy-poets-share.md
@@ -1,0 +1,5 @@
+---
+"vitest-environment-miniflare": patch
+---
+
+fix: add `type: "module"` to vitest-environment-miniflare

--- a/packages/vitest-environment-miniflare/package.json
+++ b/packages/vitest-environment-miniflare/package.json
@@ -11,6 +11,7 @@
   ],
   "author": "MrBBot <me@mrbbot.dev>",
   "license": "MIT",
+  "type": "module",
   "main": "./dist/src/index.js",
   "module": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
fixes #645