### PR TITLE
Fix D1 binding

### DIFF
--- a/docs/src/content/storage/d1.md
+++ b/docs/src/content/storage/d1.md
@@ -26,7 +26,9 @@ database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 ```js
 const mf = new Miniflare({
-  d1Databases: ["DB"],
+  d1Databases: {
+    DB: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  },
 });
 ```
 


### PR DESCRIPTION
Because in this example the `binding` and `database_id` are different, the binding needs to be expressed as `Record<string, string>`

[https://github.com/cloudflare/workers-sdk/tree/4a925629238c9244d0fcf058301f46fc8fb64da2/packages/miniflare#d1](https://github.com/cloudflare/workers-sdk/tree/4a925629238c9244d0fcf058301f46fc8fb64da2/packages/miniflare#d1)