### PR TITLE
use relative imports in miniflare core

### DIFF
--- a/packages/core/src/standards/crypto.ts
+++ b/packages/core/src/standards/crypto.ts
@@ -1,6 +1,6 @@
 import { createHash, timingSafeEqual, webcrypto } from "crypto";
 import { WritableStream } from "stream/web";
-import { DOMException } from "@miniflare/core";
+import { DOMException } from "./domexception";
 import { viewToBuffer } from "@miniflare/shared";
 import {
   assertsInRequest,

--- a/packages/core/src/standards/encoding.ts
+++ b/packages/core/src/standards/encoding.ts
@@ -1,4 +1,4 @@
-import { DOMException } from "@miniflare/core";
+import { DOMException } from "./domexception";
 
 // Implementations of base64 functions adapted from Node.js:
 // https://github.com/nodejs/node/blob/1086468aa3d328d2eac00bf66058906553ecd209/lib/buffer.js#L1213-L1239

--- a/packages/core/src/standards/timers.ts
+++ b/packages/core/src/standards/timers.ts
@@ -1,4 +1,4 @@
-import { DOMException } from "@miniflare/core";
+import { DOMException } from "./domexception";
 import { assertInRequest, waitForOpenInputGate } from "@miniflare/shared";
 
 export type TimerFunction<Return> = <Args extends any[]>(


### PR DESCRIPTION
- switch `@miniflare/core` to use relative imports to its own files rather than self-referencing its package name
- should fix usage in `pnpm`-style package installation environments

fixes #663 