### PR TITLE
Remove reference to `Miniflare#getDurableObjectStorage()`

### DIFF
--- a/docs/src/content/storage/durable-objects.md
+++ b/docs/src/content/storage/durable-objects.md
@@ -36,9 +36,8 @@ const mf = new Miniflare({
 ## Persistence
 
 By default, Durable Object data is stored in memory. It will persist between
-reloads, but not different `Miniflare` instances. To enable
-persistence to the file system or Redis, specify the Durable Object persistence
-option:
+reloads, but not different `Miniflare` instances. To enable persistence to the
+file system or Redis, specify the Durable Object persistence option:
 
 ```js
 const mf = new Miniflare({
@@ -47,7 +46,6 @@ const mf = new Miniflare({
   durableObjectsPersist: "redis://localhost:6379", // Redis server
 });
 ```
-
 
 When using the file system, each object instance will get its own directory
 within the Durable Object persistence directory.
@@ -76,13 +74,12 @@ Like the real Workers runtime, Miniflare will throw errors when:
 
 ## Manipulating Outside Workers
 
-For testing, it can be useful to put/get data from Durable Object storage
-outside a worker. You can do this with the `getDurableObjectNamespace` and
-`getDurableObjectStorage` methods.
+For testing, it can be useful to make requests to your Durable Objects from
+outside a worker. You can do this with the `getDurableObjectNamespace` method.
 
 ```js
 ---
-highlight: [32,33,34,35,36,37,38,39,40]
+highlight: [28,29,30,31,32]
 ---
 import { Miniflare } from "miniflare";
 
@@ -97,7 +94,7 @@ const mf = new Miniflare({
 
     async fetch(request) {
       const url = new URL(request.url);
-      if(url.pathname === "/put") await this.storage.put("key", 1);
+      if (url.pathname === "/put") await this.storage.put("key", 1);
       return new Response((await this.storage.get("key")).toString());
     }
   }
@@ -111,21 +108,14 @@ const mf = new Miniflare({
   `,
 });
 
-let res = mf.dispatchFetch("http://localhost:8787/put");
-console.log(await res.text()); // "1"
-
 const ns = await mf.getDurableObjectNamespace("TEST_OBJECT");
 const id = ns.idFromName("test");
 const stub = ns.get(id);
 const doRes = await stub.fetch("http://localhost:8787/put");
 console.log(await doRes.text()); // "1"
 
-const storage = await mf.getDurableObjectStorage(id);
-console.log(await storage.get("key")); // 1
-await storage.put("key", 2);
-
-res = await mf.dispatchFetch("http://localhost:8787/");
-console.log(await res.text()); // "2"
+const res = await mf.dispatchFetch("http://localhost:8787/");
+console.log(await res.text()); // "1"
 ```
 
 ## Using a Class Exported by Another Script
@@ -172,6 +162,8 @@ export default {
 
 Miniflare can be configured to load `TestObject` from the `api` worker with:
 
+import ConfigTabs from "../components/mdx/config-tabs";
+
 <ConfigTabs>
 
 ```toml
@@ -195,14 +187,15 @@ const mf = new Miniflare({
       },
       modules: true,
       scriptPath: "api/src/worker.mjs",
-    }
-  ]
+    },
+  ],
 });
 ```
 
 </ConfigTabs>
 
-Workers can access Durable Objects declared in the `workers` field assuming it has a `name` set.
+Workers can access Durable Objects declared in the `workers` field assuming it
+has a `name` set.
 
 ## Internal Details
 


### PR DESCRIPTION
We don't support this in Miniflare 3 yet, so let's remove it from the docs for now.