### PR TITLE
Bump undici library from 5.28.3 to 5.28.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [16.13.0, latest]
+        node: [16.13.0, 20.17.0]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10358,9 +10358,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -11103,7 +11103,7 @@
         "@miniflare/core": "2.14.2",
         "@miniflare/shared": "2.14.2",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.28.3"
+        "undici": "5.28.4"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.14.2",
@@ -11145,7 +11145,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.28.3",
+        "undici": "5.28.4",
         "urlpattern-polyfill": "^4.0.3"
       },
       "devDependencies": {
@@ -11184,7 +11184,7 @@
         "@miniflare/core": "2.14.2",
         "@miniflare/shared": "2.14.2",
         "@miniflare/storage-memory": "2.14.2",
-        "undici": "5.28.3"
+        "undici": "5.28.4"
       },
       "devDependencies": {
         "@miniflare/cache": "2.14.2",
@@ -11203,7 +11203,7 @@
         "@miniflare/core": "2.14.2",
         "@miniflare/shared": "2.14.2",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.28.3"
+        "undici": "5.28.4"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.14.2"
@@ -11222,7 +11222,7 @@
         "@miniflare/web-sockets": "2.14.2",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.28.3",
+        "undici": "5.28.4",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
@@ -11304,7 +11304,7 @@
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.28.3"
+        "undici": "5.28.4"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -11355,7 +11355,7 @@
       "dependencies": {
         "@miniflare/core": "2.14.2",
         "@miniflare/shared": "2.14.2",
-        "undici": "5.28.3"
+        "undici": "5.28.4"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.14.2"
@@ -11524,7 +11524,7 @@
         "@miniflare/runner-vm": "2.14.2",
         "@miniflare/shared": "2.14.2",
         "@miniflare/shared-test-environment": "2.14.2",
-        "undici": "5.28.3"
+        "undici": "5.28.4"
       },
       "devDependencies": {
         "@miniflare/shared-test": "2.14.2",
@@ -11560,7 +11560,7 @@
       "dependencies": {
         "@miniflare/core": "2.14.2",
         "@miniflare/shared": "2.14.2",
-        "undici": "5.28.3",
+        "undici": "5.28.4",
         "ws": "^8.2.2"
       },
       "devDependencies": {
@@ -13011,7 +13011,7 @@
         "@miniflare/web-sockets": "2.14.2",
         "@types/http-cache-semantics": "^4.0.1",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.28.3"
+        "undici": "5.28.4"
       }
     },
     "@miniflare/cli-parser": {
@@ -13042,7 +13042,7 @@
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.28.3",
+        "undici": "5.28.4",
         "urlpattern-polyfill": "^4.0.3"
       }
     },
@@ -13063,7 +13063,7 @@
         "@miniflare/shared": "2.14.2",
         "@miniflare/shared-test": "2.14.2",
         "@miniflare/storage-memory": "2.14.2",
-        "undici": "5.28.3"
+        "undici": "5.28.4"
       }
     },
     "@miniflare/html-rewriter": {
@@ -13073,7 +13073,7 @@
         "@miniflare/shared": "2.14.2",
         "@miniflare/shared-test": "2.14.2",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.28.3"
+        "undici": "5.28.4"
       }
     },
     "@miniflare/http-server": {
@@ -13086,7 +13086,7 @@
         "@types/node-forge": "^0.10.4",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.28.3",
+        "undici": "5.28.4",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
@@ -13111,7 +13111,7 @@
         "@miniflare/core": "2.14.2",
         "@miniflare/shared": "2.14.2",
         "@miniflare/shared-test": "2.14.2",
-        "undici": "5.28.3"
+        "undici": "5.28.4"
       }
     },
     "@miniflare/runner-vm": {
@@ -13221,7 +13221,7 @@
         "@miniflare/shared": "2.14.2",
         "@miniflare/shared-test": "2.14.2",
         "@types/ws": "^8.2.0",
-        "undici": "5.28.3",
+        "undici": "5.28.4",
         "ws": "^8.2.2"
       }
     },
@@ -16681,7 +16681,7 @@
         "open": "^8.4.0",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.28.3"
+        "undici": "5.28.4"
       }
     },
     "minimatch": {
@@ -18471,9 +18471,9 @@
       }
     },
     "undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }
@@ -18719,7 +18719,7 @@
         "@miniflare/shared-test-environment": "2.14.2",
         "miniflare": "2.14.2",
         "react-dom": "^18.1.0",
-        "undici": "5.28.3",
+        "undici": "5.28.4",
         "vitest": "^0.34.3"
       }
     },

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.14.2",
     "@miniflare/shared": "2.14.2",
     "http-cache-semantics": "^4.1.0",
-    "undici": "5.28.3"
+    "undici": "5.28.4"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.14.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "dotenv": "^10.0.0",
     "kleur": "^4.1.4",
     "set-cookie-parser": "^2.4.8",
-    "undici": "5.28.3",
+    "undici": "5.28.4",
     "urlpattern-polyfill": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/durable-objects/package.json
+++ b/packages/durable-objects/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.14.2",
     "@miniflare/shared": "2.14.2",
     "@miniflare/storage-memory": "2.14.2",
-    "undici": "5.28.3"
+    "undici": "5.28.4"
   },
   "devDependencies": {
     "@miniflare/cache": "2.14.2",

--- a/packages/html-rewriter/package.json
+++ b/packages/html-rewriter/package.json
@@ -38,7 +38,7 @@
     "@miniflare/core": "2.14.2",
     "@miniflare/shared": "2.14.2",
     "html-rewriter-wasm": "^0.4.1",
-    "undici": "5.28.3"
+    "undici": "5.28.4"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.14.2"

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -40,7 +40,7 @@
     "@miniflare/web-sockets": "2.14.2",
     "kleur": "^4.1.4",
     "selfsigned": "^2.0.0",
-    "undici": "5.28.3",
+    "undici": "5.28.4",
     "ws": "^8.2.2",
     "youch": "^2.2.2"
   },

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -66,7 +66,7 @@
     "kleur": "^4.1.4",
     "semiver": "^1.1.0",
     "source-map-support": "^0.5.20",
-    "undici": "5.28.3"
+    "undici": "5.28.4"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.14.2",

--- a/packages/r2/package.json
+++ b/packages/r2/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@miniflare/core": "2.14.2",
     "@miniflare/shared": "2.14.2",
-    "undici": "5.28.3"
+    "undici": "5.28.4"
   },
   "devDependencies": {
     "@miniflare/shared-test": "2.14.2"

--- a/packages/vitest-environment-miniflare/package.json
+++ b/packages/vitest-environment-miniflare/package.json
@@ -41,7 +41,7 @@
     "@miniflare/queues": "2.14.2",
     "@miniflare/shared": "2.14.2",
     "@miniflare/shared-test-environment": "2.14.2",
-    "undici": "5.28.3"
+    "undici": "5.28.4"
   },
   "peerDependencies": {
     "vitest": ">=0.23.0"

--- a/packages/web-sockets/package.json
+++ b/packages/web-sockets/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@miniflare/core": "2.14.2",
     "@miniflare/shared": "2.14.2",
-    "undici": "5.28.3",
+    "undici": "5.28.4",
     "ws": "^8.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
In order to resolve:

Undici's fetch with integrity option is too lax when algorithm is specified but hash value is in incorrect

Impact
If an attacker can alter the integrity option passed to fetch(), they can let fetch() accept requests as valid even if they have been tampered.

References
https://hackerone.com/reports/2377760