### PR TITLE
[Miniflare 3] Allow custom `workerd` binary via `MINIFLARE_WORKERD_PATH` variable

### DIFF
--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -75,7 +75,7 @@ export class Runtime {
   #processExitPromise?: Promise<void>;
 
   constructor(private opts: RuntimeOptions) {
-    this.#command = workerdPath;
+    this.#command = process.env.MINIFLARE_WORKERD_PATH ?? workerdPath;
   }
 
   get #args() {

--- a/packages/miniflare/test/fixtures/little-workerd.mjs
+++ b/packages/miniflare/test/fixtures/little-workerd.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import assert from "assert";
+import fs from "fs";
+import http from "http";
+import { arrayBuffer } from "stream/consumers";
+
+// Consume but otherwise ignore stdin (assuming config passed via stdin)
+await arrayBuffer(process.stdin);
+
+// Start server...
+const server = http.createServer((req, res) => {
+  res.end("When I grow up, I want to be a big workerd!");
+});
+server.listen(0, () => {
+  // ...and report port to parent via control fd
+  assert(process.argv.includes("--control-fd=3"));
+  const stream = fs.createWriteStream(null, { fd: 3 });
+  const port = server.address().port;
+  const message = JSON.stringify({ event: "listen", socket: "entry", port });
+  stream.write( `${message}\n`);
+});

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -2,6 +2,7 @@ declare namespace NodeJS {
   export interface ProcessEnv {
     NODE_ENV?: string;
     NODE_EXTRA_CA_CERTS?: string;
+    MINIFLARE_WORKERD_PATH?: string;
     MINIFLARE_ASSERT_BODIES_CONSUMED?: "true";
   }
 }


### PR DESCRIPTION
Hey! 👋 This change allows a custom `workerd` binary to be used when running Miniflare, by setting the `MINIFLARE_WORKERD_PATH` environment variable. This is an environment variable, not a config option, so it can be customised when running Miniflare through Wrangler too. This will very useful for debugging issues.