### PR TITLE
Fix broken "migrate to Miniflare 3" link

### DIFF
--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -10,7 +10,7 @@
 > Workers runtime [`workerd`](https://github.com/cloudflare/workerd). This
 > practically eliminates behaviour mismatches between development and production
 > deployments. We recommend you
-> [migrate to Miniflare 3](https://miniflare.dev/get-started/migrating) now if
+> [migrate to Miniflare 3](https://miniflare.dev/migrations/from-v2) now if
 > you can. Whilst Miniflare 3 supports most of Miniflare 2's features, one key
 > omission is the unit testing environment. We're actively working on adding
 > support for this to Miniflare 3. Once this is supported, we're planning to


### PR DESCRIPTION
The "migrate to Miniflare 3" link in the readme points at https://miniflare.dev/get-started/migrating
That redirects to https://developers.cloudflare.com/workers/testing/miniflare/get-started/migrating, which 404s
This looks right https://developers.cloudflare.com/workers/testing/miniflare/migrations/from-v2/ 
So I changed the "migrate to Miniflare 3" link to point at https://miniflare.dev/migrations/from-v2

