### PR TITLE
[Miniflare 2] Use `scriptPath` if available as the `filePath` of the script

### DIFF
--- a/.changeset/empty-dogs-lie.md
+++ b/.changeset/empty-dogs-lie.md
@@ -1,0 +1,5 @@
+---
+"@miniflare/core": patch
+---
+
+Use scriptPath if available as the filePath of the script.

--- a/.changeset/empty-dogs-lie.md
+++ b/.changeset/empty-dogs-lie.md
@@ -1,5 +1,0 @@
----
-"@miniflare/core": patch
----
-
-Use scriptPath if available as the filePath of the script.

--- a/packages/core/src/plugins/core.ts
+++ b/packages/core/src/plugins/core.ts
@@ -668,7 +668,10 @@ export class CorePlugin extends Plugin<CoreOptions> implements CoreOptions {
       return {
         globals,
         additionalModules,
-        script: { filePath: STRING_SCRIPT_PATH, code: this.script },
+        script: {
+          filePath: this.scriptPath || STRING_SCRIPT_PATH,
+          code: this.script,
+        },
       };
     }
 

--- a/packages/core/src/plugins/core.ts
+++ b/packages/core/src/plugins/core.ts
@@ -669,7 +669,7 @@ export class CorePlugin extends Plugin<CoreOptions> implements CoreOptions {
         globals,
         additionalModules,
         script: {
-          filePath: this.scriptPath || STRING_SCRIPT_PATH,
+          filePath: this.scriptPath ?? STRING_SCRIPT_PATH,
           code: this.script,
         },
       };


### PR DESCRIPTION
Hi! 👋 

While adding support for HMR, we update our code, rebuild, and then call Miniflare's `setOptions(...)` to reload the code in Miniflare. However, Miniflare doesn't reload when using `scriptPath` because it caches its content.

Therefore, we switched to using `script: await readFile(scriptPath)` instead, and this forces Miniflare to update on every `setOptions` call.

The downside is that we broke sourcemaps 🙃 . The fix for sourcemaps looks like [this](https://github.com/Shopify/hydrogen/blob/ed3db11ede25bd7469e368b53a0f093c8c8b19d0/packages/mini-oxygen/src/mini-oxygen/core.ts#L48) (we look for `<script>` and then read the bundle sourcemap file). However, we still have step-debugging broken due to the same issue.

This change in Miniflare 2 fixes both, sourcemaps and step-debugging in VSCode when using `script` and `scriptPath` together because the latter will be used as the `filePath` of the script.

Alternatively, fixing the reloading of `scriptPath` is also possible -- but I already forgot where that part of the code was 😅 