### PR TITLE
[Miniflare 3] Allow sources to be hidden in DevTools sources panel

### DIFF
--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -775,7 +775,11 @@ export class Miniflare {
 
     sharedOpts.core.cf = await setupCf(this.#log, sharedOpts.core.cf);
 
-    const sourceMapRegistry = new SourceMapRegistry(this.#log, loopbackPort);
+    const sourceMapRegistry = new SourceMapRegistry(
+      this.#log,
+      loopbackPort,
+      sharedOpts.core.unsafeSourceMapIgnoreSourcePredicate
+    );
     const durableObjectClassNames = getDurableObjectClassNames(allWorkerOpts);
     const queueConsumers = getQueueConsumers(allWorkerOpts);
     const allWorkerRoutes = getWorkerRoutes(allWorkerOpts);

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -28,6 +28,7 @@ import { getCacheServiceName } from "../cache";
 import { DURABLE_OBJECTS_STORAGE_SERVICE_NAME } from "../do";
 import {
   HEADER_CF_BLOB,
+  IgnoreSourcePredicateSchema,
   Plugin,
   SERVICE_LOOPBACK,
   SourceMapRegistry,
@@ -139,6 +140,8 @@ export const CoreSharedOptionsSchema = z.object({
   cf: z.union([z.boolean(), z.string(), z.record(z.any())]).optional(),
 
   liveReload: z.boolean().optional(),
+
+  unsafeSourceMapIgnoreSourcePredicate: IgnoreSourcePredicateSchema.optional(),
 });
 
 export const CORE_PLUGIN_NAME = "core";

--- a/packages/miniflare/test/plugins/core/errors/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/errors/index.spec.ts
@@ -60,6 +60,9 @@ test("source maps workers", async (t) => {
 
   const mf = new Miniflare({
     inspectorPort,
+    unsafeSourceMapIgnoreSourcePredicate(source) {
+      return source.includes("nested/dep.ts");
+    },
     workers: [
       {
         bindings: { MESSAGE: "unnamed" },
@@ -214,6 +217,13 @@ addEventListener("fetch", (event) => {
   // Check does nothing with URL source mapping URLs
   const sourceMapURL = await getSourceMapURL(inspectorPort, "core:user:h");
   t.regex(sourceMapURL, /^data:application\/json;base64/);
+
+  // Check adds ignored sources to `x_google_ignoreList`
+  const sourceMap = await getSourceMap(inspectorPort, "core:user:g");
+  assert(sourceMap.sourceRoot !== undefined);
+  assert(sourceMap.x_google_ignoreList?.length === 1);
+  const ignoredSource = sourceMap.sources[sourceMap.x_google_ignoreList[0]];
+  t.is(path.resolve(sourceMap.sourceRoot, ignoredSource), DEP_ENTRY_PATH);
 });
 
 function getSourceMapURL(
@@ -249,14 +259,22 @@ function getSourceMapURL(
   return promise;
 }
 
-async function getSources(inspectorPort: number, serviceName: string) {
+async function getSourceMap(inspectorPort: number, serviceName: string) {
   const sourceMapURL = await getSourceMapURL(inspectorPort, serviceName);
   // The loopback server will be listening on `127.0.0.1`, which
   // `localhost` should resolve to, but `undici` only looks at the first
   // DNS entry, which will be `::1` on Node 17+.
-  // noinspection JSObjectNullOrUndefined
   const res = await fetch(sourceMapURL.replace("localhost", "127.0.0.1"));
-  const { sourceRoot, sources } = (await res.json()) as RawSourceMap;
+  return (await res.json()) as RawSourceMap & {
+    x_google_ignoreList?: number[];
+  };
+}
+
+async function getSources(inspectorPort: number, serviceName: string) {
+  const { sourceRoot, sources } = await getSourceMap(
+    inspectorPort,
+    serviceName
+  );
   assert(sourceRoot !== undefined);
   return sources.map((source) => path.resolve(sourceRoot, source)).sort();
 }


### PR DESCRIPTION
Wrangler currently uses the non-standard `x_google_ignoreList` source map field to hide middleware and injected code from the sources panel. As part of the work to enable breakpoint debugging in Wrangler, we now defer to Miniflare to serve local source maps. This ensures source maps have the correct source paths on disk.

We'd like to keep this ignoring behaviour though. We could intercept `Network.loadNetworkResource` and rewrite the source map in Wrangler, but that feels wasteful, as we're already parsing/stringifying the source map in Miniflare.

Instead, this change adds a `unsafeSourceMapIgnoreSourcePredicate` option, that controls which sources, if any, are added to `x_google_ignoreList`. This allows DevTools to fetch source maps directly from Miniflare, without proxying through Wrangler.