### PR TITLE
[Miniflare 3] Re-enable concurrent `dispatchFetch()`s and batch proxy heap frees 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:fix": "npm run lint -- --fix",
     "prepublishOnly": "npm run lint && npm run clean && npm run build && npm run types:bundle && npm run test",
     "release": "./scripts/release.sh",
-    "test": "npm run build && ava --serial && rimraf ./.tmp",
+    "test": "npm run build && ava && rimraf ./.tmp",
     "types:build": "tsc && tsc -p packages/miniflare/src/workers/tsconfig.json",
     "types:bundle": "npm run types:build && node scripts/types.mjs"
   },

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -21,7 +21,7 @@ import type {
 import exitHook from "exit-hook";
 import { $ as colors$ } from "kleur/colors";
 import stoppable from "stoppable";
-import { Client } from "undici";
+import { Dispatcher, Pool } from "undici";
 import SCRIPT_MINIFLARE_SHARED from "worker:shared/index";
 import SCRIPT_MINIFLARE_ZOD from "worker:shared/zod";
 import { WebSocketServer } from "ws";
@@ -556,7 +556,7 @@ export class Miniflare {
   readonly #removeRuntimeExitHook?: () => void;
   #runtimeEntryURL?: URL;
   #socketPorts?: SocketPorts;
-  #runtimeClient?: Client;
+  #runtimeDispatcher?: Dispatcher;
   #proxyClient?: ProxyClient;
 
   // Path to temporary directory for use as scratch space/"in-memory" Durable
@@ -1136,10 +1136,10 @@ export class Miniflare {
       `${secure ? "https" : "http"}://${accessibleHost}:${entryPort}`
     );
     if (previousEntryURL?.toString() !== this.#runtimeEntryURL.toString()) {
-      this.#runtimeClient = new Client(this.#runtimeEntryURL, {
+      this.#runtimeDispatcher = new Pool(this.#runtimeEntryURL, {
         connect: { rejectUnauthorized: false },
       });
-      registerAllowUnauthorizedDispatcher(this.#runtimeClient);
+      registerAllowUnauthorizedDispatcher(this.#runtimeDispatcher);
     }
     if (this.#proxyClient === undefined) {
       this.#proxyClient = new ProxyClient(
@@ -1290,7 +1290,7 @@ export class Miniflare {
     await this.ready;
 
     assert(this.#runtimeEntryURL !== undefined);
-    assert(this.#runtimeClient !== undefined);
+    assert(this.#runtimeDispatcher !== undefined);
 
     const forward = new Request(input, init);
     const url = new URL(forward.url);
@@ -1312,7 +1312,7 @@ export class Miniflare {
     }
 
     const forwardInit = forward as RequestInit;
-    forwardInit.dispatcher = this.#runtimeClient;
+    forwardInit.dispatcher = this.#runtimeDispatcher;
     const response = await fetch(url, forwardInit);
 
     // If the Worker threw an uncaught exception, propagate it to the caller

--- a/packages/miniflare/src/workers/core/proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/proxy.worker.ts
@@ -140,11 +140,13 @@ export class ProxyServer implements DurableObject {
     // Get target to perform operations on
     if (targetHeader === null) return new Response(null, { status: 400 });
 
-    // If this is a FREE operation, remove the target from the heap
+    // If this is a FREE operation, remove the target(s) from the heap
     if (opHeader === ProxyOps.FREE) {
-      const targetAddress = parseInt(targetHeader);
-      assert(!Number.isNaN(targetAddress));
-      this.heap.delete(targetAddress);
+      for (const targetValue of targetHeader.split(",")) {
+        const targetAddress = parseInt(targetValue);
+        assert(!Number.isNaN(targetAddress));
+        this.heap.delete(targetAddress);
+      }
       return new Response(null, { status: 204 });
     }
 


### PR DESCRIPTION
In order to fix tests when adding the magic proxy, we restricted `dispatchFetch()` to one concurrent TCP connection. Unfortunately, this prevented long-lived `dispatchFetch()` requests.

When proxies are garbage collected, we send a network request to `workerd` to free the corresponding entry in the `ProxyServer` heap. Garbage collection often happens in phases though, freeing lots of objects at once. This caused many concurrent requests to `workerd` (~60 in some tests), leading to many TCP connections being created.

This change re-enables using multiple TCP connections, and attempts to address the root cause of the issues we were seeing, by batching frees before sending the network request.