### PR TITLE
Bump `workerd` to `1.20230821.0` and bump versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@miniflare/root",
-  "version": "3.20230814.1",
+  "version": "3.20230821.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@miniflare/root",
-      "version": "3.20230814.1",
+      "version": "3.20230821.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -54,9 +54,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230814.1.tgz",
-      "integrity": "sha512-aQUO7q7qXl+SVtOiMMlVKLNOSeL6GX43RKeflwzsD74dGgyHPiSfw5KCvXhkVbyN7u+yYF6HyFdaIvHLfn5jyA==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230821.0.tgz",
+      "integrity": "sha512-P41/PwGU09AwjIg4HyadMxFHZgpibZ7LUzpnXGU+WvgqOQwxhY05xHlsXqDDR2oVkY1IIY+ReghBzn7OEwvppw==",
       "cpu": [
         "x64"
       ],
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230814.1.tgz",
-      "integrity": "sha512-U2mcgi+AiuI/4EY5Wk/GmygiNoCNw/V2mcHmxESqe4r6XbJYOzBdEsjnqJ05rqd0JlEM8m64jRtE6/qBnQHygg==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230821.0.tgz",
+      "integrity": "sha512-g0dPoHN7QOekp0zWnknkoObYCVnZ9qcpWW+VNFGG08lL/j730IQWY4dnbeho99yPHyoEW8SsiYGlB75CUL38gw==",
       "cpu": [
         "arm64"
       ],
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230814.1.tgz",
-      "integrity": "sha512-Q4kITXLTCuG2i2Z01fbb5AjVRRIf3+lS4ZVsFbTbIwtcOOG4Ozcw7ee7tKsFES7hFqR4Eg9gMG4/aS0mmi+L2g==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230821.0.tgz",
+      "integrity": "sha512-snHR2jzXR00XZSQ3mPBcWWMvqwSRI/ZjlJuEFU+VSkEg/SJKaftM3XApGG8fUSdcRifdd3BkSzpIrzsek8T6sg==",
       "cpu": [
         "x64"
       ],
@@ -99,9 +99,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230814.1.tgz",
-      "integrity": "sha512-BX5SaksXw+pkREVw3Rw2eSNXplqZw+14CcwW/5x/4oq/C6yn5qCvKxJfM7pukJGMI4wkJPOYops7B3g27FB/HA==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230821.0.tgz",
+      "integrity": "sha512-U/M0Aw0bPcVZn/Ok921BmAnyu9VYBJO7ToeAqXkS7+riV1QtM7awep1wvoJVfjqpicInZZu6g9bsJo1W6vzyNg==",
       "cpu": [
         "arm64"
       ],
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230814.1.tgz",
-      "integrity": "sha512-GWHqfyhsG/1wm2W8afkYX3q3fWXUWWD8NGtHfAs6ZVTHdW3mmYyMhKR0lc6ptBwz5i5aXRlP2S+CxxxwwDbKpw==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230821.0.tgz",
+      "integrity": "sha512-+QRkgLp+zMBaIGcCzFidTV0gLe7w0vswxCzgvY9QAWx0DRWrR1ihvLYdOWduFtD4RxhjRydIMTK2oZgjRpA7/w==",
       "cpu": [
         "x64"
       ],
@@ -5178,9 +5178,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230814.1.tgz",
-      "integrity": "sha512-zJeSEteXuAD+bpYJT8WvzTAHvIAkKPVxOV+Jy6zCLKz5e08N3OUbAF+wrvGWc8b2aB1sj+IYsdXfkv4puH+qXQ==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230821.0.tgz",
+      "integrity": "sha512-jLqa4zjQihfgkzoNMwkq39izZ3iAHrQQISPWVLc642j/J0mCus1HuKl89U3zbMNwWytwe0lcpMXNFTRYR8PR7A==",
       "hasInstallScript": true,
       "bin": {
         "workerd": "bin/workerd"
@@ -5189,11 +5189,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20230814.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20230814.1",
-        "@cloudflare/workerd-linux-64": "1.20230814.1",
-        "@cloudflare/workerd-linux-arm64": "1.20230814.1",
-        "@cloudflare/workerd-windows-64": "1.20230814.1"
+        "@cloudflare/workerd-darwin-64": "1.20230821.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20230821.0",
+        "@cloudflare/workerd-linux-64": "1.20230821.0",
+        "@cloudflare/workerd-linux-arm64": "1.20230821.0",
+        "@cloudflare/workerd-windows-64": "1.20230821.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -5445,7 +5445,7 @@
       }
     },
     "packages/miniflare": {
-      "version": "3.20230814.1",
+      "version": "3.20230821.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.8.0",
@@ -5459,7 +5459,7 @@
         "source-map-support": "0.5.21",
         "stoppable": "^1.1.0",
         "undici": "^5.22.1",
-        "workerd": "1.20230814.1",
+        "workerd": "1.20230821.0",
         "ws": "^8.11.0",
         "youch": "^3.2.2",
         "zod": "^3.20.6"
@@ -5485,7 +5485,7 @@
     },
     "packages/tre": {
       "name": "miniflare",
-      "version": "3.20230801.0",
+      "version": "3.20230821.0",
       "extraneous": true,
       "license": "MIT",
       "dependencies": {
@@ -5535,33 +5535,33 @@
       }
     },
     "@cloudflare/workerd-darwin-64": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230814.1.tgz",
-      "integrity": "sha512-aQUO7q7qXl+SVtOiMMlVKLNOSeL6GX43RKeflwzsD74dGgyHPiSfw5KCvXhkVbyN7u+yYF6HyFdaIvHLfn5jyA==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230821.0.tgz",
+      "integrity": "sha512-P41/PwGU09AwjIg4HyadMxFHZgpibZ7LUzpnXGU+WvgqOQwxhY05xHlsXqDDR2oVkY1IIY+ReghBzn7OEwvppw==",
       "optional": true
     },
     "@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230814.1.tgz",
-      "integrity": "sha512-U2mcgi+AiuI/4EY5Wk/GmygiNoCNw/V2mcHmxESqe4r6XbJYOzBdEsjnqJ05rqd0JlEM8m64jRtE6/qBnQHygg==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230821.0.tgz",
+      "integrity": "sha512-g0dPoHN7QOekp0zWnknkoObYCVnZ9qcpWW+VNFGG08lL/j730IQWY4dnbeho99yPHyoEW8SsiYGlB75CUL38gw==",
       "optional": true
     },
     "@cloudflare/workerd-linux-64": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230814.1.tgz",
-      "integrity": "sha512-Q4kITXLTCuG2i2Z01fbb5AjVRRIf3+lS4ZVsFbTbIwtcOOG4Ozcw7ee7tKsFES7hFqR4Eg9gMG4/aS0mmi+L2g==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230821.0.tgz",
+      "integrity": "sha512-snHR2jzXR00XZSQ3mPBcWWMvqwSRI/ZjlJuEFU+VSkEg/SJKaftM3XApGG8fUSdcRifdd3BkSzpIrzsek8T6sg==",
       "optional": true
     },
     "@cloudflare/workerd-linux-arm64": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230814.1.tgz",
-      "integrity": "sha512-BX5SaksXw+pkREVw3Rw2eSNXplqZw+14CcwW/5x/4oq/C6yn5qCvKxJfM7pukJGMI4wkJPOYops7B3g27FB/HA==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230821.0.tgz",
+      "integrity": "sha512-U/M0Aw0bPcVZn/Ok921BmAnyu9VYBJO7ToeAqXkS7+riV1QtM7awep1wvoJVfjqpicInZZu6g9bsJo1W6vzyNg==",
       "optional": true
     },
     "@cloudflare/workerd-windows-64": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230814.1.tgz",
-      "integrity": "sha512-GWHqfyhsG/1wm2W8afkYX3q3fWXUWWD8NGtHfAs6ZVTHdW3mmYyMhKR0lc6ptBwz5i5aXRlP2S+CxxxwwDbKpw==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230821.0.tgz",
+      "integrity": "sha512-+QRkgLp+zMBaIGcCzFidTV0gLe7w0vswxCzgvY9QAWx0DRWrR1ihvLYdOWduFtD4RxhjRydIMTK2oZgjRpA7/w==",
       "optional": true
     },
     "@cloudflare/workers-types": {
@@ -7717,7 +7717,7 @@
         "source-map-support": "0.5.21",
         "stoppable": "^1.1.0",
         "undici": "^5.22.1",
-        "workerd": "1.20230814.1",
+        "workerd": "1.20230821.0",
         "ws": "^8.11.0",
         "youch": "^3.2.2",
         "zod": "^3.20.6"
@@ -8615,15 +8615,15 @@
       "dev": true
     },
     "workerd": {
-      "version": "1.20230814.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230814.1.tgz",
-      "integrity": "sha512-zJeSEteXuAD+bpYJT8WvzTAHvIAkKPVxOV+Jy6zCLKz5e08N3OUbAF+wrvGWc8b2aB1sj+IYsdXfkv4puH+qXQ==",
+      "version": "1.20230821.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230821.0.tgz",
+      "integrity": "sha512-jLqa4zjQihfgkzoNMwkq39izZ3iAHrQQISPWVLc642j/J0mCus1HuKl89U3zbMNwWytwe0lcpMXNFTRYR8PR7A==",
       "requires": {
-        "@cloudflare/workerd-darwin-64": "1.20230814.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20230814.1",
-        "@cloudflare/workerd-linux-64": "1.20230814.1",
-        "@cloudflare/workerd-linux-arm64": "1.20230814.1",
-        "@cloudflare/workerd-windows-64": "1.20230814.1"
+        "@cloudflare/workerd-darwin-64": "1.20230821.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20230821.0",
+        "@cloudflare/workerd-linux-64": "1.20230821.0",
+        "@cloudflare/workerd-linux-arm64": "1.20230821.0",
+        "@cloudflare/workerd-windows-64": "1.20230821.0"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miniflare/root",
-  "version": "3.20230814.1",
+  "version": "3.20230821.0",
   "private": true,
   "description": "Fun, full-featured, fully-local simulator for Cloudflare Workers",
   "keywords": [

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniflare",
-  "version": "3.20230814.1",
+  "version": "3.20230821.0",
   "description": "Fun, full-featured, fully-local simulator for Cloudflare Workers",
   "keywords": [
     "cloudflare",
@@ -38,7 +38,7 @@
     "source-map-support": "0.5.21",
     "stoppable": "^1.1.0",
     "undici": "^5.22.1",
-    "workerd": "1.20230814.1",
+    "workerd": "1.20230821.0",
     "ws": "^8.11.0",
     "youch": "^3.2.2",
     "zod": "^3.20.6"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,7 +17,7 @@ git fetch origin tre:tre
 git checkout -b "${USER}/v${MINIFLARE_VERSION}" tre
 
 # update workerd
-npm install --workspace miniflare "workerd@${WORKERD_VERSION}"
+npm install --workspace miniflare --save-exact "workerd@${WORKERD_VERSION}"
 
 # bump version and commit and tag release
 npm version "$MINIFLARE_VERSION" --force --include-workspace-root --workspace miniflare -m "Bump versions to %s"


### PR DESCRIPTION
...also adds `--save-exact` to the release script to ensure we don't accidentally add a `^` to the `workerd` version constraint. 👍 