### PR TITLE
[Miniflare 3] Bump workerd to `1.20231025.0` and enable coloured logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@miniflare/root",
-  "version": "3.20231023.0",
+  "version": "3.20231025.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@miniflare/root",
-      "version": "3.20231023.0",
+      "version": "3.20231025.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -60,6 +60,81 @@
       "dev": true,
       "dependencies": {
         "mime": "^3.0.0"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231025.0.tgz",
+      "integrity": "sha512-MYRYTbSl+tjGg6su7savlLIb8cOcKJfdGpA+WdtgqT2OF7O+89Lag0l1SA/iyVlUkT31Jc6OLHqvzsXgmg+niQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231025.0.tgz",
+      "integrity": "sha512-BszjtBDR84TVa6oWe74dePJSAukWlTmLw9zR4KeWuwZLJGV7RMm6AmwGStetjnwZrecZaaOFELfBCAHtsebV0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231025.0.tgz",
+      "integrity": "sha512-AT9dxgKXOa9xZxZ3k2a432axPJJ58KpoNWnPiPYGpuAuLoWnfcYwwh6mr9sZVcTdAdTAK9Xu9c81tp0YABanUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231025.0.tgz",
+      "integrity": "sha512-EIjex5o2k80YZWPix1btGybL/vNZ3o6vqKX9ptS0JcFkHV5aFX5/kcMwSBRjiIC+w04zVjmGQx3N1Vh3njuncg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231025.0.tgz",
+      "integrity": "sha512-7vtq0mO22A2v0OOsKXa760r9a84Gg8CK0gDu5uNWlj6hojmt011iz7jJt76I7oo/XrVwVlVfu69GnA3ljx6U8w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@cloudflare/workers-types": {
@@ -4766,6 +4841,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/workerd": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231025.0.tgz",
+      "integrity": "sha512-W1PFtpMFfvmm+ozBf+u70TE3Pviv7WA4qzDeejHDC4z+PFDq4+3KJCkgffaGBO86h+akWO0hSsc0uXL2zAqofQ==",
+      "hasInstallScript": true,
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20231025.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20231025.0",
+        "@cloudflare/workerd-linux-64": "1.20231025.0",
+        "@cloudflare/workerd-linux-arm64": "1.20231025.0",
+        "@cloudflare/workerd-windows-64": "1.20231025.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "dev": true,
@@ -5017,7 +5111,7 @@
       }
     },
     "packages/miniflare": {
-      "version": "3.20231023.0",
+      "version": "3.20231025.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.8.0",
@@ -5028,7 +5122,7 @@
         "source-map-support": "0.5.21",
         "stoppable": "^1.1.0",
         "undici": "^5.22.1",
-        "workerd": "1.20231023.0",
+        "workerd": "1.20231025.0",
         "ws": "^8.11.0",
         "youch": "^3.2.2",
         "zod": "^3.20.6"
@@ -5052,103 +5146,9 @@
         "node": ">=16.13"
       }
     },
-    "packages/miniflare/node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20231023.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231023.0.tgz",
-      "integrity": "sha512-/xnC/pe4xVuWPVEP0e6LdFuRL8cCFKdlcpWkvVKU4Y/WygtS7YSzMRIh3AbCbwqlo2MGQBI9xjclG7/R9y8G5A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/miniflare/node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20231023.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231023.0.tgz",
-      "integrity": "sha512-7cXxIA65K3njJlYC+ofj6u5l0ZIrLRuL9iakTVEPc/3+NqII6Ux6aFdcaGlYJE9rX0R3Z/gQB0Bi+WVtb5U+VQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/miniflare/node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20231023.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231023.0.tgz",
-      "integrity": "sha512-OwHaazD35cpLTtoyHmJdBeBJ+xiYQeGaw5m05XWlSnZ7A8PMICQg5vgS7xL9X+lSce0frPS/yxBmMDsnGOaRrg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/miniflare/node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20231023.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231023.0.tgz",
-      "integrity": "sha512-Ug1uBmR59dIOCh0NCrz8x4j25fzvv0dEZfdSKWJbt8hu04bq31EpQbxYzRwa2KJO0oK28n1+QJ1+3D3DsR8vtQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/miniflare/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20231023.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231023.0.tgz",
-      "integrity": "sha512-guQ20xyUOH+HlURSp/cku2X8bRBnO9fsMVevX1sGql6hcIjJzrIgaYphh+m4AxBa+i7p42DTZgdrHNtW6FQDkw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/miniflare/node_modules/workerd": {
-      "version": "1.20231023.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231023.0.tgz",
-      "integrity": "sha512-rbMeTo4t2wqO0FmIqULChNEKKH0YJKuFDVH5lw4g3XPOeCY82LDC0n/vkaHFPCeCD3FiSA5HXKhofIou7PRwiw==",
-      "hasInstallScript": true,
-      "bin": {
-        "workerd": "bin/workerd"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20231023.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20231023.0",
-        "@cloudflare/workerd-linux-64": "1.20231023.0",
-        "@cloudflare/workerd-linux-arm64": "1.20231023.0",
-        "@cloudflare/workerd-windows-64": "1.20231023.0"
-      }
-    },
     "packages/tre": {
       "name": "miniflare",
-      "version": "3.20231010.0",
+      "version": "3.20231025.0",
       "extraneous": true,
       "license": "MIT",
       "dependencies": {
@@ -5205,6 +5205,36 @@
       "requires": {
         "mime": "^3.0.0"
       }
+    },
+    "@cloudflare/workerd-darwin-64": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231025.0.tgz",
+      "integrity": "sha512-MYRYTbSl+tjGg6su7savlLIb8cOcKJfdGpA+WdtgqT2OF7O+89Lag0l1SA/iyVlUkT31Jc6OLHqvzsXgmg+niQ==",
+      "optional": true
+    },
+    "@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231025.0.tgz",
+      "integrity": "sha512-BszjtBDR84TVa6oWe74dePJSAukWlTmLw9zR4KeWuwZLJGV7RMm6AmwGStetjnwZrecZaaOFELfBCAHtsebV0Q==",
+      "optional": true
+    },
+    "@cloudflare/workerd-linux-64": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231025.0.tgz",
+      "integrity": "sha512-AT9dxgKXOa9xZxZ3k2a432axPJJ58KpoNWnPiPYGpuAuLoWnfcYwwh6mr9sZVcTdAdTAK9Xu9c81tp0YABanUw==",
+      "optional": true
+    },
+    "@cloudflare/workerd-linux-arm64": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231025.0.tgz",
+      "integrity": "sha512-EIjex5o2k80YZWPix1btGybL/vNZ3o6vqKX9ptS0JcFkHV5aFX5/kcMwSBRjiIC+w04zVjmGQx3N1Vh3njuncg==",
+      "optional": true
+    },
+    "@cloudflare/workerd-windows-64": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231025.0.tgz",
+      "integrity": "sha512-7vtq0mO22A2v0OOsKXa760r9a84Gg8CK0gDu5uNWlj6hojmt011iz7jJt76I7oo/XrVwVlVfu69GnA3ljx6U8w==",
+      "optional": true
     },
     "@cloudflare/workers-types": {
       "version": "4.20231002.0",
@@ -7279,54 +7309,10 @@
         "source-map-support": "0.5.21",
         "stoppable": "^1.1.0",
         "undici": "^5.22.1",
-        "workerd": "1.20231023.0",
+        "workerd": "1.20231025.0",
         "ws": "^8.11.0",
         "youch": "^3.2.2",
         "zod": "^3.20.6"
-      },
-      "dependencies": {
-        "@cloudflare/workerd-darwin-64": {
-          "version": "1.20231023.0",
-          "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231023.0.tgz",
-          "integrity": "sha512-/xnC/pe4xVuWPVEP0e6LdFuRL8cCFKdlcpWkvVKU4Y/WygtS7YSzMRIh3AbCbwqlo2MGQBI9xjclG7/R9y8G5A==",
-          "optional": true
-        },
-        "@cloudflare/workerd-darwin-arm64": {
-          "version": "1.20231023.0",
-          "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231023.0.tgz",
-          "integrity": "sha512-7cXxIA65K3njJlYC+ofj6u5l0ZIrLRuL9iakTVEPc/3+NqII6Ux6aFdcaGlYJE9rX0R3Z/gQB0Bi+WVtb5U+VQ==",
-          "optional": true
-        },
-        "@cloudflare/workerd-linux-64": {
-          "version": "1.20231023.0",
-          "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231023.0.tgz",
-          "integrity": "sha512-OwHaazD35cpLTtoyHmJdBeBJ+xiYQeGaw5m05XWlSnZ7A8PMICQg5vgS7xL9X+lSce0frPS/yxBmMDsnGOaRrg==",
-          "optional": true
-        },
-        "@cloudflare/workerd-linux-arm64": {
-          "version": "1.20231023.0",
-          "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231023.0.tgz",
-          "integrity": "sha512-Ug1uBmR59dIOCh0NCrz8x4j25fzvv0dEZfdSKWJbt8hu04bq31EpQbxYzRwa2KJO0oK28n1+QJ1+3D3DsR8vtQ==",
-          "optional": true
-        },
-        "@cloudflare/workerd-windows-64": {
-          "version": "1.20231023.0",
-          "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231023.0.tgz",
-          "integrity": "sha512-guQ20xyUOH+HlURSp/cku2X8bRBnO9fsMVevX1sGql6hcIjJzrIgaYphh+m4AxBa+i7p42DTZgdrHNtW6FQDkw==",
-          "optional": true
-        },
-        "workerd": {
-          "version": "1.20231023.0",
-          "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231023.0.tgz",
-          "integrity": "sha512-rbMeTo4t2wqO0FmIqULChNEKKH0YJKuFDVH5lw4g3XPOeCY82LDC0n/vkaHFPCeCD3FiSA5HXKhofIou7PRwiw==",
-          "requires": {
-            "@cloudflare/workerd-darwin-64": "1.20231023.0",
-            "@cloudflare/workerd-darwin-arm64": "1.20231023.0",
-            "@cloudflare/workerd-linux-64": "1.20231023.0",
-            "@cloudflare/workerd-linux-arm64": "1.20231023.0",
-            "@cloudflare/workerd-windows-64": "1.20231023.0"
-          }
-        }
       }
     },
     "minimatch": {
@@ -8112,6 +8098,18 @@
     "word-wrap": {
       "version": "1.2.3",
       "dev": true
+    },
+    "workerd": {
+      "version": "1.20231025.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231025.0.tgz",
+      "integrity": "sha512-W1PFtpMFfvmm+ozBf+u70TE3Pviv7WA4qzDeejHDC4z+PFDq4+3KJCkgffaGBO86h+akWO0hSsc0uXL2zAqofQ==",
+      "requires": {
+        "@cloudflare/workerd-darwin-64": "1.20231025.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20231025.0",
+        "@cloudflare/workerd-linux-64": "1.20231025.0",
+        "@cloudflare/workerd-linux-arm64": "1.20231025.0",
+        "@cloudflare/workerd-windows-64": "1.20231025.0"
+      }
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miniflare/root",
-  "version": "3.20231023.0",
+  "version": "3.20231025.0",
   "private": true,
   "description": "Fun, full-featured, fully-local simulator for Cloudflare Workers",
   "keywords": [

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniflare",
-  "version": "3.20231023.0",
+  "version": "3.20231025.0",
   "description": "Fun, full-featured, fully-local simulator for Cloudflare Workers",
   "keywords": [
     "cloudflare",
@@ -35,7 +35,7 @@
     "source-map-support": "0.5.21",
     "stoppable": "^1.1.0",
     "undici": "^5.22.1",
-    "workerd": "1.20231023.0",
+    "workerd": "1.20231025.0",
     "ws": "^8.11.0",
     "youch": "^3.2.2",
     "zod": "^3.20.6"

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -3,7 +3,7 @@ import childProcess from "child_process";
 import { Abortable, once } from "events";
 import rl from "readline";
 import { Readable } from "stream";
-import { red } from "kleur/colors";
+import { $ as $colors, red } from "kleur/colors";
 import workerdPath, {
   compatibilityDate as supportedCompatibilityDate,
 } from "workerd";
@@ -135,9 +135,12 @@ export class Runtime {
     // 2. Start new process
     const command = getRuntimeCommand();
     const args = getRuntimeArgs(options);
+    // By default, `workerd` will only log with colours if it detects a TTY.
+    // `"pipe"` doesn't create a TTY, so we force enable colours if supported.
+    const FORCE_COLOR = $colors.enabled ? "1" : "0";
     const runtimeProcess = childProcess.spawn(command, args, {
       stdio: ["pipe", "pipe", "pipe", "pipe"],
-      env: process.env,
+      env: { ...process.env, FORCE_COLOR },
     });
     this.#process = runtimeProcess;
     this.#processExitPromise = waitForExit(runtimeProcess);


### PR DESCRIPTION
Hey! 👋 This PR bumps `workerd` to `1.20231025.0` to fix some issues with logging, and also makes sure logs are coloured when coloured output is supported. 👍 