### PR TITLE
[Miniflare 3] Return copy of entry URL from `Miniflare#ready`

### DIFF
--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1071,7 +1071,8 @@ export class Miniflare {
     // called by `#init()`, and `#initPromise` doesn't resolve until `#init()`
     // returns.
     assert(this.#runtimeEntryURL !== undefined);
-    return this.#runtimeEntryURL;
+    // Return a copy so external mutations don't propagate to `#runtimeEntryURL`
+    return new URL(this.#runtimeEntryURL.toString());
   }
   get ready(): Promise<URL> {
     return this.#waitForReady();

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -77,6 +77,21 @@ test("Miniflare: validates options", async (t) => {
   );
 });
 
+test("Miniflare: ready returns copy of entry URL", async (t) => {
+  const mf = new Miniflare({
+    port: 0,
+    modules: true,
+    script: "",
+  });
+  t.teardown(() => mf.dispose());
+
+  const url1 = await mf.ready;
+  url1.protocol = "ws:";
+  const url2 = await mf.ready;
+  t.not(url1, url2);
+  t.is(url2.protocol, "http:");
+});
+
 test("Miniflare: keeps port between updates", async (t) => {
   const opts: MiniflareOptions = {
     port: 0,


### PR DESCRIPTION
Hey! 👋 There are cases where mutating the URL returned from `Miniflare#ready` may be desirable, e.g. changing the protocol to `ws:` and using the `ws` module to establish a WebSocket connection. Previously, doing this would break Miniflare's `dispatchFetch`, as the returned URL was Miniflare's own internal reference. This change makes sure we return a copy.