### PR TITLE
Docs: add missing worker variable declaration

### DIFF
--- a/docs/src/content/get-started/index.md
+++ b/docs/src/content/get-started/index.md
@@ -183,6 +183,8 @@ const res = await mf.dispatchFetch("http://localhost:8787/", {
 });
 console.log(await res.text()); // Hello Miniflare!
 
+const worker = await mf.getWorker();
+
 const scheduledResult = await worker.scheduled({
   cron: "* * * * *",
 });
@@ -442,6 +444,8 @@ const res = await mf.dispatchFetch("http://localhost:8787/", {
 const text = await res.text();
 
 // Dispatch "scheduled" event to worker
+const worker = await mf.getWorker();
+
 const scheduledResult = await worker.scheduled({ cron: "30 * * * *" })
 
 const TEST_NAMESPACE = await mf.getKVNamespace("TEST_NAMESPACE");


### PR DESCRIPTION
Hi! I was reading [Getting started](https://miniflare.dev/get-started) when I came across using undefined variable `worker`, which made me wondering where it comes from.
Tried examples locally and indeed it reproduces:
<img width="723" alt="Screenshot 2024-06-17 at 19 01 34" src="https://github.com/cloudflare/miniflare/assets/4685931/2e5ed308-d66a-4f7b-a227-6d92294950bf">

Luckily, I found an example on [Scheduled Events](https://miniflare.dev/core/scheduled) page.

Please review :)