### PR TITLE
Ensure path is relative

### DIFF
--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -40,7 +40,7 @@ function getUserRequest(
     // If a custom `upstream` was specified, make sure the URL starts with it
     let path = url.pathname + url.search;
     // Remove leading slash, so we resolve relative to `upstream`'s path
-    if (path.startsWith("/")) path = path.substring(1);
+    if (path.startsWith("/")) path = `./${path.substring(1)}`;
     url = new URL(path, upstreamUrl);
   }
 

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -514,7 +514,24 @@ test("Miniflare: fetch mocking", async (t) => {
     }
   );
 });
-
+test("Miniflare: custom upstream as origin (with colons)", async (t) => {
+  const upstream = await useServer(t, (req, res) => {
+    res.end(`upstream: ${new URL(req.url ?? "", "http://upstream")}`);
+  });
+  const mf = new Miniflare({
+    upstream: new URL("/extra:extra/", upstream.http.toString()).toString(),
+    modules: true,
+    script: `export default {
+      fetch(request) {
+        return fetch(request);
+      }
+    }`,
+  });
+  t.teardown(() => mf.dispose());
+  // Check rewrites protocol, hostname, and port, but keeps pathname and query
+  const res = await mf.dispatchFetch("https://random:0/path:path?a=1");
+  t.is(await res.text(), "upstream: http://upstream/extra:extra/path:path?a=1");
+});
 test("Miniflare: custom upstream as origin", async (t) => {
   const upstream = await useServer(t, (req, res) => {
     res.end(`upstream: ${new URL(req.url ?? "", "http://upstream")}`);


### PR DESCRIPTION
Fixes https://github.com/cloudflare/miniflare/issues/698. Previously paths which included a colon were being parsed as hostname + port