### PR TITLE
[Miniflare 3] Switch Miniflare's CI back to Node 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [16.13.0, 18]
+        node: [16.13.0, 20]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Hey! 👋 We switched to Node 18 as part of #623, to get around cloudflare/workers-sdk#3626. Now that Miniflare's simulators are implemented as Durable Objects, we no longer hit the erroneous Node code paths, so can switch back to version 20.