### PR TITLE
[Miniflare 3] Fix `Miniflare#dispose()` immediately after `new Miniflare()`

### DIFF
--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import childProcess from "child_process";
-import type { Abortable } from "events";
+import { Abortable, once } from "events";
 import rl from "readline";
 import { Readable } from "stream";
 import { red } from "kleur/colors";
@@ -146,9 +146,10 @@ export class Runtime {
     const controlPipe = runtimeProcess.stdio[3];
     assert(controlPipe instanceof Readable);
 
-    // 3. Write config
+    // 3. Write config, and wait for writing to finish
     runtimeProcess.stdin.write(configBuffer);
     runtimeProcess.stdin.end();
+    await once(runtimeProcess.stdin, "finish");
 
     // 4. Wait for sockets to start listening
     return waitForPorts(controlPipe, options);

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -709,6 +709,12 @@ test("Miniflare: listens on ipv6", async (t) => {
   t.true(response.ok);
 });
 
+test("Miniflare: dispose() immediately after construction", async (t) => {
+  const mf = new Miniflare({ script: "", modules: true });
+  await mf.dispose();
+  t.pass();
+});
+
 test("Miniflare: getBindings() returns all bindings", async (t) => {
   const tmp = await useTmp(t);
   const blobPath = path.join(tmp, "blob.txt");


### PR DESCRIPTION
We previously waited for Miniflare to be ready before `dispose()`ing. Unfortunately, we weren't waiting for the `workerd` config to finish being written to stdin. Calling `dispose()` immediately after `new Miniflare()` would stop waiting for socket ports to be reported, and kill the `workerd` process while data was still being written. This threw an unhandled `EPIPE` error.

This changes makes sure we don't report that Miniflare is ready until after the config is fully-written.

Closes #680