### PR TITLE
[Miniflare 3] Remove unused `handleQueue()` function from entry worker

### DIFF
--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -523,9 +523,7 @@ export function getGlobalServices({
       durableObjectNamespace: { className: "ProxyServer" },
     },
     // Add `proxyBindings` here, they'll be added to the `ProxyServer` `env`.
-    // It would be nice if we didn't add all these bindings to the entry worker,
-    // but the entry worker shares lots of `devalue` code with the proxy, and
-    // we'd rather not duplicate that.
+    // TODO(someday): consider making the proxy server a separate worker
     ...proxyBindings,
   ];
   if (sharedOptions.upstream !== undefined) {

--- a/packages/miniflare/src/workers/core/constants.ts
+++ b/packages/miniflare/src/workers/core/constants.ts
@@ -3,7 +3,6 @@ export const CoreHeaders = {
   ORIGINAL_URL: "MF-Original-URL",
   ERROR_STACK: "MF-Experimental-Error-Stack",
   ROUTE_OVERRIDE: "MF-Route-Override",
-  CUSTOM_EVENT: "MF-Custom-Event",
 
   // API Proxy
   OP: "MF-Op",


### PR DESCRIPTION
With #656, the Queues dispatcher is now implemented as part of the broker Durable Object. We no longer send message batches directly from Node.js, so can remove queue handling from the entry worker.

Note the magic proxy enqueues messages through queue producer bindings like regular workers, so never used this endpoint directly.