### PR TITLE
[Miniflare 2] Fix body.cancel() throwing undefined

### DIFF
--- a/packages/core/src/standards/http.ts
+++ b/packages/core/src/standards/http.ts
@@ -265,7 +265,10 @@ export class Body<Inner extends BaseRequest | BaseResponse> {
           controller.byobRequest?.respond(0);
         }
       },
-      cancel: (reason) => reader.cancel(reason),
+      cancel: (reason) => {
+        if (reader === undefined) reader = body.getReader();
+        return reader.cancel(reason);
+      },
     };
     // TODO: maybe set { highWaterMark: 0 } as a strategy here?
     bodyStream = new ReadableStream(source);

--- a/packages/core/test/standards/http.spec.ts
+++ b/packages/core/test/standards/http.spec.ts
@@ -179,6 +179,26 @@ test("Body: can pause, resume and cancel body stream", async (t) => {
   t.true(result.done);
   t.is(result.value, undefined);
 });
+test("Body: can cancel body directly", async (t) => {
+  const chunks = ["123", "456", "789"];
+  const bodyStream = new ReadableStream({
+    pull(controller) {
+      const chunk = chunks.shift();
+      if (chunk) {
+        controller.enqueue(utf8Encode(chunk));
+      } else {
+        controller.close();
+      }
+    },
+  });
+  const { body } = new Response(bodyStream);
+  assert(body);
+
+  await body.cancel();
+  const result = await body.getReader().read();
+  t.true(result.done);
+  t.is(result.value, undefined);
+});
 test("Body: throws on string chunks", async (t) => {
   const inputStream = new ReadableStream({
     start(controller) {


### PR DESCRIPTION
We noticed while writing a test for code that uses the Cache API that `body.cancel()` existed, but threw an error complaining that the underlying `reader` was undefined.

This ensures that `reader` is set before calling `cancel()`. I have included a test which failed before but works after the change.