### PR TITLE
Fixed code snippet mistake on docs

### DIFF
--- a/docs/src/content/storage/d1.md
+++ b/docs/src/content/storage/d1.md
@@ -42,7 +42,7 @@ bound to a worker. You can do this with the `getD1Database` method:
 ```js
 
 const db = await mf.getD1Database("DB");
-const { results } = await db.prepare("<Query>");
+const { results } = await db.prepare("<Query>").run();
 
 console.log(await res.json(results));
 ```


### PR DESCRIPTION
It looks like the D1 prepared statement API requires a `.run()` to dispatch the query.  Not sure if this is a relic from an older API version or just a typo.