### PR TITLE
Fix `fetcher.fetch()` internal url

### DIFF
--- a/packages/miniflare/src/workers/core/proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/proxy.worker.ts
@@ -184,11 +184,15 @@ export class ProxyServer implements DurableObject {
 
       // See `isFetcherFetch()` comment for why this special
       if (isFetcherFetch(targetName, keyHeader)) {
-        // Create a new request to allow header mutation
-        request = new Request(request);
+        const originalUrl = request.headers.get(CoreHeaders.ORIGINAL_URL);
+        const url = new URL(originalUrl ?? request.url);
+        // Create a new request to allow header mutation and use original URL
+        request = new Request(url, request);
         request.headers.delete(CoreHeaders.OP);
         request.headers.delete(CoreHeaders.OP_TARGET);
         request.headers.delete(CoreHeaders.OP_KEY);
+        request.headers.delete(CoreHeaders.ORIGINAL_URL);
+        request.headers.delete(CoreHeaders.DISABLE_PRETTY_ERROR);
         return func.call(target, request);
       }
 

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -818,6 +818,8 @@ test("Miniflare: getWorker() allows dispatching events directly", async (t) => {
               bodyType: message.body.constructor.name,
             })),
           });
+        } else if (pathname === "/get-url") {
+          return new Response(request.url);
         } else {
           return new Response(null, { status: 404 });
         }
@@ -899,6 +901,10 @@ test("Miniflare: getWorker() allows dispatching events directly", async (t) => {
       },
     ],
   });
+
+  // Check `Fetcher#fetch()`
+  res = await fetcher.fetch("https://dummy:1234/get-url");
+  t.is(await res.text(), "https://dummy:1234/get-url");
 });
 test("Miniflare: getBindings() and friends return bindings for different workers", async (t) => {
   const mf = new Miniflare({


### PR DESCRIPTION
This PR fixes #721 

Now the origin passed to `Fetcher.fetch(url)` is what is seen inside the worker in `request.url`