### PR TITLE
[Miniflare 3] Use existing `//# sourceURL` comments if present

### DIFF
--- a/packages/miniflare/src/plugins/core/modules.ts
+++ b/packages/miniflare/src/plugins/core/modules.ts
@@ -134,6 +134,10 @@ function moduleName(modulesRoot: string, modulePath: string) {
   return path.sep === "\\" ? name.replaceAll("\\", "/") : name;
 }
 export function withSourceURL(script: string, scriptPath: string): string {
+  // If we've already got a `//# sourceURL` comment, return `script` as is
+  // (searching from the end as that's where we'd expect it)
+  if (script.lastIndexOf("//# sourceURL=") !== -1) return script;
+
   let scriptURL: URL | string = scriptPath;
   if (maybeGetStringScriptPathIndex(scriptPath) === undefined) {
     scriptURL = pathToFileURL(scriptPath);


### PR DESCRIPTION
With Wrangler's new `find_additional_modules` support, there are cases where we'd like `//# sourceURL` not to be resolved from the module name/path. This change makes sure we don't insert this comment if it's already present, so Wrangler can add it.