### PR TITLE
[Miniflare 2] Bump `undici` to `5.28.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1570,6 +1570,14 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.2",
       "dev": true,
@@ -10350,14 +10358,14 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "dependencies": {
-        "busboy": "^1.6.0"
+        "@fastify/busboy": "^2.0.0"
       },
       "engines": {
-        "node": ">=12.18"
+        "node": ">=14.0"
       }
     },
     "node_modules/unique-string": {
@@ -11095,7 +11103,7 @@
         "@miniflare/core": "2.14.1",
         "@miniflare/shared": "2.14.1",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.14.1",
@@ -11137,7 +11145,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.20.0",
+        "undici": "5.28.2",
         "urlpattern-polyfill": "^4.0.3"
       },
       "devDependencies": {
@@ -11176,7 +11184,7 @@
         "@miniflare/core": "2.14.1",
         "@miniflare/shared": "2.14.1",
         "@miniflare/storage-memory": "2.14.1",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       },
       "devDependencies": {
         "@miniflare/cache": "2.14.1",
@@ -11195,7 +11203,7 @@
         "@miniflare/core": "2.14.1",
         "@miniflare/shared": "2.14.1",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.14.1"
@@ -11214,7 +11222,7 @@
         "@miniflare/web-sockets": "2.14.1",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.20.0",
+        "undici": "5.28.2",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
@@ -11296,7 +11304,7 @@
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -11347,7 +11355,7 @@
       "dependencies": {
         "@miniflare/core": "2.14.1",
         "@miniflare/shared": "2.14.1",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.14.1"
@@ -11516,7 +11524,7 @@
         "@miniflare/runner-vm": "2.14.1",
         "@miniflare/shared": "2.14.1",
         "@miniflare/shared-test-environment": "2.14.1",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.14.1",
@@ -11552,7 +11560,7 @@
       "dependencies": {
         "@miniflare/core": "2.14.1",
         "@miniflare/shared": "2.14.1",
-        "undici": "5.20.0",
+        "undici": "5.28.2",
         "ws": "^8.2.2"
       },
       "devDependencies": {
@@ -12530,6 +12538,11 @@
         }
       }
     },
+    "@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA=="
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.2",
       "dev": true,
@@ -12998,7 +13011,7 @@
         "@miniflare/web-sockets": "2.14.1",
         "@types/http-cache-semantics": "^4.0.1",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       }
     },
     "@miniflare/cli-parser": {
@@ -13029,7 +13042,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.20.0",
+        "undici": "5.28.2",
         "urlpattern-polyfill": "^4.0.3"
       }
     },
@@ -13050,7 +13063,7 @@
         "@miniflare/shared": "2.14.1",
         "@miniflare/shared-test": "2.14.1",
         "@miniflare/storage-memory": "2.14.1",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       }
     },
     "@miniflare/html-rewriter": {
@@ -13060,7 +13073,7 @@
         "@miniflare/shared": "2.14.1",
         "@miniflare/shared-test": "2.14.1",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       }
     },
     "@miniflare/http-server": {
@@ -13073,7 +13086,7 @@
         "@types/node-forge": "^0.10.4",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.20.0",
+        "undici": "5.28.2",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
@@ -13098,7 +13111,7 @@
         "@miniflare/core": "2.14.1",
         "@miniflare/shared": "2.14.1",
         "@miniflare/shared-test": "2.14.1",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       }
     },
     "@miniflare/runner-vm": {
@@ -13208,7 +13221,7 @@
         "@miniflare/shared": "2.14.1",
         "@miniflare/shared-test": "2.14.1",
         "@types/ws": "^8.2.0",
-        "undici": "5.20.0",
+        "undici": "5.28.2",
         "ws": "^8.2.2"
       }
     },
@@ -16668,7 +16681,7 @@
         "open": "^8.4.0",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.20.0"
+        "undici": "5.28.2"
       }
     },
     "minimatch": {
@@ -18458,11 +18471,11 @@
       }
     },
     "undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "requires": {
-        "busboy": "^1.6.0"
+        "@fastify/busboy": "^2.0.0"
       }
     },
     "unique-string": {
@@ -18706,7 +18719,7 @@
         "@miniflare/shared-test-environment": "2.14.1",
         "miniflare": "2.14.1",
         "react-dom": "^18.1.0",
-        "undici": "5.20.0",
+        "undici": "5.28.2",
         "vitest": "^0.34.3"
       }
     },

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.14.1",
     "@miniflare/shared": "2.14.1",
     "http-cache-semantics": "^4.1.0",
-    "undici": "5.20.0"
+    "undici": "5.28.2"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.14.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "dotenv": "^10.0.0",
     "kleur": "^4.1.4",
     "set-cookie-parser": "^2.4.8",
-    "undici": "5.20.0",
+    "undici": "5.28.2",
     "urlpattern-polyfill": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -796,14 +796,10 @@ class MiniflareDispatcher extends Dispatcher {
     options: Dispatcher.DispatchOptions,
     handler: Dispatcher.DispatchHandlers
   ): boolean {
+    // Remove any default fetch headers that the user didn't explicitly set,
+    // `headers` has the form `["key1", "value1", "key2", "value2", ...]`
     const headers = options.headers;
-    if (headers) {
-      // Note: I'm fully expecting this to break in future undici versions
-      // and need to be updated, but that's why we pin our undici version and
-      // have tests
-      assert(Array.isArray(headers));
-      // Remove any default fetch headers that the user didn't explicitly set,
-      // `headers` has the form `["key1", "value1", "key2", "value2", ...]`
+    if (Array.isArray(headers)) {
       let i = 0;
       while (i < headers.length) {
         if (this.removeHeaders.includes(headers[i].toLowerCase())) {
@@ -811,6 +807,10 @@ class MiniflareDispatcher extends Dispatcher {
         } else {
           i += 2;
         }
+      }
+    } else if (headers != null) {
+      for (const key in headers) {
+        if (this.removeHeaders.includes(key.toLowerCase())) delete headers[key];
       }
     }
     return this.inner.dispatch(options, handler);

--- a/packages/durable-objects/package.json
+++ b/packages/durable-objects/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.14.1",
     "@miniflare/shared": "2.14.1",
     "@miniflare/storage-memory": "2.14.1",
-    "undici": "5.20.0"
+    "undici": "5.28.2"
   },
   "devDependencies": {
     "@miniflare/cache": "2.14.1",

--- a/packages/html-rewriter/package.json
+++ b/packages/html-rewriter/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.14.1",
     "@miniflare/shared": "2.14.1",
     "html-rewriter-wasm": "^0.4.1",
-    "undici": "5.20.0"
+    "undici": "5.28.2"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.14.1"

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -40,7 +40,7 @@
     "@miniflare/web-sockets": "2.14.1",
     "kleur": "^4.1.4",
     "selfsigned": "^2.0.0",
-    "undici": "5.20.0",
+    "undici": "5.28.2",
     "ws": "^8.2.2",
     "youch": "^2.2.2"
   },

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -66,7 +66,7 @@
     "kleur": "^4.1.4",
     "semiver": "^1.1.0",
     "source-map-support": "^0.5.20",
-    "undici": "5.20.0"
+    "undici": "5.28.2"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.14.1",

--- a/packages/r2/package.json
+++ b/packages/r2/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@miniflare/core": "2.14.1",
     "@miniflare/shared": "2.14.1",
-    "undici": "5.20.0"
+    "undici": "5.28.2"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.14.1"

--- a/packages/vitest-environment-miniflare/package.json
+++ b/packages/vitest-environment-miniflare/package.json
@@ -41,7 +41,7 @@
     "@miniflare/queues": "2.14.1",
     "@miniflare/shared": "2.14.1",
     "@miniflare/shared-test-environment": "2.14.1",
-    "undici": "5.20.0"
+    "undici": "5.28.2"
   },
   "peerDependencies": {
     "vitest": ">=0.23.0"

--- a/packages/web-sockets/package.json
+++ b/packages/web-sockets/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@miniflare/core": "2.14.1",
     "@miniflare/shared": "2.14.1",
-    "undici": "5.20.0",
+    "undici": "5.28.2",
     "ws": "^8.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey! 👋 This PR bumps `undici` to `5.27.2`, addressing a low severity `npm audit` warning: https://github.com/advisories/GHSA-wqq4-5wpv-mx2g. I only needed to make a small change for tests to pass. 👍 

Fixes #607
Fixes #738