### PR TITLE
(docs|fix): Fix incorrect link to legacy miniflare v2 docs

### DIFF
--- a/docs/src/content/testing/index.md
+++ b/docs/src/content/testing/index.md
@@ -6,4 +6,4 @@ order: 5
 
 <!-- <DirectoryListing path="/testing"/> -->
 
-We are currently working on unit testing, and will update the docs as functionality is added. For now, we recommend using the Miniflare v2 [test environments](https://v2.miniflare.dev/testing) for unit testing.
+We are currently working on unit testing, and will update the docs as functionality is added. For now, we recommend using the Miniflare v2 [test environments](https://legacy.miniflare.dev/testing) for unit testing.


### PR DESCRIPTION
Resolves #745 