### PR TITLE
decouple MF-Original-URL header from disabling the pretty-error page

### DIFF
--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1155,6 +1155,7 @@ export class Miniflare {
     const forward = new Request(input, init);
     const url = new URL(forward.url);
     forward.headers.set(CoreHeaders.ORIGINAL_URL, url.toString());
+    forward.headers.set(CoreHeaders.DISABLE_PRETTY_ERROR, "");
     url.protocol = this.#runtimeEntryURL.protocol;
     url.host = this.#runtimeEntryURL.host;
     if (forward.cf) {

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1155,7 +1155,7 @@ export class Miniflare {
     const forward = new Request(input, init);
     const url = new URL(forward.url);
     forward.headers.set(CoreHeaders.ORIGINAL_URL, url.toString());
-    forward.headers.set(CoreHeaders.DISABLE_PRETTY_ERROR, "");
+    forward.headers.set(CoreHeaders.DISABLE_PRETTY_ERROR, "true");
     url.protocol = this.#runtimeEntryURL.protocol;
     url.host = this.#runtimeEntryURL.host;
     if (forward.cf) {

--- a/packages/miniflare/src/workers/core/constants.ts
+++ b/packages/miniflare/src/workers/core/constants.ts
@@ -1,6 +1,7 @@
 export const CoreHeaders = {
   CUSTOM_SERVICE: "MF-Custom-Service",
   ORIGINAL_URL: "MF-Original-URL",
+  DISABLE_PRETTY_ERROR: "MF-Disable-Pretty-Error",
   ERROR_STACK: "MF-Experimental-Error-Stack",
   ROUTE_OVERRIDE: "MF-Route-Override",
 

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -57,6 +57,7 @@ function getUserRequest(
     request = new Request(request, { cf: env[CoreBindings.JSON_CF_BLOB] });
   }
   request.headers.delete(CoreHeaders.ORIGINAL_URL);
+  request.headers.delete(CoreHeaders.DISABLE_PRETTY_ERROR);
   return request;
 }
 
@@ -208,11 +209,11 @@ export default <ExportedHandler<Env>>{
     const isProxy = request.headers.get(CoreHeaders.OP) !== null;
     if (isProxy) return handleProxy(request, env);
 
-    // `dispatchFetch()` will always inject the passed URL as a header. When
+    // `dispatchFetch()` will always inject this header. When
     // calling this function, we never want to display the pretty-error page.
     // Instead, we propagate the error and reject the returned `Promise`.
-    const isDispatchFetch =
-      request.headers.get(CoreHeaders.ORIGINAL_URL) !== null;
+    const disablePrettyErrorPage =
+      request.headers.get(CoreHeaders.DISABLE_PRETTY_ERROR) !== null;
 
     request = getUserRequest(request, env);
     const url = new URL(request.url);
@@ -227,7 +228,7 @@ export default <ExportedHandler<Env>>{
       }
 
       let response = await service.fetch(request);
-      if (!isDispatchFetch) {
+      if (!disablePrettyErrorPage) {
         response = await maybePrettifyError(request, response, env);
       }
       response = maybeInjectLiveReload(response, env, ctx);


### PR DESCRIPTION
See https://jira.cfdata.org/browse/DEVX-945 for context

TL;DR this PR decouples the `MF-Original-URL` header from disabling the pretty-error page and instead uses an explicit `MF-Disable-Pretty-Error` header to disable it.

This allows `MF-Original-URL` to be set without disabling the pretty-error page.