### PR TITLE
[Miniflare 3] Add additional traps to magic proxy stubs

### DIFF
--- a/packages/miniflare/src/workers/core/constants.ts
+++ b/packages/miniflare/src/workers/core/constants.ts
@@ -30,6 +30,10 @@ export const CoreBindings = {
 export const ProxyOps = {
   // Get the target or a property of the target
   GET: "GET",
+  // Get the descriptor for a property of the target
+  GET_OWN_DESCRIPTOR: "GET_OWN_DESCRIPTOR",
+  // Get the target's own property names
+  GET_OWN_KEYS: "GET_OWN_KEYS",
   // Call a method on the target
   CALL: "CALL",
   // Remove the strong reference to the target on the "heap", allowing it to be

--- a/packages/miniflare/test/plugins/core/proxy/client.spec.ts
+++ b/packages/miniflare/test/plugins/core/proxy/client.spec.ts
@@ -215,3 +215,26 @@ test("ProxyClient: returns empty ReadableStream synchronously", async (t) => {
   assert(objectBody != null);
   t.is(await text(objectBody.body), ""); // Synchronous empty stream access
 });
+test("ProxyClient: can `JSON.stringify()` proxies", async (t) => {
+  const mf = new Miniflare({ script: nullScript, r2Buckets: ["BUCKET"] });
+  t.teardown(() => mf.dispose());
+
+  const bucket = await mf.getR2Bucket("BUCKET");
+  const object = await bucket.put("key", "value");
+  assert(object !== null);
+  t.is(Object.getPrototypeOf(object), null);
+  const plainObject = JSON.parse(JSON.stringify(object));
+  t.deepEqual(plainObject, {
+    checksums: {
+      md5: "2063c1608d6e0baf80249c42e2be5804",
+    },
+    customMetadata: {},
+    etag: "2063c1608d6e0baf80249c42e2be5804",
+    httpEtag: '"2063c1608d6e0baf80249c42e2be5804"',
+    httpMetadata: {},
+    key: "key",
+    size: 5,
+    uploaded: object.uploaded.toISOString(),
+    version: object.version,
+  });
+});


### PR DESCRIPTION
Hey! 👋  This change adds `getOwnPropertyDescriptor`, `ownKeys` and `getPrototypeOf` traps to magic proxy stubs. The first two allow proxy stubs to be `JSON.stringify`ed. The last ensures proxies aren't detected as plain objects.