### PR TITLE
[Miniflare 3] Avoid using temporary directory if possible

### DIFF
--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -943,6 +943,8 @@ export class Miniflare {
       }
 
       // Collect all services required by this worker
+      const unsafeEphemeralDurableObjects =
+        workerOpts.core.unsafeEphemeralDurableObjects ?? false;
       const pluginServicesOptionsBase: Omit<
         PluginServicesOptions<z.ZodTypeAny, undefined>,
         "options" | "sharedOptions"
@@ -954,6 +956,7 @@ export class Miniflare {
         tmpPath: this.#tmpPath,
         workerNames,
         durableObjectClassNames,
+        unsafeEphemeralDurableObjects,
         queueConsumers,
       };
       for (const [key, plugin] of PLUGIN_ENTRIES) {

--- a/packages/miniflare/src/plugins/do/index.ts
+++ b/packages/miniflare/src/plugins/do/index.ts
@@ -71,7 +71,12 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin<
     const objects = Object.keys(options.durableObjects ?? {});
     return Object.fromEntries(objects.map((name) => [name, kProxyNodeBinding]));
   },
-  async getServices({ sharedOptions, tmpPath, durableObjectClassNames }) {
+  async getServices({
+    sharedOptions,
+    tmpPath,
+    durableObjectClassNames,
+    unsafeEphemeralDurableObjects,
+  }) {
     // Check if we even have any Durable Object bindings, if we don't, we can
     // skip creating the storage directory
     let hasDurableObjects = false;
@@ -82,6 +87,11 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin<
       }
     }
     if (!hasDurableObjects) return;
+
+    // If this worker has enabled `unsafeEphemeralDurableObjects`, it won't need
+    // the Durable Object storage service. If all workers have this enabled, we
+    // don't need to create the storage service at all.
+    if (unsafeEphemeralDurableObjects) return;
 
     const storagePath = getPersistPath(
       DURABLE_OBJECTS_PLUGIN_NAME,

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -40,6 +40,7 @@ export interface PluginServicesOptions<
 
   // ~~Leaky abstractions~~ "Plugin specific options" :)
   durableObjectClassNames: DurableObjectClassNames;
+  unsafeEphemeralDurableObjects: boolean;
   queueConsumers: QueueConsumers;
 }
 


### PR DESCRIPTION
Miniflare 2 persisted data in-memory between `setOptions()` calls when `*Persist` options were disabled. Whilst `workerd` has in-memory storage for Durable Objects, this is reset when `workerd` is restarted (i.e. when `setOptions()` is called). To retain Miniflare 2 behaviour in Miniflare 3, we actually persist to a temporary directory when `*Persist` options are disabled. There are cases where we don't need the temporary directory though: if we have no storage bindings configured, `cache` is `false`, and `unsafeEphemeralDurableObjects` is `true`. This change ensures we don't write to the temporary directory in these cases.

Ref: https://github.com/cloudflare/workers-sdk/issues/4167