### PR TITLE
Miniflare3: Add Content-Length and FixedLengthStream to R2 get response

### DIFF
--- a/packages/miniflare/src/workers/r2/bucket.worker.ts
+++ b/packages/miniflare/src/workers/r2/bucket.worker.ts
@@ -184,6 +184,7 @@ function encodeResult(
     headers: {
       [R2Headers.METADATA_SIZE]: `${encoded.metadataSize}`,
       "Content-Type": "application/json",
+      "Content-Length": `${encoded.size}`,
     },
   });
 }


### PR DESCRIPTION
Before this, we would see that the following code wouldn't work:
```
  const res = await env.BUCKET.get(name);
  await env.BUCKET.put(name, res!.body);
```

As it would throw:
	TypeError: Provided readable stream must have a known length (request/response body or readable half of FixedLengthStream)