### PR TITLE
[Miniflare 3] Add `getFetcher()` for dispatching `fetch`/`scheduled`/`queue` events

### DIFF
--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -598,6 +598,18 @@ defined at the top-level.
   bindings, for all bindings in the Worker with the specified `workerName`. If
   `workerName` is not specified, defaults to the entrypoint Worker.
 
+- `getFetcher(workerName?: string): Promise<Fetcher>`
+
+  Returns a `Promise` that resolves with a
+  [`Fetcher`](https://workers-types.pages.dev/experimental/#Fetcher) pointing to
+  the specified `workerName`. If `workerName` is not specified, defaults to the
+  entrypoint Worker. Note this `Fetcher` uses the experimental
+  [`service_binding_extra_handlers`](https://github.com/cloudflare/workerd/blob/1d9158af7ca1389474982c76ace9e248320bec77/src/workerd/io/compatibility-date.capnp#L290-L297)
+  compatibility flag to expose
+  [`scheduled()`](https://workers-types.pages.dev/experimental/#Fetcher.scheduled)
+  and [`queue()`](https://workers-types.pages.dev/experimental/#Fetcher.queue)
+  methods for dispatching `scheduled` and `queue` events.
+
 - `getCaches(): Promise<CacheStorage>`
 
   Returns a `Promise` that resolves with the

--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -598,7 +598,7 @@ defined at the top-level.
   bindings, for all bindings in the Worker with the specified `workerName`. If
   `workerName` is not specified, defaults to the entrypoint Worker.
 
-- `getFetcher(workerName?: string): Promise<Fetcher>`
+- `getWorker(workerName?: string): Promise<Fetcher>`
 
   Returns a `Promise` that resolves with a
   [`Fetcher`](https://workers-types.pages.dev/experimental/#Fetcher) pointing to

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1400,7 +1400,7 @@ export class Miniflare {
 
     return bindings as Env;
   }
-  async getFetcher(workerName?: string): Promise<ReplaceWorkersTypes<Fetcher>> {
+  async getWorker(workerName?: string): Promise<ReplaceWorkersTypes<Fetcher>> {
     const proxyClient = await this._getProxyClient();
 
     // Find worker by name, defaulting to entrypoint worker if none specified

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -519,8 +519,7 @@ export function getGlobalServices({
       name: CoreBindings.DURABLE_OBJECT_NAMESPACE_PROXY,
       durableObjectNamespace: { className: "ProxyServer" },
     },
-    // Add `proxyBindings` here, they'll be added to the `ProxyServer` `env`.
-    // TODO(someday): consider making the proxy server a separate worker
+    // Add `proxyBindings` here, they'll be added to the `ProxyServer` `env`
     ...proxyBindings,
   ];
   if (sharedOptions.upstream !== undefined) {

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -794,7 +794,7 @@ test("Miniflare: getBindings() returns all bindings", async (t) => {
   };
   t.throws(() => bindings.KV.get("key"), expectations);
 });
-test("Miniflare: getFetcher() allows dispatching events directly", async (t) => {
+test("Miniflare: getWorker() allows dispatching events directly", async (t) => {
   const mf = new Miniflare({
     modules: true,
     script: `
@@ -836,7 +836,7 @@ test("Miniflare: getFetcher() allows dispatching events directly", async (t) => 
     }`,
   });
   t.teardown(() => mf.dispose());
-  const fetcher = await mf.getFetcher();
+  const fetcher = await mf.getWorker();
 
   // Check `Fetcher#scheduled()` (implicitly testing `Fetcher#fetch()`)
   let scheduledResult = await fetcher.scheduled({
@@ -943,14 +943,14 @@ test("Miniflare: getBindings() and friends return bindings for different workers
     message: '"c" worker not found',
   });
 
-  // Check `getFetcher()`
-  let fetcher = await mf.getFetcher();
+  // Check `getWorker()`
+  let fetcher = await mf.getWorker();
   t.is(await (await fetcher.fetch("http://localhost")).text(), "a");
-  fetcher = await mf.getFetcher("");
+  fetcher = await mf.getWorker("");
   t.is(await (await fetcher.fetch("http://localhost")).text(), "unnamed");
-  fetcher = await mf.getFetcher("b");
+  fetcher = await mf.getWorker("b");
   t.is(await (await fetcher.fetch("http://localhost")).text(), "b");
-  await t.throwsAsync(() => mf.getFetcher("c"), {
+  await t.throwsAsync(() => mf.getWorker("c"), {
     instanceOf: TypeError,
     message: '"c" worker not found',
   });


### PR DESCRIPTION
Hey! 👋  This change adds back support for dispatching `scheduled` and `queue` events directly. Miniflare 2 previously provided similar `dispatchScheduled()` and `dispatchQueue()` methods, but these implemented an inconsistent, non-standard API.

With `getFetcher()`, we're able to reuse magic proxy code to support arbitrary Workers APIs. This is important for `queue()`, which supports sending any structured serialisable as a message `body`.

`getFetcher()` also provides an idiomatic Miniflare API for dealing with multiple workers, matching that provided by `getBindings()`.